### PR TITLE
optimize number of bytes for u30_add_nocarry

### DIFF
--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -100,10 +100,12 @@ pub fn u30_add_carry() -> Script {
 
 pub fn u30_add_nocarry(head_offset: u32) -> Script {
     script! {
-        OP_ADD OP_DUP
-        { head_offset } OP_GREATERTHANOREQUAL
+        OP_ADD { head_offset } OP_2DUP
+        OP_GREATERTHANOREQUAL
         OP_IF
-            { head_offset } OP_SUB
+            OP_SUB
+        OP_ELSE
+            OP_DROP
         OP_ENDIF
     }
 }


### PR DESCRIPTION
This PR will reduce some bytes in u30_add_nocarry.

Typically, when the `head offset` is 1 << 14( U254), the old u30_add_nocarry scripts will be   
`OP_ADD OP_DUP OP_PUSHBYTES_2 0040 OP_GREATERTHANOREQUAL OP_IF OP_PUSHBYTES_2 0040 OP_SUB OP_ENDIF`(The length is 12), 
while the new scripts will be 
`OP_ADD OP_PUSHBYTES_2 0040 OP_2DUP OP_GREATERTHANOREQUAL OP_IF OP_SUB OP_ELSE OP_DROP OP_ENDIF`(The length is 11).