### PR TITLE
Fix u32 sub, add uint sub/cmp, add u32 1add

### DIFF
--- a/tapscripts/Cargo.toml
+++ b/tapscripts/Cargo.toml
@@ -12,9 +12,9 @@ strum_macros = "0.26"
 hex = "0.4.3"
 bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"}
 serde = { version = "1.0.197", features = ["derive"] }
-rand_chacha = "0.3.1"
-rand = "0.8.5"
 
 [dev-dependencies]
+rand_chacha = "0.3.1"
+rand = "0.8.5"
 num-bigint = { version = "0.4.4", features = ["rand"] }
 num-traits = "0.2.18"

--- a/tapscripts/src/opcodes/u32_add.rs
+++ b/tapscripts/src/opcodes/u32_add.rs
@@ -33,6 +33,36 @@ pub fn u8_add() -> Script {
     }
 }
 
+pub fn u32_1add() -> Script {
+    script! {
+        1
+
+        // A0 + B0
+        u8_add_carry
+        OP_SWAP
+        OP_TOALTSTACK
+
+        // A1 + B1 + carry_0
+        u8_add_carry
+        OP_SWAP
+        OP_TOALTSTACK
+
+        // A2 + B2 + carry_1
+        u8_add_carry
+        OP_SWAP
+        OP_TOALTSTACK
+
+        // A3 + B3 + carry_2
+        u8_add
+
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+
+        // Now there's the result C_3 C_2 C_1 C_0 on the stack
+    }
+}
+
 /// Addition of two u32 values represented as u8
 /// Copies the first summand `a` and drops `b`
 pub fn u32_add(a: u32, b: u32) -> Script {

--- a/tapscripts/src/opcodes/u32_zip.rs
+++ b/tapscripts/src/opcodes/u32_zip.rs
@@ -5,22 +5,26 @@ use bitcoin_script::bitcoin_script as script;
 
 /// Zip the top two u32 elements
 /// input:  a0 a1 a2 a3 b0 b1 b2 b3
-/// output: a0 b0 a1 b1 a2 b2 a3 b3 (a < b)
-///     or: b0 a0 b1 a1 b2 a2 b3 a3 (a > b)
+/// output: a0 b0 a1 b1 a2 b2 a3 b3
 pub fn u32_zip(mut a: u32, mut b: u32) -> Script {
     assert_ne!(a, b);
-    if a > b {
-        (a, b) = (b, a);
-    }
-
     a = (a + 1) * 4 - 1;
     b = (b + 1) * 4 - 1;
 
-    script! {
-        {a+0} OP_ROLL {b} OP_ROLL
-        {a+1} OP_ROLL {b} OP_ROLL
-        {a+2} OP_ROLL {b} OP_ROLL
-        {a+3} OP_ROLL {b} OP_ROLL
+    if a < b {
+        script! {
+            {a + 0} OP_ROLL {b} OP_ROLL
+            {a + 1} OP_ROLL {b} OP_ROLL
+            {a + 2} OP_ROLL {b} OP_ROLL
+            {a + 3} OP_ROLL {b} OP_ROLL
+        }
+    } else {
+        script! {
+            {a} OP_ROLL {b + 1} OP_ROLL
+            {a} OP_ROLL {b + 2} OP_ROLL
+            {a} OP_ROLL {b + 3} OP_ROLL
+            {a} OP_ROLL {b + 4} OP_ROLL
+        }
     }
 }
 

--- a/tapscripts/src/opcodes/uint.rs
+++ b/tapscripts/src/opcodes/uint.rs
@@ -1,4 +1,3 @@
-use bitcoin::opcodes::OP_EQUALVERIFY;
 use bitcoin::ScriptBuf as Script;
 use bitcoin_script::bitcoin_script as script;
 use crate::opcodes::{unroll, pushable};
@@ -145,6 +144,88 @@ impl<const N_BITS: usize> UintImpl<N_BITS> {
             { unroll(n_limbs as u32, |_| script!{
                 OP_EQUALVERIFY
             })}
+        }
+    }
+
+    pub fn equal(a: u32, b: u32) -> Script {
+        let n_limbs: usize = (N_BITS + 30 - 1) / 30;
+
+        script! {
+            { Self::zip(a, b) }
+            { unroll(n_limbs as u32, |_| script!{
+                OP_EQUAL
+                OP_TOALTSTACK
+            })}
+            { unroll(n_limbs as u32, |_| script! {
+                OP_FROMALTSTACK
+            })}
+            { unroll((n_limbs - 1) as u32, |_| script! {
+                OP_BOOLAND
+            })}
+        }
+    }
+
+    pub fn notequal(a: u32, b: u32) -> Script {
+        script! {
+            { Self::equal(a, b) }
+            OP_NOT
+        }
+    }
+
+    // return if a < b
+    pub fn lessthan(a: u32, b: u32) -> Script {
+        let n_limbs: usize = (N_BITS + 30 - 1) / 30;
+
+        script! {
+            { Self::zip(a, b) }
+            OP_2DUP
+            OP_GREATERTHAN OP_TOALTSTACK
+            OP_LESSTHAN OP_TOALTSTACK
+
+            { unroll((n_limbs - 1) as u32, |_| script! {
+                OP_2DUP
+                OP_GREATERTHAN OP_TOALTSTACK
+                OP_LESSTHAN OP_TOALTSTACK
+            })}
+
+            OP_FROMALTSTACK OP_FROMALTSTACK
+            OP_OVER OP_BOOLOR
+
+            { unroll((n_limbs - 1) as u32, |_| script! {
+                OP_FROMALTSTACK
+                OP_FROMALTSTACK
+                OP_ROT
+                OP_IF
+                    OP_2DROP 1
+                OP_ELSE
+                    OP_ROT OP_DROP
+                    OP_OVER
+                    OP_BOOLOR
+                OP_ENDIF
+            }) }
+
+            OP_BOOLAND
+        }
+    }
+
+    // return if a <= b
+    pub fn lessthanorequal(a: u32, b: u32) -> Script {
+        Self::greaterthanorequal(b, a)
+    }
+
+    // return if a > b
+    pub fn greaterthan(a: u32, b: u32) -> Script {
+        script! {
+            { Self::lessthanorequal(a, b) }
+            OP_NOT
+        }
+    }
+
+    // return if a >= b
+    pub fn greaterthanorequal(a: u32, b: u32) -> Script {
+        script! {
+            { Self::lessthan(a, b) }
+            OP_NOT
         }
     }
 }

--- a/tapscripts/src/opcodes/uint.rs
+++ b/tapscripts/src/opcodes/uint.rs
@@ -6,7 +6,7 @@ use crate::opcodes::{unroll, pushable};
 pub struct UintImpl<const N_BITS: usize>;
 
 impl<const N_BITS: usize> UintImpl<N_BITS> {
-    fn push_u32_le(v: &[u32]) -> Script {
+    pub fn push_u32_le(v: &[u32]) -> Script {
         let n_limbs: usize = (N_BITS + 30 - 1) / 30;
 
         let mut bits = vec![];
@@ -45,27 +45,25 @@ impl<const N_BITS: usize> UintImpl<N_BITS> {
 
     /// Copy and zip the top two u{16N} elements
     /// input:  a0 ... a{N-1} b0 ... b{N-1}
-    /// output: a0 b0 ... ... a{N-1} b{N-1} (if a < b)
-    ///     or: b0 a0 ... ... b{N-1} a{N-1} (if a > b)
-    fn zip(mut a: u32, mut b: u32) -> Script {
+    /// output: a0 b0 ... ... a{N-1} b{N-1}
+    pub fn zip(mut a: u32, mut b: u32) -> Script {
         let n_limbs: usize = (N_BITS + 30 - 1) / 30;
-
-        assert_ne!(a, b);
-        if a > b {
-            (a, b) = (b, a);
-        }
-
         a = (a + 1) * (n_limbs as u32) - 1;
         b = (b + 1) * (n_limbs as u32) - 1;
 
-        unroll(n_limbs as u32, |i| {
-            script! {
+        assert_ne!(a, b);
+        if a < b {
+            unroll(n_limbs as u32, |i| script! {
                 { a + i } OP_ROLL { b } OP_ROLL
-            }
-        })
+            })
+        } else {
+            unroll(n_limbs as u32, |i| script! {
+                { a } OP_ROLL { b + i + 1 } OP_ROLL
+            })
+        }
     }
 
-    fn add(a: u32, b: u32) -> Script {
+    pub fn add(a: u32, b: u32) -> Script {
         let n_limbs: usize = (N_BITS + 30 - 1) / 30;
         let head = N_BITS - (n_limbs - 1) * 30;
         let head_offset = 1u32 << head;
@@ -102,7 +100,44 @@ impl<const N_BITS: usize> UintImpl<N_BITS> {
         }
     }
 
-    fn equalverify(a: u32, b: u32) -> Script {
+    pub fn sub(a: u32, b: u32) -> Script {
+        let n_limbs: usize = (N_BITS + 30 - 1) / 30;
+        let head = N_BITS - (n_limbs - 1) * 30;
+        let head_offset = 1u32 << head;
+
+        script! {
+            {Self::zip(a,b)}
+
+            1073741824
+
+            // A0 - B0
+            u30_sub_carry
+            OP_SWAP
+            OP_TOALTSTACK
+
+            // from     A1      - (B1        + borrow_0)
+            //   to     A{N-2}  - (B{N-2}    + borrow_{N-3})
+            { unroll((n_limbs - 2) as u32, |_| script! {
+                OP_ROT
+                OP_ADD
+                OP_SWAP
+                u30_sub_carry
+                OP_SWAP
+                OP_TOALTSTACK
+            })}
+
+            // A{N-1} - (B{N-1} + borrow_{N-2})
+            OP_SWAP OP_DROP
+            OP_ADD
+            { u30_sub(head_offset) }
+
+            { unroll((n_limbs - 1) as u32, |_| script! {
+                OP_FROMALTSTACK
+            })}
+        }
+    }
+
+    pub fn equalverify(a: u32, b: u32) -> Script {
         let n_limbs: usize = (N_BITS + 30 - 1) / 30;
 
         script! {
@@ -137,72 +172,32 @@ pub fn u30_add_nocarry(head_offset: u32) -> Script {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use core::ops::{Add, Rem, Shl};
-    use bitcoin::opcodes::OP_PUSHNUM_1;
-    use rand_chacha::ChaCha20Rng;
-    use rand::{Rng, SeedableRng};
-    use bitcoin_script::bitcoin_script as script;
-    use num_bigint::{BigUint, RandomBits};
-    use num_traits::One;
-    use crate::opcodes::{execute_script, pushable, unroll};
-    use crate::opcodes::uint::UintImpl;
-
-    #[test]
-    fn test_zip() {
-        const N_BITS: usize = 1500;
-        const N_U30_LIMBS: usize = 50;
-        let mut prng = ChaCha20Rng::seed_from_u64(0);
-
-        let mut v = vec![];
-        for _ in 0..N_U30_LIMBS {
-            v.push(prng.gen::<i32>());
-        }
-        for _ in 0..N_U30_LIMBS {
-            v.push(prng.gen::<i32>());
-        }
-
-        let mut expected = vec![];
-        for i in 0..N_U30_LIMBS {
-            expected.push(v[N_U30_LIMBS + i]);
-            expected.push(v[i]);
-        }
-
-        let script = script! {
-            { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
-                { v[i as usize] }
-            })}
-            { UintImpl::<N_BITS>::zip(1, 0) }
-            { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
-                { expected[N_U30_LIMBS * 2 - 1 - (i as usize)] }
-                OP_EQUALVERIFY
-            })}
-            OP_PUSHNUM_1
-        };
-        let exec_result = execute_script(script);
-        assert!(exec_result.success)
+pub fn u30_sub_carry() -> Script {
+    script! {
+        OP_ROT OP_ROT
+        OP_SUB
+        OP_DUP
+        0
+        OP_LESSTHAN
+        OP_IF
+            OP_OVER
+            OP_ADD
+            1
+        OP_ELSE
+            0
+        OP_ENDIF
     }
+}
 
-    #[test]
-    fn test_add() {
-        const N_BITS: usize = 256;
-
-        let mut prng = ChaCha20Rng::seed_from_u64(0);
-
-        let a: BigUint = prng.sample(RandomBits::new(256));
-        let b: BigUint = prng.sample(RandomBits::new(256));
-        let c: BigUint = (a.clone() + b.clone()).rem(BigUint::one().shl(256));
-
-        let script = script! {
-            { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
-            { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
-            { UintImpl::<N_BITS>::add(1, 0) }
-            { UintImpl::<N_BITS>::push_u32_le(&c.to_u32_digits()) }
-            { UintImpl::<N_BITS>::equalverify(1, 0) }
-            OP_PUSHNUM_1
-        };
-        let exec_result = execute_script(script);
-        assert!(exec_result.success)
+pub fn u30_sub(head_offset: u32) -> Script {
+    script! {
+        OP_SUB
+        OP_DUP
+        0
+        OP_LESSTHAN
+        OP_IF
+            { head_offset }
+            OP_ADD
+        OP_ENDIF
     }
 }

--- a/tapscripts/tests/u32_add.rs
+++ b/tapscripts/tests/u32_add.rs
@@ -3,7 +3,9 @@
 mod test {
     use tapscripts::opcodes::execute_script;
     use bitcoin_script::bitcoin_script as script;
-    use tapscripts::opcodes::u32_std::u32_push;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+    use tapscripts::opcodes::u32_std::{u32_equal, u32_push};
     use tapscripts::opcodes::u32_add::*;
     use tapscripts::opcodes::pushable;
     
@@ -23,5 +25,24 @@ mod test {
         };
         let exec_result = execute_script(script);
         assert!(exec_result.success)
+    }
+
+    #[test]
+    fn test_u32_1add() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..100 {
+            let u32_value_a: u32 = prng.gen();
+            let u32_value_a_plus_1 = u32_value_a.wrapping_add(1);
+
+            let script = script! {
+                { u32_push(u32_value_a) }
+                u32_1add
+                { u32_push(u32_value_a_plus_1) }
+                u32_equal
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
     }
 }

--- a/tapscripts/tests/u32_sub.rs
+++ b/tapscripts/tests/u32_sub.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod test {
+    use tapscripts::opcodes::execute_script;
+    use bitcoin_script::bitcoin_script as script;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+    use tapscripts::opcodes::u32_std::{u32_equalverify, u32_push};
+    use tapscripts::opcodes::u32_sub::*;
+    use tapscripts::opcodes::pushable;
+    
+    #[test]
+    fn test_u32_sub() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let u32_value_a: u32 = prng.gen();
+        let u32_value_b: u32 = prng.gen();
+        let u32_value_c = u32_value_a.wrapping_sub(u32_value_b);
+
+        let script = script! {
+            { u32_push(u32_value_a) }
+            { u32_push(u32_value_b) }
+            { u32_sub_drop(1, 0) }
+            { u32_push(u32_value_c) }
+            { u32_equalverify() }
+            OP_PUSHNUM_1
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+
+        let script = script! {
+            { u32_push(u32_value_b) }
+            { u32_push(u32_value_a) }
+            { u32_sub_drop(0, 1) }
+            { u32_push(u32_value_c) }
+            { u32_equalverify() }
+            OP_PUSHNUM_1
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success)
+    }
+}

--- a/tapscripts/tests/u32_sub.rs
+++ b/tapscripts/tests/u32_sub.rs
@@ -12,30 +12,32 @@ mod test {
     fn test_u32_sub() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
 
-        let u32_value_a: u32 = prng.gen();
-        let u32_value_b: u32 = prng.gen();
-        let u32_value_c = u32_value_a.wrapping_sub(u32_value_b);
+        for _ in 0..100 {
+            let u32_value_a: u32 = prng.gen();
+            let u32_value_b: u32 = prng.gen();
+            let u32_value_c = u32_value_a.wrapping_sub(u32_value_b);
 
-        let script = script! {
-            { u32_push(u32_value_a) }
-            { u32_push(u32_value_b) }
-            { u32_sub_drop(1, 0) }
-            { u32_push(u32_value_c) }
-            { u32_equalverify() }
-            OP_PUSHNUM_1
-        };
-        let exec_result = execute_script(script);
-        assert!(exec_result.success);
+            let script = script! {
+                { u32_push(u32_value_a) }
+                { u32_push(u32_value_b) }
+                { u32_sub_drop(1, 0) }
+                { u32_push(u32_value_c) }
+                { u32_equalverify() }
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
 
-        let script = script! {
-            { u32_push(u32_value_b) }
-            { u32_push(u32_value_a) }
-            { u32_sub_drop(0, 1) }
-            { u32_push(u32_value_c) }
-            { u32_equalverify() }
-            OP_PUSHNUM_1
-        };
-        let exec_result = execute_script(script);
-        assert!(exec_result.success)
+            let script = script! {
+                { u32_push(u32_value_b) }
+                { u32_push(u32_value_a) }
+                { u32_sub_drop(0, 1) }
+                { u32_push(u32_value_c) }
+                { u32_equalverify() }
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
     }
 }

--- a/tapscripts/tests/uint.rs
+++ b/tapscripts/tests/uint.rs
@@ -1,8 +1,7 @@
-use tapscripts::opcodes::execute_script;
-
 #[cfg(test)]
 mod test {
     use core::ops::{Add, Rem, Shl};
+    use core::cmp::Ordering;
     use rand_chacha::ChaCha20Rng;
     use rand::{Rng, SeedableRng};
     use bitcoin_script::bitcoin_script as script;
@@ -133,6 +132,77 @@ mod test {
                 { UintImpl::<N_BITS>::push_u32_le(&c.to_u32_digits()) }
                 { UintImpl::<N_BITS>::equalverify(1, 0) }
                 OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_cmp() {
+        const N_BITS: usize = 256;
+
+        let mut prng = ChaCha20Rng::seed_from_u64(2);
+
+        for i in 0..100 {
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a_lessthan = if a.cmp(&b) == Ordering::Less { 1u32 } else { 0u32 };
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::lessthan(1, 0) }
+                { a_lessthan }
+                OP_EQUAL
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+
+        for i in 0..100 {
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a_lessthanorequal = if a.cmp(&b) != Ordering::Greater { 1u32 } else { 0u32 };
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::lessthanorequal(1, 0) }
+                { a_lessthanorequal }
+                OP_EQUAL
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+
+        for i in 0..100 {
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a_greaterthan = if a.cmp(&b) == Ordering::Greater { 1u32 } else { 0u32 };
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::greaterthan(1, 0) }
+                { a_greaterthan }
+                OP_EQUAL
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+
+        for i in 0..100 {
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a_greaterthanorequal = if a.cmp(&b) != Ordering::Less { 1u32 } else { 0u32 };
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::greaterthanorequal(1, 0) }
+                { a_greaterthanorequal }
+                OP_EQUAL
             };
             let exec_result = execute_script(script);
             assert!(exec_result.success);

--- a/tapscripts/tests/uint.rs
+++ b/tapscripts/tests/uint.rs
@@ -1,0 +1,141 @@
+use tapscripts::opcodes::execute_script;
+
+#[cfg(test)]
+mod test {
+    use core::ops::{Add, Rem, Shl};
+    use rand_chacha::ChaCha20Rng;
+    use rand::{Rng, SeedableRng};
+    use bitcoin_script::bitcoin_script as script;
+    use num_bigint::{BigUint, RandomBits};
+    use num_traits::One;
+    use tapscripts::opcodes::uint::UintImpl;
+    use tapscripts::opcodes::{execute_script, pushable, unroll};
+
+    #[test]
+    fn test_zip() {
+        const N_BITS: usize = 1500;
+        const N_U30_LIMBS: usize = 50;
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for i in 0..50 {
+            let mut v = vec![];
+            for _ in 0..N_U30_LIMBS {
+                v.push(prng.gen::<i32>());
+            }
+            for _ in 0..N_U30_LIMBS {
+                v.push(prng.gen::<i32>());
+            }
+
+            let mut expected = vec![];
+            for i in 0..N_U30_LIMBS {
+                expected.push(v[i]);
+                expected.push(v[N_U30_LIMBS + i]);
+            }
+
+            let script = script! {
+                { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
+                    { v[i as usize] }
+                })}
+                { UintImpl::<N_BITS>::zip(1, 0) }
+                { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
+                    { expected[N_U30_LIMBS * 2 - 1 - (i as usize)] }
+                    OP_EQUALVERIFY
+                })}
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+
+        for i in 0..50 {
+            let mut v = vec![];
+            for _ in 0..N_U30_LIMBS {
+                v.push(prng.gen::<i32>());
+            }
+            for _ in 0..N_U30_LIMBS {
+                v.push(prng.gen::<i32>());
+            }
+
+            let mut expected = vec![];
+            for i in 0..N_U30_LIMBS {
+                expected.push(v[N_U30_LIMBS + i]);
+                expected.push(v[i]);
+            }
+
+            let script = script! {
+                { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
+                    { v[i as usize] }
+                })}
+                { UintImpl::<N_BITS>::zip(0, 1) }
+                { unroll((N_U30_LIMBS * 2) as u32, |i| script! {
+                    { expected[N_U30_LIMBS * 2 - 1 - (i as usize)] }
+                    OP_EQUALVERIFY
+                })}
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_add() {
+        const N_BITS: usize = 256;
+
+        for _ in 0..100 {
+            let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let c: BigUint = (a.clone() + b.clone()).rem(BigUint::one().shl(256));
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::add(1, 0) }
+                { UintImpl::<N_BITS>::push_u32_le(&c.to_u32_digits()) }
+                { UintImpl::<N_BITS>::equalverify(1, 0) }
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_sub() {
+        const N_BITS: usize = 256;
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..100 {
+            let a: BigUint = prng.sample(RandomBits::new(256));
+            let b: BigUint = prng.sample(RandomBits::new(256));
+            let mut c: BigUint = BigUint::one().shl(256) + &a - &b;
+            c = c.rem(BigUint::one().shl(256));
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::sub(1, 0) }
+                { UintImpl::<N_BITS>::push_u32_le(&c.to_u32_digits()) }
+                { UintImpl::<N_BITS>::equalverify(1, 0) }
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+
+            let script = script! {
+                { UintImpl::<N_BITS>::push_u32_le(&b.to_u32_digits()) }
+                { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
+                { UintImpl::<N_BITS>::sub(0, 1) }
+                { UintImpl::<N_BITS>::push_u32_le(&c.to_u32_digits()) }
+                { UintImpl::<N_BITS>::equalverify(1, 0) }
+                OP_PUSHNUM_1
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+}

--- a/tapscripts/tests/uint.rs
+++ b/tapscripts/tests/uint.rs
@@ -144,7 +144,7 @@ mod test {
 
         let mut prng = ChaCha20Rng::seed_from_u64(2);
 
-        for i in 0..100 {
+        for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
             let b: BigUint = prng.sample(RandomBits::new(254));
             let a_lessthan = if a.cmp(&b) == Ordering::Less { 1u32 } else { 0u32 };
@@ -160,7 +160,7 @@ mod test {
             assert!(exec_result.success);
         }
 
-        for i in 0..100 {
+        for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
             let b: BigUint = prng.sample(RandomBits::new(254));
             let a_lessthanorequal = if a.cmp(&b) != Ordering::Greater { 1u32 } else { 0u32 };
@@ -176,7 +176,7 @@ mod test {
             assert!(exec_result.success);
         }
 
-        for i in 0..100 {
+        for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
             let b: BigUint = prng.sample(RandomBits::new(254));
             let a_greaterthan = if a.cmp(&b) == Ordering::Greater { 1u32 } else { 0u32 };
@@ -192,7 +192,7 @@ mod test {
             assert!(exec_result.success);
         }
 
-        for i in 0..100 {
+        for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
             let b: BigUint = prng.sample(RandomBits::new(254));
             let a_greaterthanorequal = if a.cmp(&b) != Ordering::Less { 1u32 } else { 0u32 };

--- a/tapscripts/tests/uint.rs
+++ b/tapscripts/tests/uint.rs
@@ -80,14 +80,14 @@ mod test {
 
     #[test]
     fn test_add() {
-        const N_BITS: usize = 256;
+        const N_BITS: usize = 254;
 
         for _ in 0..100 {
             let mut prng = ChaCha20Rng::seed_from_u64(0);
 
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
-            let c: BigUint = (a.clone() + b.clone()).rem(BigUint::one().shl(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
+            let c: BigUint = (a.clone() + b.clone()).rem(BigUint::one().shl(254));
 
             let script = script! {
                 { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
@@ -104,15 +104,15 @@ mod test {
 
     #[test]
     fn test_sub() {
-        const N_BITS: usize = 256;
+        const N_BITS: usize = 254;
 
         let mut prng = ChaCha20Rng::seed_from_u64(0);
 
         for _ in 0..100 {
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
-            let mut c: BigUint = BigUint::one().shl(256) + &a - &b;
-            c = c.rem(BigUint::one().shl(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
+            let mut c: BigUint = BigUint::one().shl(254) + &a - &b;
+            c = c.rem(BigUint::one().shl(254));
 
             let script = script! {
                 { UintImpl::<N_BITS>::push_u32_le(&a.to_u32_digits()) }
@@ -140,13 +140,13 @@ mod test {
 
     #[test]
     fn test_cmp() {
-        const N_BITS: usize = 256;
+        const N_BITS: usize = 254;
 
         let mut prng = ChaCha20Rng::seed_from_u64(2);
 
         for i in 0..100 {
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
             let a_lessthan = if a.cmp(&b) == Ordering::Less { 1u32 } else { 0u32 };
 
             let script = script! {
@@ -161,8 +161,8 @@ mod test {
         }
 
         for i in 0..100 {
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
             let a_lessthanorequal = if a.cmp(&b) != Ordering::Greater { 1u32 } else { 0u32 };
 
             let script = script! {
@@ -177,8 +177,8 @@ mod test {
         }
 
         for i in 0..100 {
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
             let a_greaterthan = if a.cmp(&b) == Ordering::Greater { 1u32 } else { 0u32 };
 
             let script = script! {
@@ -193,8 +193,8 @@ mod test {
         }
 
         for i in 0..100 {
-            let a: BigUint = prng.sample(RandomBits::new(256));
-            let b: BigUint = prng.sample(RandomBits::new(256));
+            let a: BigUint = prng.sample(RandomBits::new(254));
+            let b: BigUint = prng.sample(RandomBits::new(254));
             let a_greaterthanorequal = if a.cmp(&b) != Ordering::Less { 1u32 } else { 0u32 };
 
             let script = script! {


### PR DESCRIPTION
This PR fixes the u32 sub in the case when a > b, as well as supplying the implementation of generic uint sub and cmp. It also adds u32_1add, which closes #21.