### PR TITLE
Add u32_mul

### DIFF
--- a/src/scripts/opcodes/mod.rs
+++ b/src/scripts/opcodes/mod.rs
@@ -9,6 +9,7 @@ pub mod u256_std;
 pub mod u32_add;
 pub mod u32_and;
 pub mod u32_cmp;
+pub mod u32_mul;
 pub mod u32_or;
 pub mod u32_rrot;
 pub mod u32_state;

--- a/src/scripts/opcodes/u32_add.rs
+++ b/src/scripts/opcodes/u32_add.rs
@@ -104,3 +104,29 @@ pub fn u32_add_drop(a: u32, b: u32) -> Script {
         // Now there's the result C_3 C_2 C_1 C_0 on the stack
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::scripts::opcodes::execute_script;
+    use crate::scripts::opcodes::u32_std::u32_push;
+
+    use super::*;
+
+    #[test]
+    fn test_u32_add() {
+        let u32_value_a = 0xFFEEFFEEu32;
+        let u32_value_b = 0xEEFFEEFFu32;
+
+        let script = script! {
+            { u32_push(u32_value_a) }
+            { u32_push(u32_value_b) }
+            { u32_add_drop(1, 0) }
+            { 0xed } OP_EQUALVERIFY
+            { 0xee } OP_EQUALVERIFY
+            { 0xee } OP_EQUALVERIFY
+            { 0xee } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+}

--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -1,11 +1,12 @@
 use crate::scripts::opcodes::{pushable, unroll};
 use bitcoin::ScriptBuf as Script;
 use bitcoin_script::bitcoin_script as script;
+use crate::scripts::opcodes::pseudo::OP_256MUL;
 
 fn u8_to_u16() -> Script {
     script! {
         OP_SWAP
-        { unroll(8, |_| script! {OP_DUP OP_ADD}) }
+        OP_256MUL
         OP_ADD
     }
 }

--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -1,111 +1,283 @@
-use crate::scripts::opcodes::pseudo::{OP_4DROP, OP_4DUP};
-use crate::scripts::opcodes::u32_add::{u32_add, u32_add_drop};
 use crate::scripts::opcodes::{pushable, unroll};
 use bitcoin::ScriptBuf as Script;
 use bitcoin_script::bitcoin_script as script;
 
-pub fn u8_to_bits() -> Script {
+fn u8_to_u16() -> Script {
     script! {
-        OP_DUP
-        127 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 128 OP_SUB OP_ENDIF
-        OP_DUP
-        63 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 64 OP_SUB OP_ENDIF
-        OP_DUP
-        31 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 32 OP_SUB OP_ENDIF
-        OP_DUP
-        15 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 16 OP_SUB OP_ENDIF
-        OP_DUP
-        7 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 8 OP_SUB OP_ENDIF
-        OP_DUP
-        3 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 4 OP_SUB OP_ENDIF
-        OP_DUP
-        1 OP_GREATERTHAN
-        OP_SWAP OP_OVER
-        OP_IF 2 OP_SUB OP_ENDIF
+        OP_SWAP
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_ADD
     }
 }
 
-pub fn u32_double() -> Script {
+fn u32_to_u32compact() -> Script {
     script! {
-        OP_4DUP
-        { u32_add_drop(1, 0) }
+        OP_TOALTSTACK OP_TOALTSTACK
+        { u8_to_u16() }
+        OP_FROMALTSTACK OP_FROMALTSTACK
+        { u8_to_u16() }
     }
 }
 
-pub fn u32_to_bits() -> Script {
+fn u16_to_bits() -> Script {
     script! {
-        3 OP_ROLL
-        { u8_to_bits() }
-        10 OP_ROLL
-        { u8_to_bits() }
-        17 OP_ROLL
-        { u8_to_bits() }
-        24 OP_ROLL
-        { u8_to_bits() }
-    }
-}
-
-pub fn u32_mul_drop() -> Script {
-    script! {
-        { u32_to_bits() }
-        0 0 0 0
-        OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
-        35 OP_ROLL 35 OP_ROLL 35 OP_ROLL 35 OP_ROLL
-        {unroll(31, |_| script! {
-            4 OP_ROLL
-            OP_IF
-                OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
-                { u32_add(1, 0) }
-                OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
-            OP_ENDIF
-            { u32_double() }
+        {
+            unroll(15, |i| {
+                let a = 1 << (15 - i);
+                let b = a - 1;
+                script! {
+                    OP_DUP
+                    { b } OP_GREATERTHAN
+                    OP_SWAP OP_OVER
+                    OP_IF { a } OP_SUB OP_ENDIF
+                }
         })}
-        4 OP_ROLL
+    }
+}
+
+/// Zip the top two u32 elements
+/// input:  a0 a1 b0 b1
+/// output: a0 b0 a1 b1
+fn u32compact_zip(mut a: u32, mut b: u32) -> Script {
+    if a > b {
+        (a, b) = (b, a);
+    }
+
+    a = (a + 1) * 2 - 1;
+    b = (b + 1) * 2 - 1;
+
+    script! {
+        {a+0} OP_ROLL {b} OP_ROLL
+        {a+1} OP_ROLL {b} OP_ROLL
+    }
+}
+
+/// Copy and zip the top two u32 elements
+/// input:  a0 a1 b0 b1
+/// output: a0 b0 a1 b1 a0 a1
+fn u32compact_copy_zip(a: u32, b: u32) -> Script {
+    if a < b {
+        _u32compact_copy_zip(a, b)
+    } else {
+        _u32compact_zip_copy(b, a)
+    }
+}
+
+fn _u32compact_copy_zip(mut a: u32, mut b: u32) -> Script {
+    assert!(a < b);
+
+    a = (a + 1) * 2 - 1;
+    b = (b + 1) * 2 - 1;
+
+    script! {
+        {a+0} OP_PICK {b+1} OP_ROLL
+        {a+1} OP_PICK {b+2} OP_ROLL
+    }
+}
+
+fn _u32compact_zip_copy(mut a: u32, mut b: u32) -> Script {
+    assert!(a < b);
+
+    a = (a + 1) * 2 - 1;
+    b = (b + 1) * 2 - 1;
+    script! {
+        {a+0} OP_ROLL {b} OP_PICK
+        {a+1} OP_ROLL {b} OP_PICK
+    }
+}
+
+fn u16_add_carrier() -> Script {
+    script! {
+        OP_ADD
+        OP_DUP
+        65535
+        OP_GREATERTHAN
         OP_IF
-            OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
-            { u32_add_drop(1, 0) }
-            OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
+            65536
+            OP_SUB
+            1
         OP_ELSE
-            OP_4DROP
+            0
         OP_ENDIF
-        OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+    }
+}
+
+fn u16_add() -> Script {
+    script! {
+        OP_ADD
+        OP_DUP
+        65535
+        OP_GREATERTHAN
+        OP_IF
+            65536
+            OP_SUB
+        OP_ENDIF
+    }
+}
+
+fn u32compact_add(a: u32, b: u32) -> Script {
+    assert_ne!(a, b);
+    script! {
+        {u32compact_copy_zip(a, b)}
+
+        // A0 + B0
+        u16_add_carrier
+        OP_SWAP
+        OP_TOALTSTACK
+
+        // A1 + B1 + carry_0
+        OP_ADD
+        u16_add
+
+        OP_FROMALTSTACK
+
+        // Now there's the result C_1 C_0 on the stack
+    }
+}
+
+fn u32compact_add_drop(a: u32, b: u32) -> Script {
+    assert_ne!(a, b);
+    script! {
+        {u32compact_zip(a, b)}
+
+        // A0 + B0
+        u16_add_carrier
+        OP_SWAP
+        OP_TOALTSTACK
+
+        // A1 + B1 + carry_0
+        OP_ADD
+        u16_add
+
+        OP_FROMALTSTACK
+        // Now there's the result C_1 C_0 on the stack
+    }
+}
+
+fn u32compact_double() -> Script {
+    script! {
+        OP_2DUP
+        { u32compact_add_drop(1, 0) }
+    }
+}
+
+fn u32compact_to_bits() -> Script {
+    script! {
+        OP_SWAP
+        { u16_to_bits() }
+        16 OP_ROLL
+        { u16_to_bits() }
+    }
+}
+
+fn u32compact_mul_drop() -> Script {
+    script! {
+        { u32compact_to_bits() }
+        0 0
+        OP_TOALTSTACK OP_TOALTSTACK
+        33 OP_ROLL 33 OP_ROLL
+        {unroll(31, |_| script! {
+            2 OP_ROLL
+            OP_IF
+                OP_FROMALTSTACK OP_FROMALTSTACK
+                { u32compact_add(1, 0) }
+                OP_TOALTSTACK OP_TOALTSTACK
+            OP_ENDIF
+            { u32compact_double() }
+        })}
+        2 OP_ROLL
+        OP_IF
+            OP_FROMALTSTACK OP_FROMALTSTACK
+            { u32compact_add_drop(1, 0) }
+            OP_TOALTSTACK OP_TOALTSTACK
+        OP_ELSE
+            OP_2DROP
+        OP_ENDIF
+        OP_FROMALTSTACK OP_FROMALTSTACK
+    }
+}
+
+fn u16_to_u8() -> Script {
+    script! {
+        0 OP_TOALTSTACK
+        { unroll(7, |i| {
+            let a = 1 << (15 - i);
+            let b = a - 1;
+            let c = 1 << (7 - i);
+            script! {
+                OP_DUP
+                { b } OP_GREATERTHAN
+                OP_IF
+                    { a } OP_SUB
+                    OP_FROMALTSTACK { c } OP_ADD OP_TOALTSTACK
+                OP_ENDIF
+            }
+        })}
+        OP_DUP
+        255 OP_GREATERTHAN
+        OP_IF
+            256 OP_SUB
+            OP_FROMALTSTACK OP_1ADD OP_TOALTSTACK
+        OP_ENDIF
+        OP_FROMALTSTACK
+        OP_SWAP
+    }
+}
+
+fn u32compact_to_u32() -> Script {
+    script! {
+        OP_TOALTSTACK
+        { u16_to_u8() }
+        OP_FROMALTSTACK
+        { u16_to_u8() }
+    }
+}
+
+fn u32_mul_drop() -> Script {
+    script! {
+        { u32_to_u32compact() }
+        OP_TOALTSTACK OP_TOALTSTACK
+        { u32_to_u32compact() }
+        OP_FROMALTSTACK OP_FROMALTSTACK
+        { u32compact_mul_drop() }
+        { u32compact_to_u32() }
     }
 }
 
 #[cfg(test)]
-mod test {
+mod test{
     use crate::scripts::opcodes::execute_script;
-    use crate::scripts::opcodes::pushable;
     use crate::scripts::opcodes::u32_std::u32_push;
-    use bitcoin::opcodes::OP_EQUALVERIFY;
-
     use super::*;
 
     #[test]
-    fn test_u8_to_bits() {
-        let u8_value = 0x34u32;
+    fn test_u16_to_bits() {
+        let u16_value = 0x1234u32;
 
         let script = script! {
-            { u8_value }
-            { u8_to_bits() }
+            { u16_value }
+            { u16_to_bits() }
             { 0x00 } OP_EQUALVERIFY
             { 0x00 } OP_EQUALVERIFY
             { 0x01 } OP_EQUALVERIFY
             { 0x00 } OP_EQUALVERIFY
             { 0x01 } OP_EQUALVERIFY
             { 0x01 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x01 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x01 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
             { 0x00 } OP_EQUALVERIFY
             { 0x00 } OP_EQUAL
         };
@@ -114,11 +286,41 @@ mod test {
     }
 
     #[test]
-    fn test_u32_to_bits() {
+    fn test_u32_to_u32compact() {
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_to_bits() }
+            { u32_to_u32compact() }
+            { 0x5678 } OP_EQUALVERIFY
+            { 0x1234 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32compact_to_u32() {
+        let u32_value = 0x12345678u32;
+        let script = script! {
+            { u32_push(u32_value) }
+            { u32_to_u32compact() }
+            { u32compact_to_u32() }
+            { 0x78 } OP_EQUALVERIFY
+            { 0x56 } OP_EQUALVERIFY
+            { 0x34 } OP_EQUALVERIFY
+            { 0x12 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32compact_to_bits() {
+        let u32_value = 0x12345678u32;
+        let script = script! {
+            { u32_push(u32_value) }
+            { u32_to_u32compact() }
+            { u32compact_to_bits() }
             0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 1 OP_EQUALVERIFY
             1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
             0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
@@ -133,15 +335,49 @@ mod test {
     }
 
     #[test]
-    fn test_u32_double() {
+    fn test_u32compact_double() {
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_double() }
-            { 0xf0 } OP_EQUALVERIFY
-            { 0xac } OP_EQUALVERIFY
-            { 0x68 } OP_EQUALVERIFY
-            { 0x24 } OP_EQUAL
+            { u32_to_u32compact() }
+            { u32compact_double() }
+            { 0xacf0 } OP_EQUALVERIFY
+            { 0x2468 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32compact_add() {
+        let u32_value_a = 0xFFEEFFEEu32;
+        let u32_value_b = 0xEEFFEEFFu32;
+
+        let script = script! {
+            { u32_push(u32_value_a) }
+            { u32_to_u32compact() }
+            { u32_push(u32_value_b) }
+            { u32_to_u32compact() }
+            { u32compact_add_drop(1, 0) }
+            { 0xeeed } OP_EQUALVERIFY
+            { 0xeeee } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32compact_mul() {
+        let u32_value_a = 0x12345678u32;
+        let u32_value_b = 0x89abcdefu32;
+        let script = script! {
+            { u32_push(u32_value_a) }
+            { u32_to_u32compact() }
+            { u32_push(u32_value_b) }
+            { u32_to_u32compact() }
+            { u32compact_mul_drop() }
+            { 0xd208 } OP_EQUALVERIFY
+            { 0xe242 } OP_EQUAL
         };
         let exec_result = execute_script(script);
         assert!(exec_result.success)
@@ -151,6 +387,7 @@ mod test {
     fn test_u32_mul() {
         let u32_value_a = 0x12345678u32;
         let u32_value_b = 0x89abcdefu32;
+
         let script = script! {
             { u32_push(u32_value_a) }
             { u32_push(u32_value_b) }

--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -14,9 +14,9 @@ fn u8_to_u16() -> Script {
 fn u32_to_u32compact() -> Script {
     script! {
         OP_TOALTSTACK OP_TOALTSTACK
-        { u8_to_u16() }
+        u8_to_u16
         OP_FROMALTSTACK OP_FROMALTSTACK
-        { u8_to_u16() }
+        u8_to_u16
     }
 }
 
@@ -165,15 +165,15 @@ fn u32compact_double() -> Script {
 fn u32compact_to_bits() -> Script {
     script! {
         OP_SWAP
-        { u16_to_bits() }
+        u16_to_bits
         16 OP_ROLL
-        { u16_to_bits() }
+        u16_to_bits
     }
 }
 
 fn u32compact_mul_drop() -> Script {
     script! {
-        { u32compact_to_bits() }
+        u32compact_to_bits
         0 0
         OP_TOALTSTACK OP_TOALTSTACK
         33 OP_ROLL 33 OP_ROLL
@@ -184,7 +184,7 @@ fn u32compact_mul_drop() -> Script {
                 { u32compact_add(1, 0) }
                 OP_TOALTSTACK OP_TOALTSTACK
             OP_ENDIF
-            { u32compact_double() }
+            u32compact_double
         })}
         2 OP_ROLL
         OP_IF
@@ -228,20 +228,20 @@ fn u16_to_u8() -> Script {
 fn u32compact_to_u32() -> Script {
     script! {
         OP_TOALTSTACK
-        { u16_to_u8() }
+        u16_to_u8
         OP_FROMALTSTACK
-        { u16_to_u8() }
+        u16_to_u8
     }
 }
 
 fn u32_mul_drop() -> Script {
     script! {
-        { u32_to_u32compact() }
+        u32_to_u32compact
         OP_TOALTSTACK OP_TOALTSTACK
-        { u32_to_u32compact() }
+        u32_to_u32compact
         OP_FROMALTSTACK OP_FROMALTSTACK
-        { u32compact_mul_drop() }
-        { u32compact_to_u32() }
+        u32compact_mul_drop
+        u32compact_to_u32
     }
 }
 
@@ -257,7 +257,7 @@ mod test{
 
         let script = script! {
             { u16_value }
-            { u16_to_bits() }
+            u16_to_bits
             { 0x00 } OP_EQUALVERIFY
             { 0x00 } OP_EQUALVERIFY
             { 0x01 } OP_EQUALVERIFY
@@ -284,7 +284,7 @@ mod test{
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_to_u32compact() }
+            u32_to_u32compact
             { 0x5678 } OP_EQUALVERIFY
             { 0x1234 } OP_EQUAL
         };
@@ -297,8 +297,8 @@ mod test{
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_to_u32compact() }
-            { u32compact_to_u32() }
+            u32_to_u32compact
+            u32compact_to_u32
             { 0x78 } OP_EQUALVERIFY
             { 0x56 } OP_EQUALVERIFY
             { 0x34 } OP_EQUALVERIFY
@@ -313,8 +313,8 @@ mod test{
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_to_u32compact() }
-            { u32compact_to_bits() }
+            u32_to_u32compact
+            u32compact_to_bits
             0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 1 OP_EQUALVERIFY
             1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
             0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
@@ -333,8 +333,8 @@ mod test{
         let u32_value = 0x12345678u32;
         let script = script! {
             { u32_push(u32_value) }
-            { u32_to_u32compact() }
-            { u32compact_double() }
+            u32_to_u32compact
+            u32compact_double
             { 0xacf0 } OP_EQUALVERIFY
             { 0x2468 } OP_EQUAL
         };
@@ -349,9 +349,9 @@ mod test{
 
         let script = script! {
             { u32_push(u32_value_a) }
-            { u32_to_u32compact() }
+            u32_to_u32compact
             { u32_push(u32_value_b) }
-            { u32_to_u32compact() }
+            u32_to_u32compact
             { u32compact_add_drop(1, 0) }
             { 0xeeed } OP_EQUALVERIFY
             { 0xeeee } OP_EQUAL
@@ -366,10 +366,10 @@ mod test{
         let u32_value_b = 0x89abcdefu32;
         let script = script! {
             { u32_push(u32_value_a) }
-            { u32_to_u32compact() }
+            u32_to_u32compact
             { u32_push(u32_value_b) }
-            { u32_to_u32compact() }
-            { u32compact_mul_drop() }
+            u32_to_u32compact
+            u32compact_mul_drop
             { 0xd208 } OP_EQUALVERIFY
             { 0xe242 } OP_EQUAL
         };
@@ -385,7 +385,7 @@ mod test{
         let script = script! {
             { u32_push(u32_value_a) }
             { u32_push(u32_value_b) }
-            { u32_mul_drop() }
+            u32_mul_drop
             { 0x08 } OP_EQUALVERIFY
             { 0xd2 } OP_EQUALVERIFY
             { 0x42 } OP_EQUALVERIFY

--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -5,14 +5,7 @@ use bitcoin_script::bitcoin_script as script;
 fn u8_to_u16() -> Script {
     script! {
         OP_SWAP
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
-        OP_DUP OP_ADD
+        { unroll(8, |_| script! {OP_DUP OP_ADD}) }
         OP_ADD
     }
 }

--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -1,0 +1,166 @@
+use crate::scripts::opcodes::pseudo::{OP_4DROP, OP_4DUP};
+use crate::scripts::opcodes::u32_add::{u32_add, u32_add_drop};
+use crate::scripts::opcodes::{pushable, unroll};
+use bitcoin::ScriptBuf as Script;
+use bitcoin_script::bitcoin_script as script;
+
+pub fn u8_to_bits() -> Script {
+    script! {
+        OP_DUP
+        127 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 128 OP_SUB OP_ENDIF
+        OP_DUP
+        63 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 64 OP_SUB OP_ENDIF
+        OP_DUP
+        31 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 32 OP_SUB OP_ENDIF
+        OP_DUP
+        15 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 16 OP_SUB OP_ENDIF
+        OP_DUP
+        7 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 8 OP_SUB OP_ENDIF
+        OP_DUP
+        3 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 4 OP_SUB OP_ENDIF
+        OP_DUP
+        1 OP_GREATERTHAN
+        OP_SWAP OP_OVER
+        OP_IF 2 OP_SUB OP_ENDIF
+    }
+}
+
+pub fn u32_double() -> Script {
+    script! {
+        OP_4DUP
+        { u32_add_drop(1, 0) }
+    }
+}
+
+pub fn u32_to_bits() -> Script {
+    script! {
+        3 OP_ROLL
+        { u8_to_bits() }
+        10 OP_ROLL
+        { u8_to_bits() }
+        17 OP_ROLL
+        { u8_to_bits() }
+        24 OP_ROLL
+        { u8_to_bits() }
+    }
+}
+
+pub fn u32_mul_drop() -> Script {
+    script! {
+        { u32_to_bits() }
+        0 0 0 0
+        OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
+        35 OP_ROLL 35 OP_ROLL 35 OP_ROLL 35 OP_ROLL
+        {unroll(31, |_| script! {
+            4 OP_ROLL
+            OP_IF
+                OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+                { u32_add(1, 0) }
+                OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
+            OP_ENDIF
+            { u32_double() }
+        })}
+        4 OP_ROLL
+        OP_IF
+            OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+            { u32_add_drop(1, 0) }
+            OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK OP_TOALTSTACK
+        OP_ELSE
+            OP_4DROP
+        OP_ENDIF
+        OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::scripts::opcodes::execute_script;
+    use crate::scripts::opcodes::pushable;
+    use crate::scripts::opcodes::u32_std::u32_push;
+    use bitcoin::opcodes::OP_EQUALVERIFY;
+
+    use super::*;
+
+    #[test]
+    fn test_u8_to_bits() {
+        let u8_value = 0x34u32;
+
+        let script = script! {
+            { u8_value }
+            { u8_to_bits() }
+            { 0x00 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x01 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x01 } OP_EQUALVERIFY
+            { 0x01 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUALVERIFY
+            { 0x00 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32_to_bits() {
+        let u32_value = 0x12345678u32;
+        let script = script! {
+            { u32_push(u32_value) }
+            { u32_to_bits() }
+            0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 1 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY 0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY 1 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUALVERIFY 0 OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32_double() {
+        let u32_value = 0x12345678u32;
+        let script = script! {
+            { u32_push(u32_value) }
+            { u32_double() }
+            { 0xf0 } OP_EQUALVERIFY
+            { 0xac } OP_EQUALVERIFY
+            { 0x68 } OP_EQUALVERIFY
+            { 0x24 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32_mul() {
+        let u32_value_a = 0x12345678u32;
+        let u32_value_b = 0x89abcdefu32;
+        let script = script! {
+            { u32_push(u32_value_a) }
+            { u32_push(u32_value_b) }
+            { u32_mul_drop() }
+            { 0x08 } OP_EQUALVERIFY
+            { 0xd2 } OP_EQUALVERIFY
+            { 0x42 } OP_EQUALVERIFY
+            { 0xe2 } OP_EQUAL
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+}


### PR DESCRIPTION
This PR presents an implementation of the u32_mul, which can be used for ASM_MUL, for 32-bit integers.

It implements:
- u8_to_bits, convert a u8 into bits
- u32_to_bits, convert a u32 (represented as four u8 in the stack) into bits
- u32_double, double a u32
- u32_mul_drop, multiplication of two u32

And their integration tests.

The instruction deals with overflow and resembles RISC-V behavior. It only maintains the keeps the lower 4 bytes of the 32 bit integers. It is possible to similarly implement 64-bit integer operations, but it depends on the ISA.

  u32_mul_drop takes 6118 bytes
  u32_add takes 85 bytes

roughly 72x, which is expected because u32_mul_drop calls u32_add already 64 times for double-and-add