### PR TITLE
Optimize the rshift function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2.18"
 ark-bn254 = { version = "0.4.0", features = ["curve"] }
 ark-ff = "0.4.0"
 ark-ec = "0.4.0"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,1 +1,2 @@
 pub mod blake3;
+pub mod sha256;

--- a/src/hash/sha256.rs
+++ b/src/hash/sha256.rs
@@ -1,0 +1,214 @@
+#![allow(non_snake_case)]
+use std::collections::HashMap;
+
+use crate::treepp::{pushable, script, Script};
+use crate::u32::u32_add::u32_add_drop;
+use crate::u32::u32_std::{u32_dup, u32_equalverify, u32_roll};
+use crate::u32::{
+    u32_add::u32_add,
+    u32_and::u32_and,
+    u32_rrot::u32_rrot,
+    u32_std::{u32_drop, u32_fromaltstack, u32_pick, u32_push, u32_toaltstack},
+    u32_xor::{u32_xor, u8_drop_xor_table, u8_push_xor_table},
+    // unroll,
+};
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const INITSTATE: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+/// sha256 take indefinite length input on the top of statck and return 256 bit (64 byte)
+pub fn sha256(num_bytes: usize) -> Script {
+    // TODO: calculate chunks_size
+    let chunks_size: usize = 0;
+    script! {
+        {u8_push_xor_table}
+
+        // top of stack: [ [n bytes input] ]
+        {padding_and_split(num_bytes)}
+        // top of stack: [ [64 byte chunks]... ]
+        {sha256_init()}
+        // top of statck: [ [64 byte chunks]..., state[0-7]]
+        for _ in 0..chunks_size {
+            {sha256_transform()}
+        }
+
+        {u8_drop_xor_table()}
+    }
+}
+
+/// TODO:
+/// reorder bytes for u32
+pub fn padding_and_split(num_bytes: usize) -> Script {
+    script! {}
+}
+
+/// push all init state into stack
+pub fn sha256_init() -> Vec<Script> {
+    let mut state: [u32; 8] = INITSTATE;
+    state.reverse();
+    state.iter().map(|x: &u32| u32_push(*x)).collect::<Vec<_>>()
+}
+
+/// sha256 transform
+/// stack: [64byte chunk: 16; u32] state[0-7]
+pub fn sha256_transform(stack_depth: u32) -> Script {
+    script! {
+        // push old state to alt stack
+        for _ in 0..8 {
+            {u32_toaltstack()}
+        }
+
+        // reverse for the first 16 states
+        for i in 1..16 {
+            {u32_roll(i)}
+        }
+
+        // reorg data
+        for _ in 16..64 {
+            { 0 } // delimiter, may be optimized
+
+            {u32_pick(2)}
+            {sig1(stack_depth - 6)}
+            {u32_add_drop(0, 1)}
+
+            {u32_pick(7)}
+            {u32_add_drop(0, 1)}
+
+            {u32_pick(15)}
+            {sig0(stack_depth - 6)}
+            {u32_add_drop(0, 1)}
+
+            {u32_pick(16)}
+            {u32_add_drop(0, 1)}
+        }
+
+        // get a copy of states from altstack
+        for _ in 0..8 {
+            {u32_fromaltstack()}
+        }
+
+        for _ in 0..8 {
+            {u32_pick(7)}
+        }
+
+        for _ in 0..8 {
+            {u32_toaltstack()}
+        }
+
+        // loop for transform
+
+    }
+}
+
+/// shift right the top u32
+pub fn u32_shr(rot_num: usize, stack_depth: u32) -> Script {
+    script! {
+        {u32_rrot(rot_num)}
+        {u32_push(0xffffffff >> rot_num)}
+        {u32_and(0, 1, stack_depth + 1)}
+        {u32_toaltstack()}
+        {u32_drop()}
+        {u32_fromaltstack()}
+    }
+}
+
+/// Change top element x to ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3)
+pub fn sig0(stack_depth: u32) -> Script {
+    script! {
+        {u32_dup()}
+        {u32_dup()}
+        {u32_toaltstack()}
+        {u32_toaltstack()}
+
+        {u32_shr(3, stack_depth)}
+        {u32_fromaltstack()}
+        {u32_rrot(7)}
+        {u32_fromaltstack()}
+        {u32_rrot(18)}
+        {u32_xor(0, 1, stack_depth + 2)}
+        {u32_xor(0, 2, stack_depth + 2)}
+
+        // clean stack
+        {u32_toaltstack()}
+        {u32_drop()}
+        {u32_drop()}
+        {u32_fromaltstack()}
+    }
+}
+
+/// Change top element x to (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
+pub fn sig1(stack_depth: u32) -> Script {
+    script! {
+        {u32_dup()}
+        {u32_dup()}
+        {u32_toaltstack()}
+        {u32_toaltstack()}
+
+        {u32_shr(10, stack_depth)}
+        {u32_fromaltstack()}
+        {u32_rrot(19)}
+        {u32_fromaltstack()}
+        {u32_rrot(17)}
+        {u32_xor(0, 1, stack_depth + 2)}
+        {u32_xor(0, 2, stack_depth + 2)}
+
+        // clean stack
+        {u32_toaltstack()}
+        {u32_drop()}
+        {u32_drop()}
+        {u32_fromaltstack()}
+    }
+}
+
+pub fn ep0() -> Script { script!() }
+
+pub fn ep1() -> Script { script!() }
+
+/// Push (((x) & (y)) ^ (~(x) & (z))) into stack
+pub fn ch(x: u32, y: u32, z: u32, stack_depth: u32) -> Script { script!() }
+
+/// Push (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z))) into stack
+pub fn maj(x: u32, y: u32, z: u32, stack_depth: u32) -> Script { script!() }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::hash::sha256::*;
+    use crate::treepp::pushable;
+    use crate::treepp::{execute_script, script};
+
+    fn rrot(x: u32, n: usize) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        (x >> n) | (x << (32 - n))
+    }
+
+    #[test]
+    fn test_sig0() {
+        let x: u32 = 12;
+        let result: u32 = rrot(x, 7) ^ rrot(x, 18) ^ (x >> 3);
+        let script = script! {
+            {u8_push_xor_table()}
+            {u32_push(x)}
+            {sig0(2)}
+            {u32_toaltstack()}
+            {u8_drop_xor_table()}
+            {u32_fromaltstack()}
+        };
+        let res = execute_script(script);
+        println!("stack: {:100}, result: {:X}", res, result);
+    }
+}

--- a/src/hash/sha256.rs
+++ b/src/hash/sha256.rs
@@ -75,6 +75,20 @@ pub fn sha256_init() -> Vec<Script> {
     state.iter().map(|x: &u32| u32_push(*x)).collect::<Vec<_>>()
 }
 
+pub fn sha256_final() -> Script {
+    script! {
+        for _ in 0..8 {
+            OP_SWAP
+            OP_2SWAP
+            OP_SWAP
+            {u32_toaltstack()}
+        }
+        for _ in 0..8 {
+            {u32_fromaltstack()}
+        }
+    }
+}
+
 /// sha256 transform
 /// stack: [m[15], m[14], ..., m[0], state[7], state[6], ..., state[0]]
 /// output: [state[7], state[6], ..., state[0]]
@@ -369,6 +383,8 @@ pub fn maj(x: u32, y: u32, z: u32, stack_depth: u32) -> Script {
 #[cfg(test)]
 mod tests {
 
+    use bitcoin::opcodes::all::OP_SWAP;
+
     use crate::hash::blake3::push_bytes_hex;
     use crate::hash::sha256::*;
     use crate::treepp::pushable;
@@ -554,10 +570,10 @@ mod tests {
             }
 
             {u8_drop_xor_table()}
-
         };
 
         let res = execute_script(script);
+        // println!("stack: {:100}", res);
         assert_eq!(res.final_stack.len(), 0);
     }
 }

--- a/src/u32/mod.rs
+++ b/src/u32/mod.rs
@@ -2,6 +2,7 @@ pub mod u32_add;
 pub mod u32_and;
 pub mod u32_or;
 pub mod u32_rrot;
+pub mod u32_rshit;
 pub mod u32_std;
 pub mod u32_xor;
 pub mod u32_zip;

--- a/src/u32/mod.rs
+++ b/src/u32/mod.rs
@@ -1,4 +1,6 @@
 pub mod u32_add;
+pub mod u32_and;
+pub mod u32_or;
 pub mod u32_rrot;
 pub mod u32_std;
 pub mod u32_xor;

--- a/src/u32/u32_and.rs
+++ b/src/u32/u32_and.rs
@@ -1,0 +1,133 @@
+#![allow(dead_code)]
+
+use crate::treepp::{pushable, script, Script};
+use crate::u32::u32_zip::u32_copy_zip;
+
+/// The bitwise AND of two u8 elements.
+/// Expects the u8_xor_table to be on the stack
+pub fn u8_and(i: u32) -> Script {
+    script! {
+        // f_A = f(A)
+        OP_DUP
+        {i}
+        OP_ADD
+        OP_PICK
+
+        // A_even = f_A << 1
+        OP_DUP
+        OP_DUP
+        OP_ADD
+
+        // A_odd = A - A_even
+        OP_ROT
+        OP_SWAP
+        OP_SUB
+
+        // f_B = f(B)
+        OP_ROT
+        OP_DUP
+        {i + 1}
+        OP_ADD
+        OP_PICK
+
+        // B_even = f_B << 1
+        OP_DUP
+        OP_DUP
+        OP_ADD
+
+        // B_odd = B - B_even
+        OP_ROT
+        OP_SWAP
+        OP_SUB
+
+        // A_andxor_B_even = f_A + f_B
+        OP_SWAP
+        3
+        OP_ROLL
+        OP_ADD
+        // A_and_B_even = f(A_andxor_B_even)
+        {i}
+        OP_ADD
+        OP_PICK
+
+        // A_andxor_B_odd = A_odd + B_odd
+        OP_SWAP
+        OP_ROT
+        OP_ADD
+
+        // A_and_B_odd = f(A_andxor_B_odd)
+        {i - 1}
+        OP_ADD
+        OP_PICK
+
+        // A_and_B = A_and_B_odd + (A_and_B_even << 1)
+        OP_SWAP
+        OP_DUP
+        OP_ADD
+        OP_ADD
+    }
+}
+
+/// The bitwise AND of the u32 elements at address a and at address b. Drops a and b
+///
+/// Expects the u8_xor_table to be on the stack
+pub fn u32_and(a: u32, b: u32, stack_size: u32) -> Script {
+    assert_ne!(a, b);
+    script! {
+        {u32_copy_zip(a, b)}
+
+        {u8_and(8 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_and(6 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_and(4 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_and(2 + (stack_size - 2) * 4)}
+
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::treepp::pushable;
+    use crate::treepp::{execute_script, script};
+    use crate::u32::u32_and::*;
+    use crate::u32::u32_std::*;
+    use crate::u32::u32_xor::{u8_drop_xor_table, u8_push_xor_table};
+    use rand::Rng;
+
+    fn and(x: u32, y: u32) -> u32 { x & y }
+
+    #[test]
+    fn test_and() {
+        for _ in 0..100 {
+            let mut rng = rand::thread_rng();
+            let x: u32 = rng.gen();
+            let y: u32 = rng.gen();
+            let exec_script = script! {
+                {u8_push_xor_table()}
+                {u32_push(x)}
+                {u32_push(y)}
+                {u32_and(0, 1, 3)}
+                {u32_push(and(x, y))}
+                {u32_equal()}
+                OP_TOALTSTACK
+                {u32_drop()} // drop y
+                {u8_drop_xor_table()}
+                OP_FROMALTSTACK
+            };
+            let res = execute_script(exec_script);
+            assert_eq!(res.success, true);
+        }
+    }
+}

--- a/src/u32/u32_or.rs
+++ b/src/u32/u32_or.rs
@@ -1,0 +1,166 @@
+#![allow(dead_code)]
+
+use crate::treepp::{pushable, script, Script};
+use crate::u32::u32_zip::u32_copy_zip;
+
+/// Bitwise OR of two u8 elements.
+/// Expects the u8_xor_table to be on the stack.
+///
+pub fn u8_or(i: u32) -> Script {
+    script! {
+        // f_A = f(A)
+        OP_DUP
+        {i}
+        OP_ADD
+        OP_PICK
+
+        // A_even = f_A << 1
+        OP_DUP
+        OP_DUP
+        OP_ADD
+
+        // A_odd = A - A_even
+        OP_ROT
+        OP_SWAP
+        OP_SUB
+
+        // f_B = f(B)
+        OP_ROT
+        OP_DUP
+        {i + 1}
+        OP_ADD
+        OP_PICK
+
+        // B_even = f_B << 1
+        OP_DUP
+        OP_DUP
+        OP_ADD
+
+        // B_odd = B - B_even
+        OP_ROT
+        OP_SWAP
+        OP_SUB
+
+        // A_andxor_B_even = f_A + f_B
+        OP_SWAP
+        3
+        OP_ROLL
+        OP_ADD
+
+        // A_or_B_even = f(A_andxor_B_even << 1) + f(A_andxor_B_even)
+        OP_DUP
+        OP_DUP
+        OP_ADD
+        OP_DUP         // The left shift may overflow 1 bit
+        255
+        OP_GREATERTHAN
+        OP_IF
+            256
+            OP_SUB
+        OP_ENDIF
+        {i + 1}
+        OP_ADD
+        OP_PICK
+        OP_SWAP
+        {i + 1}
+        OP_ADD
+        OP_PICK
+        OP_ADD
+
+        // A_andxor_B_odd = A_odd + B_odd
+        OP_SWAP
+        OP_ROT
+        OP_ADD
+
+        // A_or_B_odd = f(A_andxor_B_odd << 1) + f(A_andxor_B_odd)
+        OP_DUP
+        OP_DUP
+        OP_ADD
+        OP_DUP
+        255
+        OP_GREATERTHAN
+        OP_IF
+            256
+            OP_SUB
+        OP_ENDIF
+        {i}
+        OP_ADD
+        OP_PICK
+        OP_SWAP
+        {i}
+        OP_ADD
+        OP_PICK
+        OP_ADD
+
+        // A_or_B = A_or_B_odd + (A_or_B_even << 1)
+        OP_SWAP
+        OP_DUP
+        OP_ADD
+        OP_ADD
+    }
+}
+
+/// Bitwise OR of two u32 elements.
+/// Expects the u8_xor_table to be on the stack
+pub fn u32_or(a: u32, b: u32, stack_size: u32) -> Script {
+    assert_ne!(a, b);
+
+    script! {
+        {u32_copy_zip(a, b)}
+
+        {u8_or(8 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_or(6 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_or(4 + (stack_size - 2) * 4)}
+
+        OP_TOALTSTACK
+
+        {u8_or(2 + (stack_size - 2) * 4)}
+
+
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::treepp::pushable;
+    use crate::treepp::{execute_script, script};
+    use crate::u32::u32_or::*;
+    use crate::u32::u32_std::*;
+    use crate::u32::u32_xor::{u8_drop_xor_table, u8_push_xor_table};
+    use rand::Rng;
+
+    fn or(x: u32, y: u32) -> u32 { x | y }
+
+    #[test]
+    fn test_or() {
+        for _ in 0..100 {
+            let mut rng = rand::thread_rng();
+            let x: u32 = rng.gen();
+            let y: u32 = rng.gen();
+            let exec_script = script! {
+                {u8_push_xor_table()}
+                {u32_push(x)}
+                {u32_push(y)}
+                {u32_or(0, 1, 3)}
+                {u32_push(or(x, y))}
+                {u32_equal()}
+                OP_TOALTSTACK
+                {u32_drop()} // drop y
+                {u8_drop_xor_table()}
+                OP_FROMALTSTACK
+            };
+            let res = execute_script(exec_script);
+            assert_eq!(res.success, true);
+        }
+    }
+}

--- a/src/u32/u32_rshit.rs
+++ b/src/u32/u32_rshit.rs
@@ -1,0 +1,164 @@
+#![allow(dead_code)]
+
+use bitcoin::opcodes::all::OP_DROP;
+
+use crate::{
+    treepp::{pushable, script, Script},
+    u32::u32_rrot::u8_extract_hbit,
+};
+use core::panic;
+
+pub fn post_process(offset: usize) -> Script {
+    assert!(offset < 4);
+    let res: Script = match offset {
+        0 => script! {
+            OP_FROMALTSTACK //[c+cD]
+            OP_FROMALTSTACK //[c+cD, b+bC]
+            OP_FROMALTSTACK //[c+cD, b+bC, a+cB]
+            OP_FROMALTSTACK //[c+cD, b+bC, a+cB, cA]
+            OP_SWAP         //[c+cD, b+bC, cA, a+cB]
+            OP_2SWAP        //[cA, a+cB, c+cD, b+bC]
+            OP_SWAP         //[cA, a+cB, b+bC, c+cD]
+        },
+        1 => script! {
+            OP_FROMALTSTACK // [c+cD]
+            OP_DROP         // []
+            0               // [0]
+            OP_FROMALTSTACK // [0,b+bC]
+            OP_FROMALTSTACK // [0,b+bC,a+cB]
+            OP_FROMALTSTACK // [0,b+bC,a+cB,cA]
+            1 OP_ROLL       // [0,b+bC,cA,a+cB]
+            2 OP_ROLL       // [0,cA,a+cB,b+bC]
+        },
+        2 => script! {
+            OP_FROMALTSTACK // [c+cD]
+            OP_DROP         // []
+            0               // [0]
+            OP_FROMALTSTACK // [0,b+bC]
+            OP_DROP         // [0]
+            0               // [0, 0]
+            OP_FROMALTSTACK // [0,0,a+cB]
+            OP_FROMALTSTACK // [0,0,a+cB,cA]
+            OP_SWAP         // [0,0,cA,a+cB]
+        },
+        3 => script! {
+            OP_FROMALTSTACK // [c+cD]
+            OP_DROP         // []
+            0               // [0]
+            OP_FROMALTSTACK // [0,b+bC]
+            OP_DROP         // [0]
+            0               // [0, 0]
+            OP_FROMALTSTACK // [0,0,a+cB]
+            OP_DROP         // [0,0]
+            0               // [0,0,0]
+            OP_FROMALTSTACK // [0,0,0,cA]
+        },
+        _ => panic!("offset out of range"),
+    };
+    res
+}
+pub fn specific_optimize_rshift(shift_num: usize) -> Option<Script> {
+    let res: Option<Script> = match shift_num {
+        0 => script! {}.into(),
+        8 => script! {  // [a, b, c, d]
+            OP_DROP        //[a, b, c]
+            0              //[a, b, c, 0]
+            3 OP_ROLL      //[b, c, 0, a]
+            3 OP_ROLL      //[c, 0, a, b]
+            3 OP_ROLL      //[0, c, a, b]
+
+        }
+        .into(),
+        16 => script! {
+            OP_DROP         //[a, b, c]
+            OP_DROP         //[a, b]
+            0               //[a, b, 0]
+            0               //[a, b, 0, 0]
+            OP_2SWAP        //[0, 0, a, b]
+        }
+        .into(),
+        24 => script! {
+            OP_DROP         //[a, b, c]
+            OP_DROP         //[a, b]
+            OP_DROP         //[a]
+            0               //[a, 0]
+            0               //[a, 0, 0]
+            0               //[a, 0, 0, 0]
+            3 OP_ROLL       //[0, 0, 0, a]
+        }
+        .into(),
+        _ => None,
+    };
+    res
+}
+pub fn u32_rshift(shift_num: usize) -> Script {
+    assert!(shift_num < 32);
+    match specific_optimize_rshift(shift_num) {
+        Some(res) => return res,
+        None => {}
+    }
+    let remainder: usize = shift_num % 8;
+
+    let hbit: usize = 8 - remainder;
+    let offset: usize = (shift_num - remainder) / 8;
+
+    script! {
+        {u8_extract_hbit(hbit)} //[A, B, C, d, carryD]
+        2 OP_ROLL {u8_extract_hbit(hbit)} //[A, B, d, carryD, c, carryC]
+        4 OP_ROLL {u8_extract_hbit(hbit)} //[A, d, carryD, c, carryC, b, carryB]
+        6 OP_ROLL {u8_extract_hbit(hbit)} //[d, carryD, c, carryC, b, carryB, a, carryA]
+
+        OP_TOALTSTACK // carryA
+
+        OP_ADD
+        OP_TOALTSTACK // a+carryB
+
+        OP_ADD
+        OP_TOALTSTACK // b+carryC
+
+        OP_ADD
+        OP_TOALTSTACK // c+carryD
+
+        OP_DROP
+
+        {post_process(offset)}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::treepp::{execute_script, script};
+    use crate::u32::u32_rshit::*;
+    use crate::u32::u32_std::*;
+    use rand::Rng;
+
+    fn rshift(x: u32, n: usize) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        x >> n
+    }
+
+    #[test]
+    fn test_rshift() {
+        for _ in 0..100 {
+            let mut rng = rand::thread_rng();
+            let x: u32 = rng.gen();
+            // println!("x {:?}", x);
+            for i in 0..32 {
+                // println!("i: {:?}", i);
+                let exec_script = script! {
+                    {u32_push(x)}
+                    {u32_rshift(i)}
+                    {u32_push(rshift(x, i))}
+                    {u32_equal()}
+                };
+                // println!("{:?}", exec_script);
+                let res = execute_script(exec_script);
+                assert_eq!(res.success, true);
+                // println!("{:?}", res.success);
+            }
+        }
+    }
+}

--- a/src/u32/u32_xor.rs
+++ b/src/u32/u32_xor.rs
@@ -336,3 +336,38 @@ pub fn u8_drop_xor_table() -> Script {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::treepp::pushable;
+    use crate::treepp::{execute_script, script};
+    use crate::u32::u32_std::*;
+    use crate::u32::u32_xor::{u32_xor, u8_drop_xor_table, u8_push_xor_table};
+    use rand::Rng;
+
+    fn xor(x: u32, y: u32) -> u32 { x ^ y }
+
+    #[test]
+    fn test_xor() {
+        for _ in 0..100 {
+            let mut rng = rand::thread_rng();
+            let x: u32 = rng.gen();
+            let y: u32 = rng.gen();
+            let exec_script = script! {
+                {u8_push_xor_table()}
+                {u32_push(x)}
+                {u32_push(y)}
+                {u32_xor(0, 1, 3)}
+                {u32_push(xor(x, y))}
+                {u32_equal()}
+                OP_TOALTSTACK
+                {u32_drop()} // drop y
+                {u8_drop_xor_table()}
+                OP_FROMALTSTACK
+            };
+            let res = execute_script(exec_script);
+            assert_eq!(res.success, true);
+        }
+    }
+}


### PR DESCRIPTION
i rewrite the following function, and i find that the `rrot` is unnecessary,  as well as the xor function. 
thx @wz14 contribution of general `rrot`, i take lots of code from him.
```Rust
pub fn u32_rshift(shift_num: usize) -> Script
```