### PR TITLE
Optimized Sha256 version working with u4 

### DIFF
--- a/src/bridge/graph.rs
+++ b/src/bridge/graph.rs
@@ -28,13 +28,15 @@ const N_OF_N_SECRET: &str = "a9bd8b8ade888ed12301b21318a3a7342923234358704987013
 pub type CompiledBitVMGraph = HashMap<OutPoint, Vec<Transaction>>;
 
 pub fn funding_script() -> Script {
+    /*
     let secp = Secp256k1::new();
     //let operator_key = Keypair::from_seckey_str(&secp, OPERATOR_SECRET).unwrap();
     let n_of_n_key = Keypair::from_seckey_str(&secp, N_OF_N_SECRET).unwrap();
     script! {
         { n_of_n_key.x_only_public_key().0 }
         OP_CHECKSIG
-    }
+    }*/
+    script! {}
 }
 
 pub fn funding_taproot_spend_info() -> TaprootSpendInfo {

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,2 +1,3 @@
 pub mod blake3;
 pub mod sha256;
+pub mod sha256_u4;

--- a/src/hash/sha256_u4.rs
+++ b/src/hash/sha256_u4.rs
@@ -1,0 +1,652 @@
+use std::vec;
+use crate::treepp::{pushable, script, Script};
+use crate::u4::{u4_add::*, u4_logic::*, u4_rot::*, u4_std::*};
+
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const INITSTATE: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
+    //55 bytes fits in one block
+    //56 to 64 requires two block padding
+
+    let mut chunks = num_bytes / 64;
+    chunks += 1;
+
+    if num_bytes % 64 > 55 {
+
+        let mut bytes_left_first_padding = 64 - (num_bytes % 64);
+        bytes_left_first_padding -= 1; // remove the 0x80 that will be added always
+        let script1 = script! {
+            8
+            0
+            for _ in 0..bytes_left_first_padding { //can optimize with a couple of dups
+                0
+                0
+            }
+        };
+
+        let script2 = script! {
+            0
+            OP_DUP
+            for _ in 0..59 {
+                OP_2DUP
+            }
+            { u4_number_to_nibble( num_bytes * 8 ) }
+        };
+
+        
+        chunks += 1;
+
+        let mut results = Vec::new();
+        for _ in 0..(chunks - 2) {
+            results.push(script!{});
+        }
+        results.push(script1);
+        results.push(script2);
+
+        (results, chunks)
+
+
+    } else {
+        let (script1,_) = padding(num_bytes);
+        let mut results = Vec::new();
+        for _ in 0..(chunks - 1) {
+            results.push(script!{});
+        }
+        results.push(script1);
+        (results, chunks)
+    }
+
+}
+
+
+
+
+pub fn padding(num_bytes: u32) -> (Script, u32) {
+
+    let l = (num_bytes * 8) as i32;
+    let mut k = 512 - l - 8 - 32;     // heres is usually minus 8, but as 
+                                            // there will be never that many bytes to process
+                                            // one u32 will be enough
+    let mut chunks = 1;
+    while k < 0 {
+        k += 512;
+        chunks += 1;
+    }
+    let zeros = k/16;
+    let extras = k % 16;
+
+    ( script! {
+        8
+        0
+        for i in 0..zeros {
+            if i == 0 {
+                0
+                OP_DUP
+                OP_2DUP
+            } else {
+                OP_2DUP
+                OP_2DUP
+            }
+        }
+        if extras > 0 {
+            0
+            0
+        }
+        { u4_number_to_nibble( l as u32 ) }
+      },
+      chunks
+    )
+
+}
+
+pub fn calculate_s_part_1( offset_number: u32, offset_rrot: u32, shift_value: Vec<u32>, last_is_shift: bool ) -> Script {
+    script!{
+        { u4_rrot(shift_value[0], offset_number, offset_rrot, false) }
+        { u4_rrot(shift_value[1], offset_number, offset_rrot, false) }
+        { u4_rrot(shift_value[2], offset_number, offset_rrot, last_is_shift) }
+    }
+}
+
+
+pub fn calculate_s_part_2( offset_and: u32 ) -> Script {
+    script! {
+        for _ in 0..24 {
+            OP_FROMALTSTACK
+        }
+
+        { u4_xor_u32(vec![0,8,16], offset_and + 24) }
+
+    }
+}
+
+pub fn calculate_s( offset_number: u32, offset_rrot: u32, offset_and: u32, shift_value: Vec<u32>, last_is_shift: bool ) -> Script {
+    script! {
+        { calculate_s_part_1(offset_number, offset_rrot, shift_value, last_is_shift) }
+        { calculate_s_part_2(offset_and) }
+    }
+}
+
+fn get_w_pos(i: u32) -> u32 {
+    let pos = (i + 1) * 8;
+    pos
+}
+
+fn get_extra_pos(i: u32) -> u32 {
+    (i-16) * 8
+}
+
+fn get_pos_var(name: char) -> u32 {
+    let i = match name {
+        'a' => 0,
+        'b' => 1,
+        'c' => 2,
+        'd' => 3,
+        'e' => 4,
+        'f' => 5,
+        'g' => 6,
+        'h' => 7,
+        _ => 0
+    };
+
+    let top = 8*8;
+    let base = top - 8;
+    base - i * 8
+}
+pub fn debug() -> Script {
+
+    script! {
+        OP_DEPTH
+        OP_TOALTSTACK
+        60000
+        OP_PICK
+    }
+
+}
+
+pub fn ch_calculation(e: u32, f:u32, g:u32, offset_and: u32) -> Script {
+
+    script! {
+        for nib in 0..8 {
+
+            { e + 7  }                         // e_nib_pos
+            OP_PICK                                 // e[nib]
+            OP_DUP                                  // e e
+
+            OP_NEGATE
+            OP_15
+            OP_ADD                                  // e ~e
+
+            { g + 7  + 2}                      // e  ~e  g_nib_pos (account for e and ~e)
+            OP_PICK                                 // e  ~e  g
+
+            { u4_and_half_table(nib + offset_and + 3) }   // e  ( ~e & g )
+            OP_SWAP                                 // ( ~e & g ) e
+
+
+            { f + 7  + 2}                      // ( ~e & g ) e f_nib_pos
+            OP_PICK                                 // ( ~e & g ) e f
+
+            { u4_and_half_table(nib + offset_and + 3) }   // ( ~e & g ) (e & f) 
+            { u4_xor_half_table(nib + offset_and + 2) }   // ( ~e & g ) ^ (e & f) 
+
+            //OP_TOALTSTACK
+        }
+    }
+
+}
+
+pub fn maj_calculation(a: u32, b:u32, c:u32, offset_and: u32) -> Script {
+
+    script! {
+        for nib in 0..8 {
+
+            { a + 7  }                                    // a_nib_pos
+            OP_PICK                                       // a[nib]
+
+            { b + 7 + 1 }                                 // a b_nib_pos
+            OP_PICK                                       // a b
+            OP_2DUP                                       // a b a b
+
+            { u4_xor_half_table(nib + offset_and + 4) }   // a b (a^b)
+
+            { c + 7 + 3 }                                 // a b (a^b) c_nib_pos
+            OP_PICK                                       // a b (a^b) c
+
+            { u4_and_half_table(nib + offset_and + 4) }   // a b ((a^b) & c)
+            OP_ROT
+            OP_ROT                                        // ((a^b) & c) a b
+
+            { u4_and_half_table(nib + offset_and + 3) }   // ((a^b) & c) (a & b)
+
+            { u4_xor_half_table(nib + offset_and + 2) }   // ((a^b) & c) ^ (a & b)
+
+        }
+    }
+
+}
+
+
+pub fn schedule_iteration(i:u32, offset_top_sched: u32, offset_rot:u32, offset_and: u32, offset_add: u32, use_add_table: bool) -> Script {
+    script! {
+        { calculate_s( offset_top_sched - get_w_pos(i-15), offset_rot, offset_and, vec![7,18,3], true)}
+        { calculate_s( offset_top_sched - get_w_pos(i-2), offset_rot, offset_and, vec![17,19,10], true)}
+        { u4_fromaltstack(16) }
+        { u4_copy_u32_from(offset_top_sched - get_w_pos(i-16)+16 )}   // this can be avoided arranging directly with roll
+        { u4_copy_u32_from(offset_top_sched - get_w_pos(i-7)+24 )}
+        { u4_add(8, vec![0, 8, 16, 24], offset_add + 32, use_add_table )}  
+        { u4_fromaltstack(8) }
+    }
+}
+
+fn get_full_w_pos(top_table: u32, i:u32) -> u32 {
+    top_table - (i+1) * 8
+}
+
+pub fn sha256(num_bytes: u32) -> Script {
+
+    // up to 55 is one block and always supports add table
+    // probably up to 68 bytes I can afford to load the add tables for the first chunk (but have I would have to unload it)
+
+    let (mut padding_scripts, chunks) = double_padding(num_bytes);
+    let mut bytes_per_chunk : Vec<u32> = Vec::new();
+    let mut bytes_remaining = num_bytes;
+    while bytes_remaining > 0 {
+        if bytes_remaining > 64 {
+            bytes_per_chunk.push( 64);
+            bytes_remaining -= 64;
+        } else {
+            bytes_per_chunk.push( bytes_remaining);
+            bytes_remaining = 0;
+        }
+    } 
+    if bytes_per_chunk.len() < chunks as usize {
+        bytes_per_chunk.push(0);
+    }
+    println!("{:?}", bytes_per_chunk);
+    println!("{:?}", padding_scripts);
+
+    let add_size = 130;
+    let sched_size = 128;
+    let rrot_size = 96;
+    let half_logic_size = 136+16;
+    let mut tables_size = rrot_size + half_logic_size;
+    let use_add_table = chunks == 1;
+    if use_add_table {
+        tables_size += add_size;
+    } 
+
+
+    let sched_loop_offset_and = sched_size;
+    let sched_loop_offset_rrot = sched_loop_offset_and + half_logic_size;
+    let sched_loop_offset_add = sched_loop_offset_rrot + rrot_size;
+
+
+    let full_sched_size = 512;
+    let temp_vars_size  = 8*8;
+
+    let vars_top = temp_vars_size + full_sched_size;
+    let main_loop_offset_and = vars_top;
+    let main_loop_offset_rrot = main_loop_offset_and + half_logic_size;
+    let main_loop_offset_add = main_loop_offset_rrot + rrot_size;
+
+
+    script! {
+
+        if use_add_table {
+            { u4_push_add_tables() }
+        }
+        { u4_push_rrot_tables() }     // rshiftn 16*6= 96 
+        { u4_push_half_and_table() }  // 136 
+        { u4_push_half_lookup() }     // 16
+                                      // total :  136 + 16 + 96 = 248
+
+        for c in 0..chunks {
+
+            for _ in 0..bytes_per_chunk[c as usize]*2 {
+                { (tables_size + (num_bytes * 2) - 1 - (c*128))  }
+                OP_ROLL
+            }
+
+
+            { padding_scripts.remove(0) }                  
+            
+            //schedule loop 
+            for i in 16..64 {
+                { schedule_iteration(i, sched_size + get_extra_pos(i), sched_loop_offset_rrot + get_extra_pos(i), sched_loop_offset_and + get_extra_pos(i), sched_loop_offset_add + get_extra_pos(i), use_add_table) }
+            }
+
+
+            if c == 0 {
+                //set initial variables a,b,c,d,e,f,g,h
+                for value in INITSTATE.iter() {
+                    { u4_number_to_nibble(*value) }
+                }
+            } else {
+                { u4_fromaltstack( 64 )}
+            }
+
+
+            
+                    
+            for i in 0..64 {
+
+                //Calculate S1
+                { calculate_s( get_pos_var('e'), main_loop_offset_rrot, main_loop_offset_and, vec![6, 11, 25], false  ) }
+                { u4_fromaltstack(8)}
+
+
+                //calculate ch (this leaves on the stack)
+                { ch_calculation(8 + get_pos_var('e'), 8 + get_pos_var('f'), 8 + get_pos_var('g'), 8 + main_loop_offset_and ) }
+
+                //calculate temp1
+                { u4_copy_u32_from( 16 + get_full_w_pos(vars_top, i) ) }
+                { u4_number_to_nibble(K[i as usize])}                    //this add can be optimized by adding nibble constants
+                if use_add_table {
+                    { u4_add(8, vec![0, 8], 32 + main_loop_offset_add, true) }        //this could be joined with the next one and a bigger table
+                    { u4_fromaltstack(8)}
+                    { u4_add(8, vec![0, 8, 16, 24 + get_pos_var('h') ], 24 + main_loop_offset_add, true) }  //consumes h
+                } else {
+                    { u4_add_no_table(8, vec![0, 8, 16, 24, 32 + get_pos_var('h') ]) }  //consumes h
+                }
+                //consumes previous numbers and leaves result on altstack
+
+                //puts temp1 on stack
+                { u4_fromaltstack(8)}
+
+                //Calculate S0   (on altstack)
+                { calculate_s( get_pos_var('a'),  main_loop_offset_rrot,  main_loop_offset_and, vec![2, 13, 22], false  ) }
+
+                //Calculate maj  (on stack)
+                { maj_calculation( get_pos_var('a'),  get_pos_var('b'),  get_pos_var('c'),  main_loop_offset_and ) }
+
+                //copies temp1
+                { u4_copy_u32_from(8) }
+
+                //put S0 on stack
+                { u4_fromaltstack(8)}
+
+                //temp2 = maj + s0
+                //calculate a = temp1 + temp2 
+                //consumes the three values and leaves a on the stack updated
+                { u4_add(8, vec![0, 8, 16], main_loop_offset_add + 24, use_add_table) } 
+                { u4_fromaltstack(8)}
+
+                
+                //all this moves can be avoided doing index magic with get_pos_var('X', round)
+                //b = a
+                { u4_move_u32_from( temp_vars_size  ) }
+                //c = b
+                { u4_move_u32_from( temp_vars_size  ) }
+                //d = c
+                { u4_move_u32_from( temp_vars_size  ) }
+                
+                //e = d + temp1
+                { u4_add(8, vec![32, temp_vars_size], main_loop_offset_add + 8, use_add_table ) } 
+                { u4_fromaltstack(8)}
+
+                //f = e
+                { u4_move_u32_from( temp_vars_size - 8 ) }
+                //g = f
+                { u4_move_u32_from( temp_vars_size - 8 ) }
+                //h = g
+                { u4_move_u32_from( temp_vars_size - 8) }
+
+            }
+
+
+            if c == 0 {
+                // add constants to variables
+                // and leave the result on the altstack
+                // first chunk is added with the init state
+                for i in (0..8).rev() {
+                    { u4_number_to_nibble( INITSTATE[i] ) }
+                    { u4_add(8, vec![0, 8], main_loop_offset_add + 8 - ((7-i) as u32 * 8), use_add_table ) } 
+                }
+            } else {
+                // following chunks are added with the previous result
+                { u4_fromaltstack( 64 )}
+                for i in 0..8 {
+                    { u4_add_no_table(8, vec![0, 64 - i * 8]) } 
+                }
+            }
+
+            { u4_drop(64*8) }       // drop the whole schedule
+            
+            //if it's not the last chunk
+            //save a copy of the result
+            if chunks > 1 && c < chunks - 1 {
+                { u4_fromaltstack( 64 )}
+                for _ in 0..64 {
+                    { 63 }
+                    OP_PICK
+                }
+                { u4_toaltstack( 128 )}
+            }
+
+
+        }
+
+        { u4_drop_half_lookup() }
+        { u4_drop_half_and() }
+        { u4_drop_rrot_tables() } 
+        if use_add_table {
+            { u4_drop_add_tables() }
+        }
+
+        { u4_fromaltstack( 64 )}
+
+    }
+
+
+}
+
+#[cfg(test)]
+mod tests {
+
+
+use crate::treepp::{execute_script, script};
+use crate::hash::sha256_u4::*;
+use sha2::{Digest, Sha256};
+
+
+    #[test]
+    fn test_sizes() {
+        let x = sha256(80);
+        println!("sha 80 bytes: {}",x.len());
+        let x = sha256(32);
+        println!("sha 32 bytes: {}",x.len());
+        let x = calculate_s(20, 30, 40, vec![7,18,3], true);
+        println!("compute s   : {}",x.len());
+        let x = schedule_iteration(16, 128, 128, 300, 400, false);
+        println!("schedule it : {}",x.len());
+        let x = ch_calculation(10, 20, 30,300);
+        println!("compute ch  : {}",x.len());
+        let x = maj_calculation(10, 20, 30,300);
+        println!("compute maj : {}",x.len());
+    }
+
+        
+    #[test]
+    fn test_shatemp() {
+        
+        let script = script! {
+            { u4_number_to_nibble(0xdeadbeaf) } 
+            { u4_number_to_nibble(0x01020304) } 
+            { sha256(8) }
+            { u4_drop(64)}
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+        
+    }
+
+    fn test_sha256( hex_in : &str ) {
+
+        let mut hasher = Sha256::new();
+        let data = hex::decode(hex_in).unwrap();
+        hasher.update(&data);
+        let result = hasher.finalize();
+        let res = hex::encode(result);
+        println!("Result: {}", res);
+        
+        let script = script! {
+            { u4_hex_to_nibbles(hex_in) }
+            { sha256(hex_in.len() as u32 /2)}
+
+            
+            { u4_hex_to_nibbles(res.as_str())}
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+
+            for i in 1..64 {
+                {i}
+                OP_ROLL
+            }
+
+            for _ in 0..64 {
+                OP_FROMALTSTACK
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+
+        };
+
+
+        let res = execute_script(script);
+        assert!(res.success);
+
+    }
+
+    #[test]
+    fn test_sha256_strs() {
+        let message = "Hello.";
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
+        test_sha256(&hex);
+        let message = "This is a longer message that still fits in one block!";
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
+        test_sha256(&hex)
+    }
+
+    #[test]
+    fn test_sha256_two_blocks() {
+        let hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaa";
+        test_sha256(&hex);
+        let hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001122334455667788";
+        test_sha256(&hex);
+        let hex = "7788ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaaaaaaaaaa001122334455667788";
+        test_sha256(&hex);
+    }
+
+    #[test]
+    fn test_padding() {
+
+        let (script, _) = padding(1);
+        let script = script! {
+            { 0}
+            { 1 }
+            { script }
+            { u4_drop(128) }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+
+ 
+    }
+    
+    #[test]
+    fn test_split_padding() {
+
+        for num_bytes in 0..150 {
+
+            let (padding_scripts, chunks) = double_padding(num_bytes);
+
+            let script = script! {
+                for _ in 0..num_bytes {
+                    { 1 }
+                    { 0 }
+                }
+                OP_DEPTH
+                OP_TOALTSTACK
+                for script in padding_scripts {
+                    { script }
+                    OP_DEPTH
+                    OP_TOALTSTACK
+                }
+                { u4_drop(chunks*128) }
+                OP_DEPTH
+                OP_TOALTSTACK
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+
+        }
+ 
+    }
+
+    #[test]
+    fn test_genesis_block() {
+        // the genesis block header of bitcoin
+        // version previous-block merkle-root time bits nonce
+        // 01000000 0000000000000000000000000000000000000000000000000000000000000000 3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a 29ab5f49 ffff001d 1dac2b7c
+        let block_header = "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c";
+        let mut hasher = Sha256::new();
+        let data = hex::decode(block_header).unwrap();
+        hasher.update(&data);
+        let mut result = hasher.finalize();
+        hasher = Sha256::new();
+        hasher.update(result);
+        result = hasher.finalize();
+        let res = hex::encode(result);
+        let genesis_block_hash = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
+        assert_eq!(res.as_str(), genesis_block_hash);
+        let script = script! {
+
+            { u4_hex_to_nibbles(block_header) }
+            { sha256(block_header.len() as u32 /2)}
+            { sha256(32) }
+
+            
+            { u4_hex_to_nibbles(res.as_str())}
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+
+            for i in 1..64 {
+                {i}
+                OP_ROLL
+            }
+
+            for _ in 0..64 {
+                OP_FROMALTSTACK
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+
+
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod fflonk;
 pub mod hash;
 pub mod pseudo;
 pub mod u32;
+pub mod u4;
 
 /// A wrapper for the stack types to print them better.
 pub struct FmtStack(Stack);

--- a/src/u4/mod.rs
+++ b/src/u4/mod.rs
@@ -1,0 +1,5 @@
+pub mod u4_std;
+pub mod u4_shift;
+pub mod u4_logic;
+pub mod u4_rot;
+pub mod u4_add;

--- a/src/u4/u4_add.rs
+++ b/src/u4/u4_add.rs
@@ -1,0 +1,555 @@
+use bitcoin::opcodes::all::*;
+use crate::treepp::{pushable, script, Script};
+
+use super::u4_std::{u4_drop, CalculateOffset};
+
+// Add it's performed be adding by nibble by nibble then duplicating the result
+// and then using two lookup tables to obtain the modulo and the quotient.
+
+// The modulo represent the result for the particular nibble
+// and the quotient will be used as carry for the next nibble
+
+// The lookup tables currently have 65 entries  
+// because habe been created to support until 4 additions
+// simultaneously to improve the performance as
+// carry only needs to be calculated once
+//
+// 5 additions would be great and would allow to avoid one currently splitted operation on sha 
+// but it's not fitting on the 1000k stack limit (alongside the rest of the operations)
+
+
+pub fn u4_push_quotient_table() -> Script {
+    script! {
+        OP_4
+        OP_3
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_2
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_1
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+    }
+}
+
+pub fn u4_drop_quotient_table() -> Script {
+    u4_drop(65)
+}
+
+
+pub fn u4_push_modulo_table() -> Script {
+    script! {
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+    }
+}
+
+pub fn u4_drop_modulo_table() -> Script {
+    u4_drop(65)
+}
+
+//130 bytes
+pub fn u4_push_add_tables() -> Script {
+    script! {
+        { u4_push_modulo_table() }
+        { u4_push_quotient_table() }
+    }
+}
+
+pub fn u4_drop_add_tables() -> Script {
+    script! {
+        { u4_drop_quotient_table() }
+        { u4_drop_modulo_table() }
+    }
+}
+
+pub fn u4_arrange_nibbles( nibble_count: u32, mut bases: Vec<u32> ) -> Script {
+    bases.sort();
+    bases.reverse();
+    for i in 0..bases.len() {
+        bases[i] += nibble_count - 1;
+    }
+
+    script! {
+        for i in 0..nibble_count {
+            for (n, base) in bases.iter().enumerate() {
+                {  (base - i)  +  ((n as u32 + 1) * (i + 1)) - 1 }
+                OP_ROLL
+            }
+        }
+    }
+}
+
+pub fn u4_add_carry_nested( current: u32, limit: u32 ) -> Script {
+
+    script! {
+        OP_DUP
+        OP_16
+        OP_GREATERTHANOREQUAL
+        OP_IF
+            OP_16
+            OP_SUB
+            if current + 1 == limit {
+                { current }
+            } else {
+                { u4_add_carry_nested(current+1, limit)}
+            }
+        OP_ELSE
+            { current }
+        OP_ENDIF
+    }
+
+}
+
+pub fn u4_add_nested( current: u32, limit: u32 ) -> Script {
+
+    script! {
+        OP_DUP
+        OP_16
+        OP_GREATERTHANOREQUAL
+        OP_IF
+            OP_16
+            OP_SUB
+            if current + 1 < limit {
+                { u4_add_nested(current+1, limit)}
+            } 
+        OP_ENDIF
+    }
+
+}
+
+
+pub fn u4_add_no_table_internal( nibble_count: u32, number_count: u32 ) -> Script {
+    script! {
+
+        for i in 0..nibble_count {
+
+            //add the column of nibbles (needs one less add than nibble count)
+            for _ in 0..number_count-1 {
+                OP_ADD
+            }
+
+            if i < nibble_count - 1 {
+                { u4_add_carry_nested(0, number_count ) }
+                OP_SWAP
+                OP_TOALTSTACK
+                OP_ADD
+            } else {
+                { u4_add_nested(0, number_count ) }
+                OP_TOALTSTACK
+            }
+
+        }
+
+    }
+}
+
+//assumes to habe the numbers prepared alongside nibble by nibble
+//tables offset
+pub fn u4_add_internal( nibble_count: u32, number_count: u32, tables_offset: u32 ) -> Script {
+
+    let quotient_table_size = 65;
+    //extra size on the stack
+    let mut offset_calc: i32 = 0; 
+    let script = script! {
+
+        for i in 0..nibble_count {
+
+            //extra add to add the carry from previous addition
+            if i > 0 {
+                { offset_calc.modify(OP_ADD) }
+            }
+
+            //add the column of nibbles (needs one less add than nibble count)
+            for _ in 0..number_count-1 {
+                { offset_calc.modify(OP_ADD) }
+            }
+            
+            // duplicate the result to be used to get the carry except for the last nibble
+            if i < nibble_count -1 {
+                { offset_calc.modify( OP_DUP) }
+            }
+
+            //get the modulo of the addition
+            {  (offset_calc - 1)  + tables_offset as i32 + quotient_table_size as i32 }   // this adds 1 to the calc
+            OP_ADD                                                    // and this one consumes it
+            { offset_calc.modify( OP_PICK) }
+            { offset_calc.modify( OP_TOALTSTACK) }
+            
+            //we don't care about the last carry
+            if i < nibble_count - 1 {
+                //obtain the quotinent to be used as carry for the next addition
+                {  (offset_calc - 1) + tables_offset as i32 }
+                OP_ADD          
+                { offset_calc.modify( OP_PICK) }
+            }
+        }
+
+
+    };
+
+    script
+
+
+}
+
+pub fn u4_add_with_table( nibble_count: u32, bases: Vec<u32>, tables_offset: u32 ) -> Script {
+    let numbers = bases.len() as u32;
+    script! {
+        { u4_arrange_nibbles(nibble_count, bases)  }
+        { u4_add_internal(nibble_count, numbers, tables_offset) }
+    }
+}
+
+pub fn u4_add_no_table( nibble_count: u32, bases: Vec<u32> ) -> Script {
+    let numbers = bases.len() as u32;
+    script! {
+        { u4_arrange_nibbles(nibble_count, bases)  }
+        { u4_add_no_table_internal(nibble_count, numbers) }
+    }
+}
+
+pub fn u4_add( nibble_count: u32, bases: Vec<u32>, tables_offset: u32, use_add_table: bool ) -> Script {
+    if use_add_table {
+        u4_add_with_table(nibble_count, bases, tables_offset)
+    } else {
+        u4_add_no_table(nibble_count, bases)
+    }
+}
+
+
+
+
+#[cfg(test)]
+mod tests {
+
+use crate::treepp::{execute_script, script};
+use crate::u4::{u4_add::*, u4_std::u4_number_to_nibble};
+
+    #[test]
+    fn test_calc() {
+
+        let x = u4_arrange_nibbles(8, vec![0,1,2,4]) ;
+        println!("{}", x.len());
+        let x = u4_add_with_table(8, vec![0,8,16,24,32], 100) ;
+        println!("{}", x.len());
+        let x = u4_add_with_table(8, vec![0,8,16,24], 100) ;
+        println!("{}", x.len());
+        let x = u4_add_no_table(8, vec![0,8,16,24,32]) ;
+        println!("{}", x.len());
+        let x = u4_add_no_table(8, vec![0,8,16,24]) ;
+        println!("{}", x.len());
+        let x = u4_add_no_table(8, vec![0,8,16]) ;
+        println!("{}", x.len());
+        let x = u4_add_no_table(8, vec![0,8]) ;
+        println!("{}", x.len());
+    }
+
+    #[test]
+    fn test_add_no_table() {
+
+        let calc  = script! {
+            { u4_add_no_table( 8, vec![0,8,16,24]) }
+        };
+
+
+        let script  = script! {
+            { u4_number_to_nibble(100) }
+            { u4_number_to_nibble(200) }
+            { u4_number_to_nibble(1000) }
+            { u4_number_to_nibble(2000) }
+            { u4_add_no_table( 8, vec![0,8,16,24]) }
+            { u4_number_to_nibble(3300) }
+
+            for _ in 0..8 {
+                OP_FROMALTSTACK
+            }
+            for i in 0..8 {
+                { 8 - i}
+                OP_ROLL
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+                
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+        println!("{}", calc.len());
+    }
+
+
+
+
+    #[test]
+    fn test_add_2_32() {
+        let script  = script! {
+            { u4_push_add_tables() }
+            { u4_number_to_nibble(253) }
+            { u4_number_to_nibble(252) }
+            { u4_add_with_table( 8, vec![0,8], 16) }
+            { u4_drop_add_tables() }
+            { u4_number_to_nibble(505) }
+
+            for _ in 0..8 {
+                OP_FROMALTSTACK
+            }
+            for i in 0..8 {
+                { 8 - i}
+                OP_ROLL
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+                
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_add_4_32() {
+        let script  = script! {
+            { u4_push_add_tables() }
+            { u4_number_to_nibble(100) }
+            { u4_number_to_nibble(200) }
+            { u4_number_to_nibble(1000) }
+            { u4_number_to_nibble(2000) }
+            { u4_add_with_table( 8, vec![0,8,16,24], 32) }
+            { u4_drop_add_tables() }
+            { u4_number_to_nibble(3300) }
+
+            for _ in 0..8 {
+                OP_FROMALTSTACK
+            }
+            for i in 0..8 {
+                { 8 - i}
+                OP_ROLL
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+                
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_add_2() {
+        let script  = script! {
+            { u4_push_add_tables() }
+            15
+            15
+            13
+            12
+            { u4_add_internal(2, 2, 4) }
+            { u4_drop_add_tables() }
+            OP_FROMALTSTACK
+            15
+            OP_EQUALVERIFY
+            OP_FROMALTSTACK
+            9
+            OP_EQUALVERIFY
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_add_step_by_step() {
+
+        let script  = script! {
+            { u4_push_modulo_table() }
+            { u4_push_quotient_table() }
+            // fd + fc = 1f9 % 100 = f9
+            15          // F
+            15          // F F
+            13          // F F D
+            12          // F F D C
+
+            OP_ADD      // F F 19
+            OP_DUP      // F F 19 19
+            { 65 + 3 }  // F F 19 19 68=offset modulo
+            OP_ADD
+            OP_PICK         // F F 19 9 
+            OP_TOALTSTACK   // F F 19     | 9
+            { 2 }           // F F 19 2   | 9
+            OP_ADD          // F F 21     | 9
+            OP_PICK         // F F 1 
+
+            OP_ADD          // F 10
+            OP_ADD          // 1F
+            { 65 }          // 1F 65      | 9
+            OP_ADD          // 1F+65      | 9
+            OP_PICK         // F          | 9
+
+            OP_FROMALTSTACK
+            9
+            OP_EQUALVERIFY
+            15
+            OP_EQUALVERIFY
+            { u4_drop_modulo_table() }
+            { u4_drop_quotient_table() }
+
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+
+    
+    }
+    #[test]
+    fn test_quotient() {
+
+        for i in 0..65 {
+
+            let script  = script! {
+                { u4_push_quotient_table() }
+                { i as u32 }
+                OP_PICK
+                { i / 16 } 
+                OP_EQUALVERIFY
+                { u4_drop_quotient_table() }
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+        }
+
+    
+    }
+
+    #[test]
+    fn test_modulo() {
+
+        for i in 0..65 {
+
+            let script  = script! {
+                { u4_push_modulo_table() }
+                { i as u32 }
+                OP_PICK
+                { i % 16 } 
+                OP_EQUALVERIFY
+                { u4_drop_modulo_table() }
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+        }
+
+    }
+
+
+    #[test]
+    fn test_arrange() {
+
+
+        let script  = script! {
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+            10
+            11
+            12
+            { u4_arrange_nibbles(4, vec![0,4,8]) }
+
+        };
+
+        let _res = execute_script(script);
+
+    }
+
+
+}

--- a/src/u4/u4_logic.rs
+++ b/src/u4/u4_logic.rs
@@ -1,0 +1,1265 @@
+use crate::treepp::{pushable, script, Script};
+
+use crate::u4::u4_add::u4_arrange_nibbles;
+
+use super::u4_std::u4_drop;
+
+
+// And / Or / Xor tables are created here and can be used for bitwise operations
+// Sadly for sha256 those does not fit well in memory at the same time and therefor
+// and optimized version that is called half table is used for the operations
+
+// As this operations are commutative there is no need to have the tables for both
+// i.e: 15 & 7  AND  7 & 15  as the result would be the same, so half of the values 
+// are stored on the tables, and to be used the values are ordered using min/max
+// before using the lookup table
+
+
+
+pub fn u4_push_or_table() -> Script {
+    script! {
+        OP_15
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_15
+        OP_14
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_15
+        OP_DUP
+        OP_2DUP
+        OP_11
+        OP_DUP
+        OP_2DUP
+        OP_15
+        OP_DUP
+        OP_2DUP
+        OP_11
+        OP_DUP
+        OP_2DUP
+        OP_15
+        OP_14
+        OP_2DUP
+        OP_11
+        OP_10
+        OP_2DUP
+        OP_15
+        OP_14
+        OP_2DUP
+        OP_11
+        OP_10
+        OP_2DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_11
+        OP_DUP
+        OP_9
+        OP_DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_11
+        OP_DUP
+        OP_9
+        OP_DUP
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_15
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_7
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_15
+        OP_14
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_7
+        OP_6
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_7
+        OP_DUP
+        OP_5
+        OP_DUP
+        OP_7
+        OP_DUP
+        OP_5
+        OP_DUP
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_2OVER
+        OP_2OVER
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_2OVER
+        OP_2OVER
+        OP_15
+        OP_DUP
+        OP_2DUP
+        OP_11
+        OP_DUP
+        OP_2DUP
+        OP_7
+        OP_DUP
+        OP_2DUP
+        OP_3
+        OP_DUP
+        OP_2DUP
+        OP_15
+        OP_14
+        OP_2DUP
+        OP_11
+        OP_10
+        OP_2DUP
+        OP_7
+        OP_6
+        OP_2DUP
+        OP_3
+        OP_2
+        OP_2DUP
+        OP_15
+        OP_DUP
+        OP_13
+        OP_DUP
+        OP_11
+        OP_DUP
+        OP_9
+        OP_DUP
+        OP_7
+        OP_DUP
+        OP_5
+        OP_DUP
+        OP_3
+        OP_DUP
+        OP_1
+        OP_DUP
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+    }
+}
+
+pub fn u4_push_xor_table() -> Script {
+    script! {
+        OP_0
+        OP_1
+        OP_2
+        OP_3
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_1
+        OP_0
+        OP_3
+        OP_2
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_2
+        OP_3
+        OP_0
+        OP_1
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_0
+        OP_1
+        OP_2
+        OP_3
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_1
+        OP_0
+        OP_3
+        OP_2
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_2
+        OP_3
+        OP_0
+        OP_1
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_0
+        OP_1
+        OP_2
+        OP_3
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_1
+        OP_0
+        OP_3
+        OP_2
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_2
+        OP_3
+        OP_0
+        OP_1
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_0
+        OP_1
+        OP_2
+        OP_3
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_1
+        OP_0
+        OP_3
+        OP_2
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_2
+        OP_3
+        OP_0
+        OP_1
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+
+    }
+}
+
+pub fn u4_push_and_table() -> Script {
+    script! {
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_14
+        OP_DUP
+        OP_12
+        OP_DUP
+        OP_10
+        OP_DUP
+        OP_8
+        OP_DUP
+        OP_6
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_13
+        OP_12
+        OP_2DUP
+        OP_9
+        OP_8
+        OP_2DUP
+        OP_5
+        OP_4
+        OP_2DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_12
+        OP_DUP
+        OP_2DUP
+        OP_8
+        OP_DUP
+        OP_2DUP
+        OP_4
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_2OVER
+        OP_2OVER
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_2OVER
+        OP_2OVER
+        OP_10
+        OP_DUP
+        OP_8
+        OP_DUP
+        OP_10
+        OP_DUP
+        OP_8
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_9
+        OP_8
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_8
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_6
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_6
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_5
+        OP_4
+        OP_2DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_5
+        OP_4
+        OP_2DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_4
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_4
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+    }
+}
+
+pub fn u4_drop_logic_table() -> Script {
+    u4_drop(16 * 16)
+}
+
+pub fn u4_push_lookup() -> Script {
+    script! {
+        256
+        240
+        224
+        208
+        192
+        176
+        160
+        144
+        128
+        112
+        96
+        80
+        64
+        48
+        32
+        16
+        OP_0   //zero is extra so it can be used as lshift4 changing the offset
+    }
+}
+
+pub fn u4_push_half_and_table() -> Script {
+    script! {
+        OP_15
+        OP_14
+        OP_DUP
+        OP_13
+        OP_12
+        OP_2DUP
+        OP_DUP
+        OP_2DUP
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_DUP
+        OP_8
+        OP_DUP
+        OP_10
+        OP_DUP
+        OP_9
+        OP_8
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_7
+        OP_6
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_6
+        OP_DUP
+        OP_5
+        OP_4
+        OP_2DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_5
+        OP_4
+        OP_2DUP
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_4
+        OP_DUP
+        OP_2DUP
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_3
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_0
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_1
+        OP_0
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_DUP
+        OP_2DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+        OP_3DUP
+    }
+}
+
+pub fn u4_drop_half_and() -> Script {
+    u4_drop(136)
+}
+
+pub fn u4_push_half_lookup() -> Script {
+    script! {
+        136
+        135
+        133
+        130
+        126
+        121
+        115
+        108
+        100
+        91
+        81
+        70
+        58
+        45
+        31
+        16
+    }
+}
+
+pub fn u4_drop_half_lookup() -> Script {
+    u4_drop(16)
+}
+
+pub fn u4_drop_lookup() -> Script {
+    u4_drop(17)
+}
+
+pub fn u4_sort() -> Script {
+    script! {
+        OP_2DUP
+        OP_MIN
+        OP_TOALTSTACK
+        OP_MAX
+        OP_FROMALTSTACK
+    }
+}
+
+pub fn u4_and_half_table(lookup: u32) -> Script {
+    script! {
+        { u4_sort() }
+        { lookup - 1 }
+        OP_ADD
+        OP_PICK
+        { lookup - 2 }
+        OP_ADD
+        OP_ADD
+        OP_PICK
+    }
+}
+
+pub fn u4_and(lookup: u32, table: u32) -> Script {
+    script! {
+        { lookup }
+        OP_ADD
+        OP_PICK
+        { table }
+        OP_ADD
+        OP_ADD
+        OP_PICK
+    }
+}
+
+//(a xor b) = (a + b) - 2*(a & b)) = b - 2(a&b) + a
+pub fn u4_xor_with_and(lookup: u32, table: u32) -> Script {
+    script! {
+        OP_2DUP
+        { u4_and( lookup+2, table+2) }
+        OP_DUP
+        OP_ADD
+        OP_SUB
+        OP_ADD
+    }
+}
+
+pub fn u4_xor_half_table(lookup: u32) -> Script {
+    script! {
+        OP_2DUP
+        { u4_and_half_table( lookup+2) }
+        OP_DUP
+        OP_ADD
+        OP_SUB
+        OP_ADD
+    }
+}
+
+
+pub fn u4_logic_nibs(nibble_count: u32, bases: Vec<u32>, offset: u32, is_xor: bool ) -> Script {
+    let numbers = bases.len() as u32;
+    script! {
+        { u4_arrange_nibbles(nibble_count, bases) }
+        for nib in 0..nibble_count {
+            for i in 0..numbers-1 {
+                if is_xor {
+                    { u4_xor_half_table( offset - i - nib * numbers ) }
+                } else {
+                    { u4_and_half_table( offset - i - nib * numbers ) }
+                }
+            }
+            OP_TOALTSTACK
+        }
+
+    }
+}
+
+pub fn u4_and_u32(bases: Vec<u32>, offset: u32) -> Script {
+    u4_logic_nibs(8, bases, offset, false)
+}
+
+pub fn u4_xor_u32(bases: Vec<u32>, offset: u32) -> Script {
+    u4_logic_nibs(8, bases, offset, true)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::u4::u4_logic::*;
+    use crate::u4::u4_shift::{u4_drop_rshift_tables, u4_push_rshift_tables};
+    use crate::u4::u4_std::{u4_number_to_nibble, u4_u32_verify_from_altstack};
+    use crate::treepp::{execute_script, script};
+
+    #[test]
+    fn test_xor_u32() {
+        let script = script! {
+            { u4_push_half_and_table() }
+            { u4_push_half_lookup()}
+            { u4_number_to_nibble(0x87878787)}
+            { u4_number_to_nibble(0xFF010203)}
+            { u4_number_to_nibble(0xAABBCCDD)}
+            { u4_logic_nibs( 8, vec![0,8,16], 24, true )}
+            { u4_drop_half_lookup() }
+            { u4_drop_half_and() }
+
+            { u4_number_to_nibble(0xD23D4959)}
+            { u4_u32_verify_from_altstack() }
+            OP_TRUE
+
+
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_logic_u32_size() {
+        let xor_x2 = u4_logic_nibs( 8, vec![0,8], 24, true );
+        println!("{}", xor_x2.len());
+        let xor_x3 = u4_logic_nibs( 8, vec![0,8,16], 24, true );
+        println!("{}", xor_x3.len());
+        let xor_x2 = u4_logic_nibs( 8, vec![0,8], 24, false );
+        println!("{}", xor_x2.len());
+        let xor_x3 = u4_logic_nibs( 8, vec![0,8,16], 24, false );
+        println!("{}", xor_x3.len());
+
+    }
+
+    #[test]
+    fn test_and_u32() {
+        let script = script! {
+            { u4_push_half_and_table() }
+            { u4_push_half_lookup()}
+            { u4_number_to_nibble(0x87878787)}
+            { u4_number_to_nibble(0xFF010203)}
+            { u4_number_to_nibble(0xAABBCCDD)}
+            { u4_logic_nibs( 8, vec![0,8,16], 24, false )}
+            { u4_drop_half_lookup() }
+            { u4_drop_half_and() }
+
+            { u4_number_to_nibble(0x82010001)}
+            { u4_u32_verify_from_altstack() }
+            OP_TRUE
+
+
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_xor_half() {
+        for x in 0..16 {
+            for y in 0..16 {
+                let script = script! {
+                    { u4_push_half_and_table() }
+                    { u4_push_half_lookup()}
+                    {x}      // X
+                    {y}       // Y
+                    { u4_xor_half_table(2)}
+                    { x ^ y}
+                    OP_EQUALVERIFY
+                    { u4_drop_half_lookup() }
+                    { u4_drop_half_and() }
+                    OP_TRUE
+                };
+
+                let res = execute_script(script);
+                assert!(res.success);
+            }
+        }
+    }
+    #[test]
+    fn test_and_half() {
+        for x in 0..16 {
+            for y in 0..16 {
+                let script = script! {
+                    { u4_push_half_and_table() }
+                    { u4_push_half_lookup()}
+                    {x}      // X
+                    {y}       // Y
+                    { u4_and_half_table(2)}
+                    { x & y}
+                    OP_EQUALVERIFY
+                    { u4_drop_half_lookup() }
+                    { u4_drop_half_and() }
+                    OP_TRUE
+                };
+
+                let res = execute_script(script);
+                assert!(res.success);
+            }
+        }
+    }
+
+    #[test]
+    fn test_xor_with_and() {
+        for x in 0..16 {
+            for y in 0..16 {
+                let script = script! {
+                    { u4_push_and_table() }
+                    { u4_push_lookup()}
+                    {x}      // X
+                    {y}       // Y
+                    { u4_xor_with_and(1, 17)}
+                    {x^y}
+                    OP_EQUALVERIFY
+                    { u4_drop_lookup() }
+                    { u4_drop_logic_table() }
+                    OP_TRUE
+                };
+
+                println!("{}", script.len());
+                let res = execute_script(script);
+
+                assert!(res.success);
+            }
+        }
+    }
+
+    #[test]
+    fn test_xor_func() {
+        let script = script! {
+            { u4_push_xor_table() }
+            { u4_push_lookup()}
+            12      // X
+            5       // Y
+            { u4_and(1, 17)}
+            9
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            { u4_drop_logic_table() }
+            OP_TRUE
+        };
+
+        println!("{}", script.len());
+        let res = execute_script(script);
+
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_and_func() {
+        let script = script! {
+            { u4_push_and_table() }
+            { u4_push_lookup()}
+            12      // X
+            5       // Y
+            { u4_and(1, 17)}
+            4
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            { u4_drop_logic_table() }
+            OP_TRUE
+        };
+
+        println!("{}", script.len());
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+    #[test]
+    fn test_lookup() {
+        let script = script! {
+            { u4_push_lookup() }
+            15
+            1
+            OP_ADD
+            OP_PICK
+            256
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+        let script = script! {
+            { u4_push_lookup() }
+            0
+            1
+            OP_ADD
+            OP_PICK
+            16
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_shift4() {
+        let script = script! {
+            { u4_push_lookup() }
+            0
+            OP_PICK
+            0
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            OP_TRUE
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+
+        let script = script! {
+            { u4_push_lookup() }
+            15
+            OP_PICK
+            240
+            OP_EQUALVERIFY
+            { u4_drop_lookup() }
+            OP_TRUE
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_and() {
+        let script = script! {
+            { u4_push_and_table() }
+            { u4_push_lookup()}
+            { u4_push_rshift_tables() }
+            12      // X
+            5       // Y
+            { 1 + 1 + 48 }       // offset (X + rshift size is the offset)
+            OP_ADD
+            OP_PICK
+            { 1 + 48 }      // size of rshift
+            OP_ADD
+            OP_ADD
+            OP_PICK
+            4
+            OP_EQUALVERIFY
+            { u4_drop_rshift_tables() }
+            { u4_drop_lookup() }
+            { u4_drop_logic_table() }
+            OP_TRUE
+        };
+
+        println!("{}", script.len());
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_xor() {
+        let script = script! {
+            { u4_push_xor_table() }
+            { u4_push_lookup()}
+            { u4_push_rshift_tables() }
+            12      // X
+            5       // Y
+            { 1 + 1 + 48 }       // offset (X + rshift size is the offset)
+            OP_ADD
+            OP_PICK
+            { 1 + 48 }      // size of rshift
+            OP_ADD
+            OP_ADD
+            OP_PICK
+            9
+            OP_EQUALVERIFY
+            { u4_drop_rshift_tables() }
+            { u4_drop_lookup() }
+            { u4_drop_logic_table() }
+            OP_TRUE
+        };
+
+        println!("{}", script.len());
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_or() {
+        let script = script! {
+            { u4_push_or_table() }
+            { u4_push_lookup()}
+            { u4_push_rshift_tables() } // just as example for the delta
+            12      // X
+            5       // Y
+            { 1 + 1 + 48 }       // offset (X + rshift size is the offset)
+            OP_ADD
+            OP_PICK
+            { 1 + 48 }      // size of rshift
+            OP_ADD
+            OP_ADD
+            OP_PICK
+            13
+            OP_EQUALVERIFY
+            { u4_drop_rshift_tables() }
+            { u4_drop_lookup() }
+            { u4_drop_logic_table() }
+            OP_TRUE
+        };
+
+        println!("{}", script.len());
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+}

--- a/src/u4/u4_rot.rs
+++ b/src/u4/u4_rot.rs
@@ -1,0 +1,287 @@
+use crate::treepp::{pushable, script, Script};
+use crate::u4::u4_shift::*;
+
+// rot right for n bits is constructed using shifting operations of two nibbles
+// also, there is a function to prepare the nibbles to be shiffte
+// so if 0xff000001 is shifted right, then the nibble 1 is copied in front to be shifted into f
+
+
+pub fn u4_push_rrot_tables() -> Script {
+    script! {
+       {  u4_push_2_nib_rshift_tables() } 
+    }
+
+}
+
+pub fn u4_drop_rrot_tables() -> Script {
+    script! {
+        { u4_drop_2_nib_rshift_tables() }
+    }
+}
+
+pub fn u4_prepare_number(shift: u32, number_pos: u32, is_shift: bool) -> Script {
+    let pos_shift = shift / 4;
+
+    let pos_shift_extra = pos_shift + 1;
+    script! {
+        for _ in 8-pos_shift_extra ..8 {
+            if is_shift {
+                OP_0
+            } else {
+                { number_pos + 7-(8-pos_shift_extra) }
+                OP_PICK
+            }
+        }
+        for _ in 0..8-pos_shift {
+            { number_pos + 7 + pos_shift_extra  }
+            OP_PICK
+        }
+
+    }
+}
+
+
+pub fn u4_rrot(shift:u32, number_pos: u32, shift_tables: u32, is_shift: bool ) -> Script {
+    let bit_shift = shift % 4;
+    //TODO: to improve, some operations of shifting zero into zero can be removed
+    script! {
+        { u4_prepare_number(shift, number_pos, is_shift ) }
+
+        for i in 0..8 {
+            if i == 7 {
+                OP_SWAP 
+                { u4_2_nib_shift_n(bit_shift, shift_tables - 2 + (9-i) ) }
+            } else {
+                OP_OVER
+                { u4_2_nib_shift_n(bit_shift, shift_tables - 2 + (10-i) ) }
+            }
+            OP_TOALTSTACK   
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+use crate::treepp::{execute_script, script};
+use rand::Rng;
+use crate::u4::{u4_std::{u4_drop, u4_number_to_nibble}, u4_rot::*}; 
+
+    #[test]
+    fn test_prepare_number() {
+
+        let script  = script! {
+            0
+            255
+            0
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            255
+            255
+            { u4_prepare_number( 7, 2, false ) }
+        };
+
+        let _ = execute_script(script);
+    
+    }
+
+    #[test]
+    fn test_prepare_number_for_shift() {
+
+        let script  = script! {
+            0
+            255
+            15
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            255
+            255
+            { u4_prepare_number( 10, 2, true ) }
+        };
+
+        let _ = execute_script(script);
+    }
+
+
+
+    fn rrot(x: u32, n: u32) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        (x >> n) | (x << (32 - n))
+    }
+
+    fn rshift(x: u32, n: u32) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        x >> n
+    }
+
+
+    #[test]
+    fn test_x() {
+        let script  = script! {
+            { u4_number_to_nibble(0x80_00_00_01) }
+            { u4_prepare_number(3, 0, false) }
+            OP_OVER 
+        };
+        let _ = execute_script(script);
+    }
+    #[test]
+    fn test_rrot_shift() {
+
+        let script  = script! {
+            { u4_push_rrot_tables() }
+            { u4_number_to_nibble(0xF0_FF_FF_FF) }
+            { u4_rrot(10, 0, 8, true ) }
+
+            { u4_drop(8) }
+            { u4_drop_rrot_tables() }
+
+            { u4_number_to_nibble(rshift(0xF0FF_FFFF, 10)) } 
+
+            for _ in 0..8 {
+                OP_FROMALTSTACK
+            }
+            for i in 0..8 {
+                { 8 - i}
+                OP_ROLL
+                OP_EQUALVERIFY
+            }
+            
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+
+    #[test]
+    fn test_rrot() {
+
+
+        let script  = script! {
+            { u4_rrot(7, 0, 8, false ) }
+        };
+        println!("{}", script.len());
+
+        let script  = script! {
+            { u4_push_rrot_tables() }
+            { u4_number_to_nibble(0xF0_00_10_01) }
+
+            { u4_rrot(7, 0, 8, false ) }
+
+            { u4_drop(8) }
+            { u4_drop_rrot_tables() }
+
+            { u4_number_to_nibble(rrot(0xF0_00_10_01, 7)) } //OP_FROMALTSTACK
+
+            for _ in 0..8 {
+                OP_FROMALTSTACK
+            }
+            for i in 0..8 {
+                { 8 - i}
+                OP_ROLL
+                OP_EQUALVERIFY
+            }
+            
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+
+    #[test]
+    fn test_rrot_rand() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let x: u32 = rng.gen();
+            let mut n: u32 = rng.gen();
+            n = n % 32;
+            if n % 4 == 0 {
+                n+=1;
+            }
+
+            let script  = script! {
+                { u4_push_rrot_tables() }
+                { u4_number_to_nibble(x) }
+
+                { u4_rrot(n, 0, 8, false ) }
+
+                { u4_drop(8) }
+                { u4_drop_rrot_tables() }
+
+                { u4_number_to_nibble(rrot(x, n)) } //OP_FROMALTSTACK
+
+                for _ in 0..8 {
+                    OP_FROMALTSTACK
+                }
+                for i in 0..8 {
+                    { 8 - i}
+                    OP_ROLL
+                    OP_EQUALVERIFY
+                }
+                
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+        }
+    }
+
+    #[test]
+    fn test_rshift_rand() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let x: u32 = rng.gen();
+            let mut n: u32 = rng.gen();
+            n = n % 32;
+            if n % 4 == 0 {
+                n+=1;
+            }
+
+            let script  = script! {
+                { u4_push_rrot_tables() }
+                { u4_number_to_nibble(x) }
+
+                { u4_rrot(n, 0, 8, true ) }
+
+                { u4_drop(8) }
+                { u4_drop_rrot_tables() }
+
+                { u4_number_to_nibble(rshift(x, n)) } //OP_FROMALTSTACK
+
+                for _ in 0..8 {
+                    OP_FROMALTSTACK
+                }
+                for i in 0..8 {
+                    { 8 - i}
+                    OP_ROLL
+                    OP_EQUALVERIFY
+                }
+                
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+        }
+    }
+
+}

--- a/src/u4/u4_shift.rs
+++ b/src/u4/u4_shift.rs
@@ -1,0 +1,265 @@
+use crate::treepp::{pushable, script, Script};
+use super::u4_std::u4_drop;
+
+// right and left shfit tables for 3 bits options
+// compressed to reduce the size of the script
+// but in memory it will be 16*3 = 48
+
+
+pub fn u4_push_lshift_tables() -> Script {
+    //lshift3, lshift2, lshift1
+    script! {
+        OP_8
+        OP_0
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_12
+        OP_8
+        OP_4
+        OP_0
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_2OVER
+        OP_14
+        OP_12
+        OP_10
+        OP_8
+        OP_6
+        OP_4
+        OP_2
+        OP_0
+        OP_14
+        OP_12
+        OP_10
+        OP_8
+        OP_6
+        OP_4
+        OP_2
+        OP_0
+    }
+}
+
+pub fn u4_drop_lshift_tables() -> Script {
+    u4_drop(16*3)
+}
+
+pub fn u4_push_rshift_tables() -> Script {
+    //rshift3, rshift2, rshift1
+    script! {
+        OP_1
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_3
+        OP_DUP
+        OP_2DUP
+        OP_2
+        OP_DUP
+        OP_2DUP
+        OP_1
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_7
+        OP_DUP
+        OP_6
+        OP_DUP
+        OP_5
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_3
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_1
+        OP_DUP
+        OP_0
+        OP_DUP
+          }
+
+}
+
+pub fn u4_drop_rshift_tables() -> Script {
+    u4_drop(16*3)
+}
+
+pub fn u4_push_2_nib_rshift_tables() -> Script {
+    script! {
+       { u4_push_lshift_tables() }
+       { u4_push_rshift_tables() }
+    }
+}
+
+pub fn u4_drop_2_nib_rshift_tables() -> Script {
+    script! {
+       { u4_drop_rshift_tables() }
+       { u4_drop_lshift_tables() }
+    }
+}
+
+
+//It will process a nibble and shift it left 1,2 or 3 bits
+pub fn u4_lshift(n: u32, lshift_offset: u32 ) -> Script {
+    script! {
+        { lshift_offset + (16*(n-1)) }
+        OP_ADD
+        OP_PICK
+    }
+}
+
+//It will process a nibble and shift it right 1,2 or 3 bits
+pub fn u4_rshift(n: u32, rshift_offset: u32 ) -> Script {
+    script! {
+        { rshift_offset + (16*(n-1)) }
+        OP_ADD
+        OP_PICK
+    }
+}
+
+
+
+
+// Assumes Y and X are on the stack and will produce YX >> n
+// It calculates the offset doing (Y << (4-n)) & 15 + (X >> n) & 15
+pub fn u4_2_nib_shift_n(n:u32, tables_offset: u32) -> Script {
+    script! {
+        { u4_lshift(4-n, tables_offset + (16*3) + 1)  }
+        OP_SWAP
+        { u4_rshift(n, tables_offset + 1)  }
+        OP_ADD
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+use crate::treepp::{execute_script, script}; 
+use crate::u4::u4_shift::*;
+
+    #[test]
+    fn test_rshift() {
+        let script  = script! {
+            { u4_push_rshift_tables() }
+            15
+            16         // 16 is the size of rshift 1,2,3 choosing 2
+            OP_ADD
+            OP_PICK
+            3
+            OP_EQUALVERIFY
+            { u4_drop_rshift_tables() }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+   
+   #[test]
+    fn test_lshift() {
+        let script  = script! {
+            { u4_push_lshift_tables() }
+            7 
+            0         // 16 is the size of rshift 1,2,3 choosing 1
+            OP_ADD
+            OP_PICK
+            14 
+            OP_EQUALVERIFY
+            { u4_drop_lshift_tables() }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+
+    #[test]
+    fn test_lshift_func() {
+        for n in 1..4 {
+            for x in 0..16 {
+                let script = script! {
+
+                    { u4_push_lshift_tables() }
+                    { x }           //  X 
+                    { u4_lshift(n , 0)}
+                    { (x << n) % 16 }
+                    OP_EQUALVERIFY 
+                    { u4_drop_lshift_tables() }
+                    OP_TRUE
+                };
+
+                let res = execute_script(script);
+                assert!(res.success);
+            }
+        }
+
+    }
+
+    #[test]
+    fn test_rshift_func() {
+        for n in 1..4 {
+            for x in 0..16 {
+                let script = script! {
+
+                    { u4_push_rshift_tables() }
+                    { x }           //  X 
+                    { u4_lshift(n , 0)}
+                    { (x >> n) % 16 }
+                    OP_EQUALVERIFY 
+                    { u4_drop_rshift_tables() }
+                    OP_TRUE
+                };
+
+                let res = execute_script(script);
+                assert!(res.success);
+            }
+        }
+
+    }
+
+
+    #[test]
+    fn test_2_nib_rshift_function () {
+        for n in 1..4 {
+            for y in 0..16 {
+
+                for x in 0..16 {
+
+                    let script  = script! {
+                        { u4_push_2_nib_rshift_tables() }
+                        { x }           //  X 
+                        { y }          //  X  |  Y
+                        { u4_2_nib_shift_n(n, 0) }
+                        { (((y << 4)+x) >> n) % 16 }         
+                        OP_EQUALVERIFY
+                        { u4_drop_2_nib_rshift_tables() }
+                        OP_TRUE
+                    };
+
+                    let res = execute_script(script);
+                    assert!(res.success);
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/u4/u4_std.rs
+++ b/src/u4/u4_std.rs
@@ -1,0 +1,175 @@
+use crate::treepp::{script, pushable, Script};
+use bitcoin::{opcodes::all::*, Opcode};
+
+// helper functions used on the rest of the u4 code
+
+
+pub fn u4_toaltstack(n: u32) -> Script {
+    script! {
+        for _ in 0..n {
+            OP_TOALTSTACK
+        }
+    }
+}
+
+pub fn u4_fromaltstack(n: u32) -> Script {
+    script! {
+        for _ in 0..n {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
+pub fn u4_copy_u32_from(address: u32) -> Script {
+    script! {
+        for _ in 0..8 {
+            { address + 7 }
+            OP_PICK
+        }
+    }
+}
+
+pub fn u4_move_u32_from(address: u32) -> Script {
+    script! {
+        for _ in 0..8 {
+            { address + 7 }
+            OP_ROLL
+        }
+    }
+}
+
+
+
+pub fn u4_u32_verify_from_altstack() -> Script {
+    script! {
+        for _ in 0..8 {
+            OP_FROMALTSTACK
+        }
+
+        for i in 0..8 {
+            { 8 - i}
+            OP_ROLL
+            OP_EQUALVERIFY
+        }
+    }
+}
+
+pub fn u4_drop(n : u32 ) -> Script {
+    script! {
+        for _ in 0..n / 2 {
+            OP_2DROP
+        }
+        if n & 1 == 1 {
+            OP_DROP
+        }
+    }
+}
+
+pub fn u4_number_to_nibble(n: u32) -> Script { //constant number used during "compile" time
+    script! {
+       for i in (0..8).rev() { 
+            { (n >> (i * 4)) & 0xF } 
+        } 
+    }
+}
+
+pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
+    let nibbles : Result<Vec<u8>, std::num::ParseIntError> = hex_str.chars().map(|c| {
+            u8::from_str_radix(&c.to_string(), 16)
+        }).collect();
+    let nibbles = nibbles.unwrap();
+    script! {
+        for nibble in nibbles {
+            { nibble }
+        }
+    }
+}
+
+
+
+pub trait CalculateOffset {
+    fn modify(&mut self, element: Opcode ) -> Script;
+}
+
+impl CalculateOffset for i32 {
+    fn modify(&mut self, element: Opcode ) -> Script {
+        match element {
+            OP_TOALTSTACK |
+            OP_ADD => *self -= 1,
+            OP_PICK => {}, //pick replaces the value so it does not change the stack count
+            OP_DUP => *self += 1,
+            _ =>  { panic!("unexpected opcode: {:?}", element); }
+        }
+
+        let mut s = Script::new();
+        s.push_opcode(element);
+        s
+    }
+}
+#[cfg(test)]
+mod tests {
+
+use crate::treepp::{execute_script, script, pushable};
+
+use crate::u4::u4_std::u4_number_to_nibble;
+
+use super::u4_hex_to_nibbles;
+
+    #[test]
+    fn test_number_to_nibble() {
+
+        let script  = script!{
+            { u4_number_to_nibble(0xfedc8765) }
+            5
+            OP_EQUALVERIFY
+            6
+            OP_EQUALVERIFY
+            7
+            OP_EQUALVERIFY
+            8
+            OP_EQUALVERIFY
+            12
+            OP_EQUALVERIFY
+            13
+            OP_EQUALVERIFY
+            14
+            OP_EQUALVERIFY
+            15
+            OP_EQUALVERIFY
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+
+    #[test]
+    fn test_hex_to_nibble() {
+        let script = script! {
+            { u4_hex_to_nibbles("fedc8765")}
+            5
+            OP_EQUALVERIFY
+            6
+            OP_EQUALVERIFY
+            7
+            OP_EQUALVERIFY
+            8
+            OP_EQUALVERIFY
+            12
+            OP_EQUALVERIFY
+            13
+            OP_EQUALVERIFY
+            14
+            OP_EQUALVERIFY
+            15
+            OP_EQUALVERIFY
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+
+}


### PR DESCRIPTION
Hi! 
I've been working on a new version of the sha256 on-chain script that works using u4 as basic unit size.

In the process of doing it I created some interesting optimized lookup tables that are used by the algorithm, and some more that I could not use because of stack limitation, but still might be usefull for other parts.

This is the comparisson between the current sha256 algo and the new one.
| Algorithm | Current | New | Gain |
|---|---|--|--|
| sha256(32) | 516K | 344K | 33% |
| sha256(80) | 1043K | 759K | 27% |

