### PR TITLE
optimize for the specific_optimize

### DIFF
--- a/src/u32/u32_rrot.rs
+++ b/src/u32/u32_rrot.rs
@@ -198,7 +198,7 @@ pub fn u32_rrot(rot_num: usize) -> Script {
 
     script! {
         {u8_extract_hbit(hbit)}
-        2 OP_ROLL {u8_extract_hbit(hbit)}
+        OP_ROT {u8_extract_hbit(hbit)}
         4 OP_ROLL {u8_extract_hbit(hbit)}
         6 OP_ROLL {u8_extract_hbit(hbit)}
 

--- a/src/u32/u32_rrot.rs
+++ b/src/u32/u32_rrot.rs
@@ -138,21 +138,24 @@ pub fn u8_extract_hbit(hbit: usize) -> Script {
         OP_FROMALTSTACK
     }
 }
-
+// 1 2 3 4
 pub fn byte_reorder(offset: usize) -> Script {
     assert!(offset < 4);
     if offset == 0 {
+        // 4 3 2 1
         return script! {
             OP_SWAP
             OP_2SWAP
             OP_SWAP
         };
     } else if offset == 1 {
+        // 1 4 3 2
         return script! {
             OP_SWAP
-            2 OP_ROLL
+            OP_ROT
         };
     } else if offset == 2 {
+        // 2 1 4 3
         return script! {
             OP_SWAP
             OP_2SWAP
@@ -172,11 +175,11 @@ pub fn byte_reorder(offset: usize) -> Script {
 
 pub fn specific_optimize(rot_num: usize) -> Option<Script> {
     let res: Option<Script> = match rot_num {
-        0 => script! {}.into(),                      // 0
-        7 => script! {u32_rrot7}.into(),             // 86
-        8 => script! {u32_rrot8}.into(),             // 3
-        16 => script! {u32_rrot16}.into(),           // 1
-        24 => script! {3 OP_ROLL}.into(), // 4
+        0 => script! {}.into(),            // 0
+        7 => script! {u32_rrot7}.into(),   // 86
+        8 => script! {u32_rrot8}.into(),   // 3
+        16 => script! {u32_rrot16}.into(), // 1
+        24 => script! {3 OP_ROLL}.into(),  // 4
         _ => None,
     };
     res

--- a/src/u32/u32_rrot.rs
+++ b/src/u32/u32_rrot.rs
@@ -176,7 +176,7 @@ pub fn specific_optimize(rot_num: usize) -> Option<Script> {
         7 => script! {u32_rrot7}.into(),             // 86
         8 => script! {u32_rrot8}.into(),             // 3
         16 => script! {u32_rrot16}.into(),           // 1
-        24 => script! {u32_rrot16 u32_rrot8}.into(), // 4
+        24 => script! {3 OP_ROLL}.into(), // 4
         _ => None,
     };
     res


### PR DESCRIPTION
## desc
hi @wz14 , thx for ur talent contribution.
i just find that u propose a general u32_rrot() function to solve the right rotate problem.
and inside for the `specific_optimize` function: 
```Rust
pub fn specific_optimize(rot_num: usize) -> Option<Script> {
    let res: Option<Script> = match rot_num {
        0 => script! {}.into(),                      // 0
        7 => script! {u32_rrot7}.into(),             // 86
        8 => script! {u32_rrot8}.into(),             // 3
        16 => script! {u32_rrot16}.into(),           // 1
        24 => script! {u32_rrot16 u32_rrot8}.into(), // 4
        _ => None,
    };
    res
}
```
i believe that the `  24 => script! {u32_rrot16 u32_rrot8}.into(), // 4` can be optimized as below:
```Rust
pub fn specific_optimize(rot_num: usize) -> Option<Script> {
    let res: Option<Script> = match rot_num {
        0 => script! {}.into(),                      // 0
        7 => script! {u32_rrot7}.into(),             // 86
        8 => script! {u32_rrot8}.into(),             // 3
        16 => script! {u32_rrot16}.into(),           // 1
        24 => script! {3 OP_ROLL}.into(), // 4
        _ => None,
    };
    res
}
```
u may refer to the stack frame below:
![image](https://github.com/BitVM/BitVM/assets/5505497/3f286145-f536-4fc3-9b9f-a56efe306984)
![image](https://github.com/BitVM/BitVM/assets/5505497/fa270301-ebb4-4d7a-9b1f-5aae94adb8d3)

# location
https://github.com/BitVM/BitVM/blob/4e0b9203d969ec87f2a9950e212ef68862cae2d4/src/u32/u32_rrot.rs#L179

