### PR TITLE
optimize fq2 and fq6 square

### DIFF
--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -42,14 +42,15 @@ impl Fq2 {
     pub fn square() -> Script {
         script! {
             { Fq::copy(1) }
-            { Fq::square() }
             { Fq::copy(1) }
-            { Fq::square() }
-            { Fq::sub(1, 0) }
-            { Fq::roll(2) }
-            { Fq::roll(2) }
+            { Fq::copy(1) }
+            { Fq::copy(1) }
             { Fq::mul() }
             { Fq::double(0) }
+            { Fq::sub(2, 1) }
+            { Fq::add(3, 2) }
+            { Fq::mul() }
+            { Fq::roll(1) }
         }
     }
 


### PR DESCRIPTION
This PR further optimizes Fq2::square from 749135 bytes to 500264 bytes and also optimizes Fq6::square from 4529796 bytes to 3022200 bytes.