### PR TITLE
optimize u32 and xor or not

### DIFF
--- a/src/hash/sha256.rs
+++ b/src/hash/sha256.rs
@@ -340,14 +340,12 @@ pub fn ep1(stack_depth: u32) -> Script {
     }
 }
 
-// A better u32_not is needed.
-pub fn u32_not(stack_depth: u32) -> Script {
+pub fn u32_not() -> Script {
     script! {
-        {u32_push(0xffffffff)}
-        {u32_xor(0, 1, stack_depth+1)}
-        {u32_toaltstack()}
-        {u32_drop()}
-        {u32_fromaltstack()}
+        for _ in 0..4 {
+            0xff
+            4 OP_ROLL OP_SUB
+        }
     }
 }
 
@@ -372,7 +370,7 @@ pub fn ch(x: u32, y: u32, z: u32, stack_depth: u32) -> Script {
         {u32_fromaltstack()}
 
         {u32_pick(x+1)}
-        {u32_not(stack_depth+2)}
+        {u32_not()}
         {u32_pick(z+2)}
         {u32_and(0, 1, stack_depth+3)}
         {u32_toaltstack()}
@@ -440,6 +438,7 @@ mod tests {
 
     #[test]
     fn test_sha256() {
+        println!("sha256(32): {} bytes", sha256(32).len());
         let hex_in = "6162636462636465636465666465666765666768666768696768696a68696a6b696a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071";
         let mut hasher = Sha256::new();
         let data = hex::decode(hex_in).unwrap();

--- a/src/u32/u32_and.rs
+++ b/src/u32/u32_and.rs
@@ -61,8 +61,7 @@ pub fn u8_and(i: u32) -> Script {
         OP_PICK
 
         // A_and_B = A_and_B_odd + (A_and_B_even << 1)
-        OP_SWAP
-        OP_DUP
+        OP_OVER
         OP_ADD
         OP_ADD
     }
@@ -110,6 +109,7 @@ mod tests {
 
     #[test]
     fn test_and() {
+        println!("u32 and: {} bytes", u32_and(0, 1, 3).len());
         for _ in 0..100 {
             let mut rng = rand::thread_rng();
             let x: u32 = rng.gen();

--- a/src/u32/u32_or.rs
+++ b/src/u32/u32_or.rs
@@ -47,54 +47,27 @@ pub fn u8_or(i: u32) -> Script {
         OP_ROLL
         OP_ADD
 
-        // A_or_B_even = f(A_andxor_B_even << 1) + f(A_andxor_B_even)
+        // A_and_B_even = f(A_andxor_B_even)
         OP_DUP
-        OP_DUP
-        OP_ADD
-        OP_DUP         // The left shift may overflow 1 bit
-        255
-        OP_GREATERTHAN
-        OP_IF
-            256
-            OP_SUB
-        OP_ENDIF
         {i + 1}
         OP_ADD
         OP_PICK
-        OP_SWAP
-        {i + 1}
-        OP_ADD
-        OP_PICK
-        OP_ADD
+        OP_SUB
 
         // A_andxor_B_odd = A_odd + B_odd
         OP_SWAP
         OP_ROT
         OP_ADD
 
-        // A_or_B_odd = f(A_andxor_B_odd << 1) + f(A_andxor_B_odd)
+        // A_and_B_odd = f(A_andxor_B_odd)
         OP_DUP
-        OP_DUP
-        OP_ADD
-        OP_DUP
-        255
-        OP_GREATERTHAN
-        OP_IF
-            256
-            OP_SUB
-        OP_ENDIF
         {i}
         OP_ADD
         OP_PICK
-        OP_SWAP
-        {i}
-        OP_ADD
-        OP_PICK
-        OP_ADD
+        OP_SUB
 
-        // A_or_B = A_or_B_odd + (A_or_B_even << 1)
-        OP_SWAP
-        OP_DUP
+        // A_and_B = A_and_B_odd + (A_and_B_even << 1)
+        OP_OVER
         OP_ADD
         OP_ADD
     }
@@ -143,6 +116,7 @@ mod tests {
 
     #[test]
     fn test_or() {
+        println!("u32 or: {} bytes", u32_or(0, 1, 3).len());
         for _ in 0..100 {
             let mut rng = rand::thread_rng();
             let x: u32 = rng.gen();

--- a/src/u32/u32_xor.rs
+++ b/src/u32/u32_xor.rs
@@ -73,8 +73,7 @@ pub fn u8_xor(i: u32) -> Script {
         OP_SUB
 
         // A_xor_B = A_xor_B_odd + (A_xor_B_even << 1)
-        OP_SWAP
-        OP_DUP
+        OP_OVER
         OP_ADD
         OP_ADD
     }
@@ -350,6 +349,7 @@ mod tests {
 
     #[test]
     fn test_xor() {
+        println!("u32 xor: {} bytes", u32_xor(0, 1, 3).len());
         for _ in 0..100 {
             let mut rng = rand::thread_rng();
             let x: u32 = rng.gen();


### PR DESCRIPTION
This PR optimizes u32 AND XOR OR NOT functions.

```
u32 and cost 170 instead of 174
u32 or cost 186 instead of 326
u32 xor cost 202 instead of 206
u32 not cost 24 instead of 230
```

It helps reduce the size of sha256 script.

