### PR TITLE
Necessary changes on the BitVM side for the new execution engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitv
 strum = "0.26"
 strum_macros = "0.26"
 hex = "0.4.3"
-bitcoin-scriptexec = { git = "https://github.com/weikengchen/rust-bitcoin-scriptexec/", branch = "new-engine"}
+bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"}
 serde = { version = "1.0.197", features = ["derive"] }
 num-bigint = "0.4.4"
 num-traits = "0.2.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitv
 strum = "0.26"
 strum_macros = "0.26"
 hex = "0.4.3"
-bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"}
+bitcoin-scriptexec = { git = "https://github.com/weikengchen/rust-bitcoin-scriptexec/", branch = "new-engine"}
 serde = { version = "1.0.197", features = ["derive"] }
 num-bigint = "0.4.4"
 num-traits = "0.2.18"

--- a/src/hash/blake3.rs
+++ b/src/hash/blake3.rs
@@ -338,7 +338,7 @@ mod tests {
             {initial_state(64)}
         };
         let res = execute_script(script);
-        assert!(res.final_stack[17][0] == 79);
+        assert!(res.final_stack.get(17)[0] == 79);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,9 @@ pub mod treepp {
 }
 
 use core::fmt;
-use std::ops::Index;
 
 use bitcoin::{hashes::Hash, hex::DisplayHex, Opcode, TapLeafHash, Transaction};
-use bitcoin_scriptexec::{
-    Exec, ExecCtx, ExecError, ExecStats, Options, TxTemplate,
-};
+use bitcoin_scriptexec::{Exec, ExecCtx, ExecError, ExecStats, Options, Stack, TxTemplate};
 
 pub mod bigint;
 pub mod bn254;
@@ -25,10 +22,10 @@ pub mod pseudo;
 pub mod u32;
 
 /// A wrapper for the stack types to print them better.
-pub struct FmtStack(Vec<Vec<u8>>);
+pub struct FmtStack(Stack);
 impl fmt::Display for FmtStack {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut iter = self.0.iter().enumerate().peekable();
+        let mut iter = self.0.iter_str().enumerate().peekable();
         write!(f, "\n0:\t\t ")?;
         while let Some((index, item)) = iter.next() {
             write!(f, "0x{:8}", item.as_hex())?;
@@ -47,6 +44,10 @@ impl FmtStack {
     fn len(&self) -> usize {
         self.0.len()
     }
+
+    fn get(&self, index: usize) -> Vec<u8> {
+        self.0.get(index)
+    }
 }
 
 impl fmt::Debug for FmtStack {
@@ -54,12 +55,6 @@ impl fmt::Debug for FmtStack {
         write!(f, "{}", self)?;
         Ok(())
     }
-}
-
-impl Index<usize> for FmtStack {
-    type Output = Vec<u8>;
-
-    fn index(&self, index: usize) -> &Self::Output { &self.0[index] }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR includes the necessary changes on the BitVM side to use the candidate new engine discussed in https://github.com/BitVM/rust-bitcoin-scriptexec/pull/1.

Needs to be merged only after the new engine is merged to main.