### PR TITLE
add div2 and optimize fq6::square

### DIFF
--- a/src/bn254/fq.rs
+++ b/src/bn254/fq.rs
@@ -249,6 +249,17 @@ impl Fq {
             { Fq::mul() }
         }
     }
+
+    pub fn div2() -> Script {
+        let p_plus_one_div2 = "183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea4";
+        script! {
+            { U254::div2rem() }
+            OP_IF
+                { Fq::push_hex(p_plus_one_div2) }
+                { Fq::add(1, 0) }
+            OP_ENDIF
+        }
+    }
 }
 
 #[cfg(test)]
@@ -429,6 +440,27 @@ mod test {
                 { Fq::push_u32_le(&BigUint::from(a).to_u32_digits()) }
                 { Fq::inv() }
                 { Fq::push_u32_le(&BigUint::from(c).to_u32_digits()) }
+                { Fq::equalverify(1, 0) }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_div2() {
+        println!("Fq.div2: {} bytes", Fq::div2().len());
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..1 {
+            let a = ark_bn254::Fq::rand(&mut prng);
+            let c = a.double();
+
+            let script = script! {
+                { Fq::push_u32_le(&BigUint::from(c).to_u32_digits()) }
+                { Fq::div2() }
+                { Fq::push_u32_le(&BigUint::from(a).to_u32_digits()) }
                 { Fq::equalverify(1, 0) }
                 OP_TRUE
             };

--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -154,6 +154,15 @@ impl Fq2 {
             { Fq::neg(0) }
         }
     }
+
+    pub fn div2() -> Script {
+        script! {
+            { Fq::roll(1) }
+            { Fq::div2() }
+            { Fq::roll(1) }
+            { Fq::div2() }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -345,6 +354,27 @@ mod test {
                 { fq2_push(a) }
                 { Fq2::square() }
                 { fq2_push(b) }
+                { Fq2::equalverify() }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_bn254_fq2_div2() {
+        println!("Fq2.div2: {} bytes", Fq2::div2().len());
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..1 {
+            let a = ark_bn254::Fq2::rand(&mut prng);
+            let b = a.double();
+
+            let script = script! {
+                { fq2_push(b) }
+                { Fq2::div2() }
+                { fq2_push(a) }
                 { Fq2::equalverify() }
                 OP_TRUE
             };

--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -105,11 +105,10 @@ impl Fq2 {
         }
 
         script! {
-            { Fq::roll(b) }
-            { Fq::copy(0) }
+            { Fq::copy(b) }
             { Fq::roll(a + 2) }
             { Fq::mul() }
-            { Fq::roll(1) }
+            { Fq::roll(b + 1) }
             { Fq::roll(a + 1) }
             { Fq::mul() }
         }

--- a/src/bn254/fq6.rs
+++ b/src/bn254/fq6.rs
@@ -256,24 +256,26 @@ impl Fq6 {
     }
 
     pub fn square() -> Script {
-        // CH-SQR2 from https://eprint.iacr.org/2006/471.pdf
+        // CH-SQR3 from https://eprint.iacr.org/2006/471.pdf
         script! {
             // compute s_0 = a_0 ^ 2
             { Fq2::copy(4) }
             { Fq2::square() }
 
-            // compute s_1 = 2a_0a_1
-            { Fq2::copy(6) }
-            { Fq2::copy(6) }
-            { Fq2::mul(2, 0) }
-            { Fq2::double(0) }
+            // compute a_0 + a_2
+            { Fq2::roll(6) }
+            { Fq2::copy(4) }
+            { Fq2::add(2, 0) }
+
+            // compute s_1 = (a_0 + a_1 + a_2) ^ 2
+            { Fq2::copy(0) }
+            { Fq2::copy(8) }
+            { Fq2::add(2, 0) }
+            { Fq2::square() }
 
             // compute s_2 = (a_0 - a_1 + a_2) ^ 2
-            { Fq2::roll(8) }
-            { Fq2::copy(6) }
-            { Fq2::add(2, 0) }
             { Fq2::copy(8) }
-            { Fq2::sub(2, 0) }
+            { Fq2::sub(4, 0) }
             { Fq2::square() }
 
             // compute s_3 = 2a_1a_2
@@ -286,25 +288,31 @@ impl Fq6 {
             { Fq2::roll(8) }
             { Fq2::square() }
 
-            // at this point, we have s_0, s_1, s_2, s_3, s_4
+            // compute t_1 = (s_1 + s_2) / 2
+            { Fq2::copy(6) }
+            { Fq2::roll(6) }
+            { Fq2::add(2, 0) }
+            { Fq2::div2() }
+
+            // at this point, we have s_0, s_1, s_3, s_4, t_1
 
             // compute c_0 = s_0 + \beta s_3
-            { Fq2::copy(2) }
+            { Fq2::copy(4) }
             { Fq6::mul_fq2_by_nonresidue() }
             { Fq2::copy(10) }
             { Fq2::add(2, 0) }
 
-            // compute c_1 = s_1 + \beta s_4
-            { Fq2::copy(2) }
+            // compute c_1 = s_1 - s_3 - t_1 + \beta s_4
+            { Fq2::copy(4) }
             { Fq6::mul_fq2_by_nonresidue() }
-            { Fq2::copy(10) }
+            { Fq2::copy(4) }
+            { Fq2::add(10, 0) }
+            { Fq2::sub(10, 0) }
             { Fq2::add(2, 0) }
 
-            // compute c_2 = s_1 + s_2 + s_3 - s_0 - s_4
-            { Fq2::add(12, 4) }
-            { Fq2::add(10, 8) }
-            { Fq2::add(8, 0) }
-            { Fq2::sub(0, 2) }
+            // compute c_2 = t_1 - s_0 - s_4
+            { Fq2::add(8, 6) }
+            { Fq2::sub(6, 0) }
         }
     }
 


### PR DESCRIPTION
This PR adds functions for dividing by 2 in Fq and Fq2, and improves Fq2::square by using it from 3022200 bytes to 2782732 bytes.