### PR TITLE
Avoid unnecessary intermediate conversion for u32_mul

### DIFF
--- a/src/scripts/opcodes/u32_mul.rs
+++ b/src/scripts/opcodes/u32_mul.rs
@@ -167,13 +167,13 @@ fn u32compact_double() -> Script {
 pub fn u32_to_bits() -> Script {
     script! {
         3 OP_ROLL
-        { u8_to_bits() }
+        u8_to_bits
         10 OP_ROLL
-        { u8_to_bits() }
+        u8_to_bits
         17 OP_ROLL
-        { u8_to_bits() }
+        u8_to_bits
         24 OP_ROLL
-        { u8_to_bits() }
+        u8_to_bits
     }
 }
 


### PR DESCRIPTION
Per offline discussion with Robin, the current u32_mul for a * b implementation converts the standard u32 representation, which is (u8 u8 u8 u8) into (u16 u16), for both a and b.

The conversion for b is indeed unnecessary, since we will immediately convert b into bits. However, the compression of (u8 u8 u8 u8) to (u16 u16) for b, which is OP_SWAP OP_256MUL OP_ADD, is unnecessary. Removing this step can already save 18. Then, notice that u16_to_bits will be less efficient compared with u8_to_bits running twice because u16_to_bits will have many larger numbers in the stack.

By not converting b into (u16 u16) but directly convert it to bits, this reduces the weight units from 3705 to 3610.