### PR TITLE
Optimized Sha256 version using bitcoin-sript-stack lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 esplora-client = { git = "https://github.com/BitVM/rust-esplora-client" }
 serde_json = "1.0.116"
 lazy_static = "1.4.0"
+bitcoin-script-stack = { git = "https://github.com/FairgateLabs/rust-bitcoin-script-stack"}
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,3 +1,4 @@
 pub mod blake3;
 pub mod sha256;
 pub mod sha256_u4;
+pub mod sha256_u4_stack;

--- a/src/hash/sha256_u4.rs
+++ b/src/hash/sha256_u4.rs
@@ -1,6 +1,7 @@
+use std::vec;
 use crate::treepp::{pushable, script, Script};
 use crate::u4::{u4_add::*, u4_logic::*, u4_rot::*, u4_std::*};
-use std::vec;
+
 
 const K: [u32; 64] = [
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
@@ -25,6 +26,7 @@ pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
     chunks += 1;
 
     if num_bytes % 64 > 55 {
+
         let mut bytes_left_first_padding = 64 - (num_bytes % 64);
         bytes_left_first_padding -= 1; // remove the 0x80 that will be added always
         let script1 = script! {
@@ -45,98 +47,96 @@ pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
             { u4_number_to_nibble( num_bytes * 8 ) }
         };
 
+        
         chunks += 1;
 
         let mut results = Vec::new();
         for _ in 0..(chunks - 2) {
-            results.push(script! {});
+            results.push(script!{});
         }
         results.push(script1);
         results.push(script2);
 
         (results, chunks)
+
+
     } else {
-        let (script1, _) = padding(num_bytes);
+        let (script1,_) = padding(num_bytes);
         let mut results = Vec::new();
         for _ in 0..(chunks - 1) {
-            results.push(script! {});
+            results.push(script!{});
         }
         results.push(script1);
         (results, chunks)
     }
+
 }
 
+
+
+
 pub fn padding(num_bytes: u32) -> (Script, u32) {
+
     let l = (num_bytes * 8) as i32;
-    let mut k = 512 - l - 8 - 32; // here it is usually minus 8, but as
-                                  // there will be never that many bytes to process
-                                  // one u32 will be enough
+    let mut k = 512 - l - 8 - 32;     // heres is usually minus 8, but as 
+                                            // there will be never that many bytes to process
+                                            // one u32 will be enough
     let mut chunks = 1;
     while k < 0 {
         k += 512;
         chunks += 1;
     }
-    let zeros = k / 16;
+    let zeros = k/16;
     let extras = k % 16;
 
-    (
-        script! {
-          8
-          0
-          for i in 0..zeros {
-              if i == 0 {
-                  0
-                  OP_DUP
-                  OP_2DUP
-              } else {
-                  OP_2DUP
-                  OP_2DUP
-              }
-          }
-          if extras > 0 {
-              0
-              0
-          }
-          { u4_number_to_nibble( l as u32 ) }
-        },
-        chunks,
+    ( script! {
+        8
+        0
+        for i in 0..zeros {
+            if i == 0 {
+                0
+                OP_DUP
+                OP_2DUP
+            } else {
+                OP_2DUP
+                OP_2DUP
+            }
+        }
+        if extras > 0 {
+            0
+            0
+        }
+        { u4_number_to_nibble( l as u32 ) }
+      },
+      chunks
     )
+
 }
 
-pub fn calculate_s_part_1(
-    offset_number: u32,
-    offset_rrot: u32,
-    shift_value: Vec<u32>,
-    last_is_shift: bool,
-) -> Script {
-    script! {
+pub fn calculate_s_part_1( offset_number: u32, offset_rrot: u32, shift_value: Vec<u32>, last_is_shift: bool ) -> Script {
+    script!{
         { u4_rrot(shift_value[0], offset_number, offset_rrot, false) }
         { u4_rrot(shift_value[1], offset_number, offset_rrot, false) }
         { u4_rrot(shift_value[2], offset_number, offset_rrot, last_is_shift) }
     }
 }
 
-pub fn calculate_s_part_2(offset_and: u32) -> Script {
+
+pub fn calculate_s_part_2( offset_and: u32, do_xor_with_and:bool ) -> Script {
     script! {
         for _ in 0..24 {
             OP_FROMALTSTACK
         }
 
-        { u4_xor_u32(vec![0,8,16], offset_and + 24) }
+        { u4_xor_u32(vec![0,8,16], offset_and + 24, do_xor_with_and) }
 
     }
 }
 
-pub fn calculate_s(
-    offset_number: u32,
-    offset_rrot: u32,
-    offset_and: u32,
-    shift_value: Vec<u32>,
-    last_is_shift: bool,
-) -> Script {
+pub fn calculate_s( offset_number: u32, offset_rrot: u32, offset_and: u32, shift_value: Vec<u32>, last_is_shift: bool, do_xor_with_and:bool ) -> Script {
     script! {
         { calculate_s_part_1(offset_number, offset_rrot, shift_value, last_is_shift) }
-        { calculate_s_part_2(offset_and) }
+        { calculate_s_part_2(offset_and, do_xor_with_and) }
     }
 }
 
@@ -145,7 +145,9 @@ fn get_w_pos(i: u32) -> u32 {
     pos
 }
 
-fn get_extra_pos(i: u32) -> u32 { (i - 16) * 8 }
+fn get_extra_pos(i: u32) -> u32 {
+    (i-16) * 8
+}
 
 fn get_pos_var(name: char) -> u32 {
     let i = match name {
@@ -157,23 +159,26 @@ fn get_pos_var(name: char) -> u32 {
         'f' => 5,
         'g' => 6,
         'h' => 7,
-        _ => 0,
+        _ => 0
     };
 
-    let top = 8 * 8;
+    let top = 8*8;
     let base = top - 8;
     base - i * 8
 }
 pub fn debug() -> Script {
+
     script! {
         OP_DEPTH
         OP_TOALTSTACK
         60000
         OP_PICK
     }
+
 }
 
-pub fn ch_calculation(e: u32, f: u32, g: u32, offset_and: u32) -> Script {
+pub fn ch_calculation(e: u32, f:u32, g:u32, offset_and: u32) -> Script {
+
     script! {
         for nib in 0..8 {
 
@@ -195,15 +200,17 @@ pub fn ch_calculation(e: u32, f: u32, g: u32, offset_and: u32) -> Script {
             { f + 7  + 2}                      // ( ~e & g ) e f_nib_pos
             OP_PICK                                 // ( ~e & g ) e f
 
-            { u4_and_half_table(nib + offset_and + 3) }   // ( ~e & g ) (e & f)
-            { u4_xor_half_table(nib + offset_and + 2) }   // ( ~e & g ) ^ (e & f)
+            { u4_and_half_table(nib + offset_and + 3) }   // ( ~e & g ) (e & f) 
+            { u4_xor_with_and_table(nib + offset_and + 2) }   // ( ~e & g ) ^ (e & f) 
 
             //OP_TOALTSTACK
         }
     }
+
 }
 
-pub fn maj_calculation(a: u32, b: u32, c: u32, offset_and: u32) -> Script {
+pub fn maj_calculation(a: u32, b:u32, c:u32, offset_and: u32) -> Script {
+
     script! {
         for nib in 0..8 {
 
@@ -214,7 +221,7 @@ pub fn maj_calculation(a: u32, b: u32, c: u32, offset_and: u32) -> Script {
             OP_PICK                                       // a b
             OP_2DUP                                       // a b a b
 
-            { u4_xor_half_table(nib + offset_and + 4) }   // a b (a^b)
+            { u4_xor_with_and_table(nib + offset_and + 4) }   // a b (a^b)
 
             { c + 7 + 3 }                                 // a b (a^b) c_nib_pos
             OP_PICK                                       // a b (a^b) c
@@ -225,49 +232,47 @@ pub fn maj_calculation(a: u32, b: u32, c: u32, offset_and: u32) -> Script {
 
             { u4_and_half_table(nib + offset_and + 3) }   // ((a^b) & c) (a & b)
 
-            { u4_xor_half_table(nib + offset_and + 2) }   // ((a^b) & c) ^ (a & b)
+            { u4_xor_with_and_table(nib + offset_and + 2) }   // ((a^b) & c) ^ (a & b)
 
         }
     }
+
 }
 
-pub fn schedule_iteration(
-    i: u32,
-    offset_top_sched: u32,
-    offset_rot: u32,
-    offset_and: u32,
-    offset_add: u32,
-    use_add_table: bool,
-) -> Script {
+
+pub fn schedule_iteration(i:u32, offset_top_sched: u32, offset_rot:u32, offset_and: u32, offset_add: u32, use_add_table: bool, do_xor_with_and:bool) -> Script {
     script! {
-        { calculate_s( offset_top_sched - get_w_pos(i-15), offset_rot, offset_and, vec![7,18,3], true)}
-        { calculate_s( offset_top_sched - get_w_pos(i-2), offset_rot, offset_and, vec![17,19,10], true)}
+        { calculate_s( offset_top_sched - get_w_pos(i-15), offset_rot, offset_and, vec![7,18,3], true, do_xor_with_and)}
+        { calculate_s( offset_top_sched - get_w_pos(i-2), offset_rot, offset_and, vec![17,19,10], true, do_xor_with_and)}
         { u4_fromaltstack(16) }
         { u4_copy_u32_from(offset_top_sched - get_w_pos(i-16)+16 )}   // this can be avoided arranging directly with roll
         { u4_copy_u32_from(offset_top_sched - get_w_pos(i-7)+24 )}
-        { u4_add(8, vec![0, 8, 16, 24], offset_add + 32, use_add_table )}
+        { u4_add(8, vec![0, 8, 16, 24], offset_add + 32, use_add_table )}  
         { u4_fromaltstack(8) }
     }
 }
 
-fn get_full_w_pos(top_table: u32, i: u32) -> u32 { top_table - (i + 1) * 8 }
+fn get_full_w_pos(top_table: u32, i:u32) -> u32 {
+    top_table - (i+1) * 8
+}
 
 pub fn sha256(num_bytes: u32) -> Script {
+
     // up to 55 is one block and always supports add table
     // probably up to 68 bytes I can afford to load the add tables for the first chunk (but have I would have to unload it)
 
     let (mut padding_scripts, chunks) = double_padding(num_bytes);
-    let mut bytes_per_chunk: Vec<u32> = Vec::new();
+    let mut bytes_per_chunk : Vec<u32> = Vec::new();
     let mut bytes_remaining = num_bytes;
     while bytes_remaining > 0 {
         if bytes_remaining > 64 {
-            bytes_per_chunk.push(64);
+            bytes_per_chunk.push( 64);
             bytes_remaining -= 64;
         } else {
-            bytes_per_chunk.push(bytes_remaining);
+            bytes_per_chunk.push( bytes_remaining);
             bytes_remaining = 0;
         }
-    }
+    } 
     if bytes_per_chunk.len() < chunks as usize {
         bytes_per_chunk.push(0);
     }
@@ -277,36 +282,49 @@ pub fn sha256(num_bytes: u32) -> Script {
     let add_size = 130;
     let sched_size = 128;
     let rrot_size = 96;
-    let half_logic_size = 136 + 16;
+    let half_logic_size = 136+16;
     let mut tables_size = rrot_size + half_logic_size;
     let use_add_table = chunks == 1;
     if use_add_table {
         tables_size += add_size;
-    }
+    } 
+
 
     let sched_loop_offset_and = sched_size;
     let sched_loop_offset_rrot = sched_loop_offset_and + half_logic_size;
     let sched_loop_offset_add = sched_loop_offset_rrot + rrot_size;
 
+
     let full_sched_size = 512;
-    let temp_vars_size = 8 * 8;
+    let temp_vars_size  = 8*8;
 
     let vars_top = temp_vars_size + full_sched_size;
     let main_loop_offset_and = vars_top;
     let main_loop_offset_rrot = main_loop_offset_and + half_logic_size;
     let main_loop_offset_add = main_loop_offset_rrot + rrot_size;
 
+
     script! {
 
         if use_add_table {
             { u4_push_add_tables() }
         }
-        { u4_push_rrot_tables() }     // rshiftn 16*6= 96
-        { u4_push_half_and_table() }  // 136
+        { u4_push_rrot_tables() }     // rshiftn 16*6= 96 
+        { u4_push_half_xor_table() }  // 136 
         { u4_push_half_lookup() }     // 16
                                       // total :  136 + 16 + 96 = 248
 
         for c in 0..chunks {
+
+            if c > 0 {
+                //change and with xor
+                //TODO: if lookup table is pushed first and substracted
+                // then we could avoid changing it  ~(32 * chunk) 
+                { u4_drop_half_lookup() }
+                { u4_drop_half_and() }
+                { u4_push_half_xor_table() }  
+                { u4_push_half_lookup() }     
+            }
 
             for _ in 0..bytes_per_chunk[c as usize]*2 {
                 { (tables_size + (num_bytes * 2) - 1 - (c*128))  }
@@ -314,13 +332,20 @@ pub fn sha256(num_bytes: u32) -> Script {
             }
 
 
-            { padding_scripts.remove(0) }
-
-            //schedule loop
+            { padding_scripts.remove(0) }                  
+            
+            //schedule loop 
             for i in 16..64 {
-                { schedule_iteration(i, sched_size + get_extra_pos(i), sched_loop_offset_rrot + get_extra_pos(i), sched_loop_offset_and + get_extra_pos(i), sched_loop_offset_add + get_extra_pos(i), use_add_table) }
+                { schedule_iteration(i, sched_size + get_extra_pos(i), sched_loop_offset_rrot + get_extra_pos(i), sched_loop_offset_and + get_extra_pos(i), sched_loop_offset_add + get_extra_pos(i), use_add_table, false) }
             }
 
+            //change xor with and table
+            { u4_toaltstack(full_sched_size) }
+            { u4_drop_half_lookup() }
+            { u4_drop_half_and() }
+            { u4_push_half_and_table() }  
+            { u4_push_half_lookup() }     
+            { u4_fromaltstack(full_sched_size) }
 
             if c == 0 {
                 //set initial variables a,b,c,d,e,f,g,h
@@ -332,12 +357,12 @@ pub fn sha256(num_bytes: u32) -> Script {
             }
 
 
-
-
+            
+                    
             for i in 0..64 {
 
                 //Calculate S1
-                { calculate_s( get_pos_var('e'), main_loop_offset_rrot, main_loop_offset_and, vec![6, 11, 25], false  ) }
+                { calculate_s( get_pos_var('e'), main_loop_offset_rrot, main_loop_offset_and, vec![6, 11, 25], false, true  ) }
                 { u4_fromaltstack(8)}
 
 
@@ -360,7 +385,7 @@ pub fn sha256(num_bytes: u32) -> Script {
                 { u4_fromaltstack(8)}
 
                 //Calculate S0   (on altstack)
-                { calculate_s( get_pos_var('a'),  main_loop_offset_rrot,  main_loop_offset_and, vec![2, 13, 22], false  ) }
+                { calculate_s( get_pos_var('a'),  main_loop_offset_rrot,  main_loop_offset_and, vec![2, 13, 22], false, true  ) }
 
                 //Calculate maj  (on stack)
                 { maj_calculation( get_pos_var('a'),  get_pos_var('b'),  get_pos_var('c'),  main_loop_offset_and ) }
@@ -372,12 +397,12 @@ pub fn sha256(num_bytes: u32) -> Script {
                 { u4_fromaltstack(8)}
 
                 //temp2 = maj + s0
-                //calculate a = temp1 + temp2
+                //calculate a = temp1 + temp2 
                 //consumes the three values and leaves a on the stack updated
-                { u4_add(8, vec![0, 8, 16], main_loop_offset_add + 24, use_add_table) }
+                { u4_add(8, vec![0, 8, 16], main_loop_offset_add + 24, use_add_table) } 
                 { u4_fromaltstack(8)}
 
-
+                
                 //all this moves can be avoided doing index magic with get_pos_var('X', round)
                 //b = a
                 { u4_move_u32_from( temp_vars_size  ) }
@@ -385,9 +410,9 @@ pub fn sha256(num_bytes: u32) -> Script {
                 { u4_move_u32_from( temp_vars_size  ) }
                 //d = c
                 { u4_move_u32_from( temp_vars_size  ) }
-
+                
                 //e = d + temp1
-                { u4_add(8, vec![32, temp_vars_size], main_loop_offset_add + 8, use_add_table ) }
+                { u4_add(8, vec![32, temp_vars_size], main_loop_offset_add + 8, use_add_table ) } 
                 { u4_fromaltstack(8)}
 
                 //f = e
@@ -406,18 +431,18 @@ pub fn sha256(num_bytes: u32) -> Script {
                 // first chunk is added with the init state
                 for i in (0..8).rev() {
                     { u4_number_to_nibble( INITSTATE[i] ) }
-                    { u4_add(8, vec![0, 8], main_loop_offset_add + 8 - ((7-i) as u32 * 8), use_add_table ) }
+                    { u4_add(8, vec![0, 8], main_loop_offset_add + 8 - ((7-i) as u32 * 8), use_add_table ) } 
                 }
             } else {
                 // following chunks are added with the previous result
                 { u4_fromaltstack( 64 )}
                 for i in 0..8 {
-                    { u4_add_no_table(8, vec![0, 64 - i * 8]) }
+                    { u4_add_no_table(8, vec![0, 64 - i * 8]) } 
                 }
             }
 
             { u4_drop(64*8) }       // drop the whole schedule
-
+            
             //if it's not the last chunk
             //save a copy of the result
             if chunks > 1 && c < chunks - 1 {
@@ -434,7 +459,7 @@ pub fn sha256(num_bytes: u32) -> Script {
 
         { u4_drop_half_lookup() }
         { u4_drop_half_and() }
-        { u4_drop_rrot_tables() }
+        { u4_drop_rrot_tables() } 
         if use_add_table {
             { u4_drop_add_tables() }
         }
@@ -442,36 +467,44 @@ pub fn sha256(num_bytes: u32) -> Script {
         { u4_fromaltstack( 64 )}
 
     }
+
+
 }
 
 #[cfg(test)]
 mod tests {
 
-    use crate::hash::sha256_u4::*;
-    use crate::treepp::{execute_script, script};
-    use sha2::{Digest, Sha256};
+
+use crate::{execute_script, treepp::script};
+use crate::hash::sha256_u4::*;
+use sha2::{Digest, Sha256};
+
 
     #[test]
     fn test_sizes() {
         let x = sha256(80);
-        println!("sha 80 bytes: {}", x.len());
+        println!("sha 80 bytes: {}",x.len());
         let x = sha256(32);
-        println!("sha 32 bytes: {}", x.len());
-        let x = calculate_s(20, 30, 40, vec![7, 18, 3], true);
-        println!("compute s   : {}", x.len());
-        let x = schedule_iteration(16, 128, 128, 300, 400, false);
-        println!("schedule it : {}", x.len());
-        let x = ch_calculation(10, 20, 30, 300);
-        println!("compute ch  : {}", x.len());
-        let x = maj_calculation(10, 20, 30, 300);
-        println!("compute maj : {}", x.len());
+        println!("sha 32 bytes: {}",x.len());
+        let x = calculate_s(20, 30, 40, vec![7,18,3], true, false);
+        println!("compute s (xor)  : {}",x.len());
+        let x = calculate_s(20, 30, 40, vec![7,18,3], true, true);
+        println!("compute s (and)  : {}",x.len());
+        let x = schedule_iteration(16, 128, 128, 300, 400, false, true);
+        println!("schedule it : {}",x.len());
+        let x = ch_calculation(10, 20, 30,300);
+        println!("compute ch  : {}",x.len());
+        let x = maj_calculation(10, 20, 30,300);
+        println!("compute maj : {}",x.len());
     }
 
+        
     #[test]
     fn test_shatemp() {
+        
         let script = script! {
-            { u4_number_to_nibble(0xdeadbeaf) }
-            { u4_number_to_nibble(0x01020304) }
+            { u4_number_to_nibble(0xdeadbeaf) } 
+            { u4_number_to_nibble(0x01020304) } 
             { sha256(8) }
             { u4_drop(64)}
             OP_TRUE
@@ -479,21 +512,23 @@ mod tests {
 
         let res = execute_script(script);
         assert!(res.success);
+        
     }
 
-    fn test_sha256(hex_in: &str) {
+    fn test_sha256( hex_in : &str ) {
+
         let mut hasher = Sha256::new();
         let data = hex::decode(hex_in).unwrap();
         hasher.update(&data);
         let result = hasher.finalize();
         let res = hex::encode(result);
         println!("Result: {}", res);
-
+        
         let script = script! {
             { u4_hex_to_nibbles(hex_in) }
             { sha256(hex_in.len() as u32 /2)}
 
-
+            
             { u4_hex_to_nibbles(res.as_str())}
             for _ in 0..64 {
                 OP_TOALTSTACK
@@ -512,25 +547,19 @@ mod tests {
 
         };
 
+
         let res = execute_script(script);
         assert!(res.success);
+
     }
 
     #[test]
     fn test_sha256_strs() {
         let message = "Hello.";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
         test_sha256(&hex);
         let message = "This is a longer message that still fits in one block!";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
         test_sha256(&hex)
     }
 
@@ -546,6 +575,7 @@ mod tests {
 
     #[test]
     fn test_padding() {
+
         let (script, _) = padding(1);
         let script = script! {
             { 0}
@@ -557,11 +587,15 @@ mod tests {
 
         let res = execute_script(script);
         assert!(res.success);
-    }
 
+ 
+    }
+    
     #[test]
     fn test_split_padding() {
+
         for num_bytes in 0..150 {
+
             let (padding_scripts, chunks) = double_padding(num_bytes);
 
             let script = script! {
@@ -584,7 +618,9 @@ mod tests {
 
             let res = execute_script(script);
             assert!(res.success);
+
         }
+ 
     }
 
     #[test]
@@ -609,7 +645,7 @@ mod tests {
             { sha256(block_header.len() as u32 /2)}
             { sha256(32) }
 
-
+            
             { u4_hex_to_nibbles(res.as_str())}
             for _ in 0..64 {
                 OP_TOALTSTACK
@@ -631,4 +667,5 @@ mod tests {
         let res = execute_script(script);
         assert!(res.success);
     }
+
 }

--- a/src/hash/sha256_u4_stack.rs
+++ b/src/hash/sha256_u4_stack.rs
@@ -1,0 +1,639 @@
+use std::{collections::HashMap, vec};
+use crate::treepp::{pushable, script, Script};
+use crate::u4::{u4_add_stack::*, u4_logic_stack::*, u4_rot_stack::*, u4_shift_stack::*, u4_std::*};
+use bitcoin_script_stack::stack::{StackTracker, StackVariable};
+
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const INITSTATE_MAPPING : [char; 8] = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+
+const INITSTATE: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
+    //55 bytes fits in one block
+    //56 to 64 requires two block padding
+
+    let mut chunks = num_bytes / 64;
+    chunks += 1;
+
+    if num_bytes % 64 > 55 {
+
+        let mut bytes_left_first_padding = 64 - (num_bytes % 64);
+        bytes_left_first_padding -= 1; // remove the 0x80 that will be added always
+        let script1 = script! {
+            8
+            0
+            for _ in 0..bytes_left_first_padding { //can optimize with a couple of dups
+                0
+                0
+            }
+        };
+
+        let script2 = script! {
+            0
+            OP_DUP
+            for _ in 0..59 {
+                OP_2DUP
+            }
+            { u4_number_to_nibble( num_bytes * 8 ) }
+        };
+
+        
+        chunks += 1;
+
+        let mut results = Vec::new();
+        for _ in 0..(chunks - 2) {
+            results.push(script!{});
+        }
+        results.push(script1);
+        results.push(script2);
+
+        (results, chunks)
+
+
+    } else {
+        let (script1,_) = padding(num_bytes);
+        let mut results = Vec::new();
+        for _ in 0..(chunks - 1) {
+            results.push(script!{});
+        }
+        results.push(script1);
+        (results, chunks)
+    }
+
+}
+
+
+
+
+pub fn padding(num_bytes: u32) -> (Script, u32) {
+
+    let l = (num_bytes * 8) as i32;
+    let mut k = 512 - l - 8 - 32;     // heres is usually minus 8, but as 
+                                            // there will be never that many bytes to process
+                                            // one u32 will be enough
+    let mut chunks = 1;
+    while k < 0 {
+        k += 512;
+        chunks += 1;
+    }
+    let zeros = k/16;
+    let extras = k % 16;
+
+    ( script! {
+        8
+        0
+        for i in 0..zeros {
+            if i == 0 {
+                0
+                OP_DUP
+                OP_2DUP
+            } else {
+                OP_2DUP
+                OP_2DUP
+            }
+        }
+        if extras > 0 {
+            0
+            0
+        }
+        { u4_number_to_nibble( l as u32 ) }
+      },
+      chunks
+    )
+
+}
+
+
+pub fn calculate_s_stack(  stack: &mut StackTracker, 
+                          number: StackVariable, 
+                     shift_table: StackVariable, 
+                     shift_value: Vec<u32>, 
+                   last_is_shift: bool,  
+                    lookup_table: StackVariable, 
+                     logic_table: StackVariable,
+                 do_xor_with_and:bool ) -> StackVariable 
+{
+    let mut results = Vec::new();
+    for nib in 0..8 {
+        u4_rrot_nib_from_u32(stack, shift_table, number, nib, shift_value[0], false);
+        u4_rrot_nib_from_u32(stack, shift_table, number, nib, shift_value[1], false);
+        u4_logic_stack_nib(stack, lookup_table, logic_table, do_xor_with_and);
+        u4_rrot_nib_from_u32(stack, shift_table, number, nib, shift_value[2], last_is_shift);
+        results.push(u4_logic_stack_nib(stack, lookup_table, logic_table, do_xor_with_and));
+    }
+
+    let var = stack.join_count(&mut results[0], 7);
+    stack.rename(var, "s");
+    var
+
+}
+
+pub fn ch_calculation_stack(stack: &mut StackTracker, e: StackVariable, f:StackVariable, g:StackVariable, lookup: StackVariable, andtable: StackVariable) -> StackVariable {
+
+    let mut ret = Vec::new();
+    for nib in 0..8 {
+        stack.copy_var_sub_n(e, nib);   // e[nib]
+        stack.op_dup();                        // e e
+
+        stack.op_negate();                     // e ~e
+        stack.number(15);
+        stack.op_add();
+
+        stack.copy_var_sub_n(g, nib);    // e ~e g[nib]
+
+        u4_logic_with_table_stack(stack, lookup, andtable); // e  ( ~e & g )
+        stack.op_swap();                       // ( ~e & g ) e
+
+        stack.copy_var_sub_n(f, nib);   // ( ~e & g ) e f[nib]
+
+        u4_logic_with_table_stack(stack, lookup, andtable); // ( ~e & g ) (e & f)
+        ret.push(u4_xor_with_and_stack(stack, lookup, andtable)); // ( ~e & g ) ^ (e & f)
+
+    }
+
+    stack.join_count(&mut ret[0], 7);
+    stack.rename(ret[0], "ch");
+    ret[0]
+
+}
+
+pub fn maj_calculation_stack(stack: &mut StackTracker, a: StackVariable, b:StackVariable, c:StackVariable, lookup: StackVariable, andtable: StackVariable) -> StackVariable {
+
+    let mut ret = Vec::new();
+    for nib in 0..8 {
+        
+        stack.copy_var_sub_n(a, nib);              // a[nib]
+
+        stack.copy_var_sub_n(b, nib);              // a b[nib]
+
+        stack.op_2dup();                                  // a b a b
+
+        u4_xor_with_and_stack(stack, lookup, andtable);  // a b (a^b)
+
+        stack.copy_var_sub_n(c, nib);                     // a b (a^b) c
+
+        u4_logic_with_table_stack(stack, lookup, andtable); // a b ((a^b) & c)
+
+        stack.op_rot();
+        stack.op_rot();                                  // ((a^b) & c) a b
+
+        u4_logic_with_table_stack(stack, lookup, andtable); // ((a^b) & c) (a & b)
+
+        ret.push(u4_xor_with_and_stack(stack, lookup, andtable));  // ((a^b) & c) ^ (a & b)
+
+    }
+
+    stack.join_count(&mut ret[0], 7);
+    stack.rename(ret[0], "maj");
+    ret[0]
+
+}
+
+
+pub fn sha256_stack(mut stack: &mut StackTracker, num_bytes: u32) -> Script {
+
+    // up to 55 is one block and always supports add table
+    // probably up to 68 bytes I can afford to load the add tables for the first chunk (but have I would have to unload it)
+
+    let (mut padding_scripts, chunks) = double_padding(num_bytes);
+    let mut bytes_per_chunk : Vec<u32> = Vec::new();
+    let mut bytes_remaining = num_bytes;
+    while bytes_remaining > 0 {
+        if bytes_remaining > 64 {
+            bytes_per_chunk.push( 64);
+            bytes_remaining -= 64;
+        } else {
+            bytes_per_chunk.push( bytes_remaining);
+            bytes_remaining = 0;
+        }
+    } 
+    if bytes_per_chunk.len() < chunks as usize {
+        bytes_per_chunk.push(0);
+    }
+    //println!("{:?}", bytes_per_chunk);
+    //println!("{:?}", padding_scripts);
+
+
+    let mut use_add_table = chunks == 1;
+
+    let mut message = (0..num_bytes*2).map(|i| stack.define(1, &format!("message[{}]", i))).collect::<Vec<StackVariable>>();
+
+    let (mut modulo,mut quotient) = match use_add_table {
+        true => {
+            ( u4_push_modulo_table_stack(&mut stack), u4_push_quotient_table_stack(&mut stack) )
+        },
+        false => {
+            (StackVariable::null(), StackVariable::null())
+        }
+    };
+
+
+    stack.set_breakpoint("init");
+
+    let shift_tables = u4_push_shift_tables_stack(&mut stack);
+    let half_lookup = u4_push_lookup_table_stack(&mut stack);
+    let mut xor_table = u4_push_xor_table_stack(&mut stack);
+    let mut and_table = StackVariable::null();
+    
+    let mut varmap : HashMap<char, StackVariable> = HashMap::new();
+    let mut initstate : HashMap<char, StackVariable> = HashMap::new();
+
+    stack.set_breakpoint("load tables");
+
+
+    for c in 0..chunks {
+
+        //change tables
+        if c > 0 {
+            stack.drop(and_table);
+
+            xor_table = u4_push_xor_table_stack(&mut stack);
+            stack.set_breakpoint("change tables");
+        }
+
+        //move the message to the top of the stack
+        //this can be optimized only moving the las nibbles that would form an u32 with the first part of the padding 
+        let mut moved_message = (0..bytes_per_chunk[c as usize]*2)
+                             .map(|i| stack.move_var( message[i as usize] ))
+                             .collect::<Vec<StackVariable>>(); 
+        message.drain(0..moved_message.len());
+
+
+        stack.set_breakpoint("moved message");
+
+        //complete message with padding
+        stack.custom(padding_scripts.remove(0), 0, false, 0, "padding");
+        let len = moved_message.len();
+        if len < 128 {
+            for i in 0..(128 - len) {
+                moved_message.push( stack.define(1, &format!("padding[{}]", i)) );
+            }
+        }
+        stack.set_breakpoint("padding");
+
+        //redefine from nibbles to u32
+        assert!(moved_message.len() == 128);
+        let mut schedule = Vec::new();
+        for i in 0..16 {
+            let joined = stack.join_count(&mut moved_message[0], 7) ;
+            stack.rename(joined, &format!("schedule[{}]", i));
+            schedule.push(joined);
+            moved_message.drain(0..8);
+        }
+        stack.set_breakpoint("schedule");
+
+        
+        //schedule loop 
+        for i in 16..64 {
+            let mut s0 = calculate_s_stack(&mut stack, schedule[i-15], shift_tables, vec![7,18,3], true, half_lookup, xor_table, false);
+            let mut s1 = calculate_s_stack(&mut stack, schedule[i-2], shift_tables, vec![17,19,10], true, half_lookup, xor_table, false);
+            u4_add_stack(&mut stack, 8, 4, vec![schedule[i-16], schedule[i-7]], vec![&mut s0, &mut s1], vec![], quotient, modulo);
+            let sched_i = stack.from_altstack_joined(8, &format!("schedule[{}]", i));
+            schedule.push(sched_i);
+            
+            stack.set_breakpoint(&format!("schedule[{}]", i));
+        }
+
+
+        //exchange xor with and table
+        stack.to_altstack_count(64);
+        stack.drop(xor_table);
+
+        and_table = u4_push_and_table_stack(stack);
+        stack.from_altstack_count(64);
+
+
+        if c == 0 {
+            for i in 0..INITSTATE.len() {
+                let var = stack.number_u32(INITSTATE[i]);
+                varmap.insert(INITSTATE_MAPPING[i], var);
+            }
+        } else {
+
+            for i in 0..INITSTATE_MAPPING.len() {
+                varmap.insert(INITSTATE_MAPPING[i], stack.from_altstack_joined(8, &format!("{}", INITSTATE_MAPPING[i])));
+                initstate.insert(INITSTATE_MAPPING[i], stack.copy_var(varmap[&INITSTATE_MAPPING[i]]));
+            }
+        }
+
+        for i in 0..64 {
+
+            //calculated that after 6 iterations of chunk 2 the add tables fit in the stack
+            if i == 6 && c == 1 {
+                modulo = u4_push_modulo_table_stack(&mut stack);
+                quotient = u4_push_quotient_table_stack(&mut stack);
+                use_add_table = true;
+            }
+
+            //Calculate S1
+            let mut s1 = calculate_s_stack( stack, varmap[&'e'], shift_tables, vec![6, 11, 25], false, half_lookup, and_table, true) ;
+
+            //calculate ch
+            let mut ch = ch_calculation_stack(&mut stack, varmap[&'e'], varmap[&'f'], varmap[&'g'], half_lookup, and_table);
+
+            //calculate temp1 
+            let mut h = varmap[&'h'].clone();
+            if use_add_table {
+                u4_add_stack(&mut stack, 8, 2, vec![],  vec![&mut schedule[i]], vec![K[i as usize]], quotient, modulo);
+                let mut parts = stack.from_altstack_count(8);
+                let mut part1 = stack.join_count(&mut parts[0], 7);
+                u4_add_stack(&mut stack, 8, 4, vec![],  vec![&mut s1, &mut ch, &mut h, &mut part1, ],vec![], quotient, modulo);
+            } else {
+                u4_add_stack(&mut stack, 8, 5, vec![],  vec![&mut s1, &mut ch, &mut h, &mut schedule[i] ],vec![K[i as usize]], StackVariable::null(), StackVariable::null());
+            }
+            let mut temp1 = stack.from_altstack_joined(8, "temp1");
+
+            //Calculate S0
+            let mut s0 = calculate_s_stack( stack, varmap[&'a'], shift_tables, vec![2, 13, 22], false, half_lookup, and_table, true) ;
+
+            //Calculate maj
+            let mut maj = maj_calculation_stack(&mut stack, varmap[&'a'], varmap[&'b'], varmap[&'c'], half_lookup, and_table);
+
+
+            //calculate a = temp1 + s0 + maj
+            u4_add_stack(&mut stack, 8, 3, vec![temp1],  vec![&mut s0, &mut maj] ,vec![], quotient, modulo);
+            let temp_a = stack.from_altstack_joined(8, "temp_a");
+
+            //e = d + temp1 (consumes d)
+            let mut d = varmap[&'d'].clone();
+            u4_add_stack(&mut stack, 8, 2, vec![],  vec![&mut d, &mut temp1] ,vec![], quotient, modulo);
+            let temp_e = stack.from_altstack_joined(8, "temp_e");
+
+            //reorder variables
+            varmap.insert('h', varmap[&'g']); 
+            varmap.insert('g', varmap[&'f']);
+            varmap.insert('f', varmap[&'e']);
+            varmap.insert('e', temp_e);
+            varmap.insert('d', varmap[&'c']);
+            varmap.insert('c', varmap[&'b']);
+            varmap.insert('b', varmap[&'a']);
+            varmap.insert('a', temp_a);
+
+            for c in INITSTATE_MAPPING.iter() {
+                stack.rename(varmap[c], &format!("{}", c));
+            }
+
+
+            stack.set_breakpoint(&format!("loop[{}]", i));
+        }
+
+
+        if c == 0 {
+            //first chunk adds with init state
+            for i in (0..INITSTATE_MAPPING.len()).rev() {
+                let mut x = varmap.get(&INITSTATE_MAPPING[i]).unwrap().clone();
+                u4_add_stack(stack, 8, 2, vec![], vec![&mut x], vec![INITSTATE[i]], quotient, modulo);
+            }
+        } else {
+
+            for i in (0..INITSTATE_MAPPING.len()).rev() {
+                let mut prev_state = initstate.get(&INITSTATE_MAPPING[i]).unwrap().clone();
+                let mut x = varmap.get(&INITSTATE_MAPPING[i]).unwrap().clone();
+                u4_add_stack(stack, 8, 2, vec![], vec![&mut x, &mut prev_state],vec![], quotient, modulo);
+            }
+        }
+
+        stack.set_breakpoint("var addition");
+
+        // if last chunk drop the tables
+        if c == chunks - 1 {
+            if use_add_table && chunks == 2 {
+                stack.drop(quotient);
+                stack.drop(modulo);
+            }
+            stack.drop(and_table);
+            stack.drop(half_lookup);
+            stack.drop(shift_tables);
+            if use_add_table && chunks == 1 {
+                stack.drop(quotient);
+                stack.drop(modulo);
+            }
+        }
+        stack.set_breakpoint("dropped");
+
+
+    }
+
+    for i in 0..INITSTATE_MAPPING.len() {
+        *varmap.get_mut(&INITSTATE_MAPPING[i]).unwrap() = stack.from_altstack_joined(8, &format!("h{}", i));
+    }
+
+    stack.set_breakpoint("final");
+
+        
+    stack.get_script()
+
+
+}
+
+#[cfg(test)]
+mod tests {
+
+use crate::{execute_script, treepp::script};
+use super::*;
+use sha2::{Digest, Sha256};
+
+
+    #[test]
+    fn test_sizes_tmp() {
+        let mut stack = StackTracker::new();
+        let x = sha256_stack(&mut stack, 32);
+        println!("sha 32 bytes: {}",x.len());
+        println!("max stack: {}", stack.get_max_stack_size());
+
+        let mut stack = StackTracker::new();
+        let x = sha256_stack(&mut stack, 80);
+        println!("sha 80 bytes: {}",x.len());
+        println!("max stack: {}", stack.get_max_stack_size());
+    }
+
+        
+    #[test]
+    fn test_shatemp() {
+
+        let mut stack = StackTracker::new();
+        stack.custom(script!{
+            {u4_number_to_nibble(0xdeadbeaf)}
+            {u4_number_to_nibble(0x01020304)}  
+        }, 0, false, 0, "message");
+
+        sha256_stack(&mut stack, 8);
+        stack.run();
+        
+    }
+
+    fn test_sha256( hex_in : &str ) {
+
+        let mut hasher = Sha256::new();
+        let data = hex::decode(hex_in).unwrap();
+        hasher.update(&data);
+        let result = hasher.finalize();
+        let res = hex::encode(result);
+        println!("Result: {}", res);
+        
+
+        let mut stack = StackTracker::new();
+        stack.custom(script!{ {u4_hex_to_nibbles(hex_in)}}, 0, false, 0, "message");
+
+        let shascript = sha256_stack(&mut stack, hex_in.len() as u32 / 2);
+
+
+        let script = script! {
+            { shascript } 
+            { u4_hex_to_nibbles(res.as_str())}
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+
+            for i in 1..64 {
+                {i}
+                OP_ROLL
+            }
+
+            for _ in 0..64 {
+                OP_FROMALTSTACK
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+
+        };
+
+
+        let res = execute_script(script);
+        assert!(res.success);
+
+    }
+
+    #[test]
+    fn test_sha256_strs() {
+        let message = "Hello.";
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
+        test_sha256(&hex);
+        let message = "This is a longer message that still fits in one block!";
+        let hex : String = message.as_bytes().iter().map(|&b| format!("{:02x}", b)).collect();
+        test_sha256(&hex)
+    }
+
+    #[test]
+    fn test_sha256_two_blocks() {
+        let hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaa";
+        test_sha256(&hex);
+        let hex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001122334455667788";
+        test_sha256(&hex);
+        let hex = "7788ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaaaaaaaaaa001122334455667788";
+        test_sha256(&hex);
+    }
+
+    #[test]
+    fn test_padding() {
+
+        let (script, _) = padding(1);
+        let script = script! {
+            { 0}
+            { 1 }
+            { script }
+            { u4_drop(128) }
+            OP_TRUE
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+
+ 
+    }
+    
+    #[test]
+    fn test_split_padding() {
+
+        for num_bytes in 0..150 {
+
+            let (padding_scripts, chunks) = double_padding(num_bytes);
+
+            let script = script! {
+                for _ in 0..num_bytes {
+                    { 1 }
+                    { 0 }
+                }
+                OP_DEPTH
+                OP_TOALTSTACK
+                for script in padding_scripts {
+                    { script }
+                    OP_DEPTH
+                    OP_TOALTSTACK
+                }
+                { u4_drop(chunks*128) }
+                OP_DEPTH
+                OP_TOALTSTACK
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            assert!(res.success);
+
+        }
+ 
+    }
+
+    #[test]
+    fn test_genesis_block() {
+        // the genesis block header of bitcoin
+        // version previous-block merkle-root time bits nonce
+        // 01000000 0000000000000000000000000000000000000000000000000000000000000000 3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a 29ab5f49 ffff001d 1dac2b7c
+        let block_header = "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c";
+        let mut hasher = Sha256::new();
+        let data = hex::decode(block_header).unwrap();
+        hasher.update(&data);
+        let mut result = hasher.finalize();
+        hasher = Sha256::new();
+        hasher.update(result);
+        result = hasher.finalize();
+        let res = hex::encode(result);
+        let genesis_block_hash = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
+        assert_eq!(res.as_str(), genesis_block_hash);
+
+
+        let mut stack = StackTracker::new();
+        stack.custom(script!{ {u4_hex_to_nibbles(block_header)}}, 0, false, 0, "message");
+        sha256_stack(&mut stack, block_header.len() as u32 / 2);
+        let shascript = sha256_stack(&mut stack, 32);
+
+        let script = script! {
+
+            { shascript }
+            
+            { u4_hex_to_nibbles(res.as_str())}
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+
+            for i in 1..64 {
+                {i}
+                OP_ROLL
+            }
+
+            for _ in 0..64 {
+                OP_FROMALTSTACK
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+
+
+        };
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+
+}

--- a/src/u4/mod.rs
+++ b/src/u4/mod.rs
@@ -1,5 +1,9 @@
-pub mod u4_add;
-pub mod u4_logic;
-pub mod u4_rot;
-pub mod u4_shift;
 pub mod u4_std;
+pub mod u4_shift;
+pub mod u4_shift_stack;
+pub mod u4_logic;
+pub mod u4_logic_stack;
+pub mod u4_rot;
+pub mod u4_rot_stack;
+pub mod u4_add;
+pub mod u4_add_stack;

--- a/src/u4/u4_add_stack.rs
+++ b/src/u4/u4_add_stack.rs
@@ -1,0 +1,183 @@
+use bitcoin_script_stack::stack::{StackTracker, StackVariable};
+
+use super::u4_add::{u4_add_no_table_internal, u4_push_modulo_table, u4_push_quotient_table};
+
+pub fn u4_push_quotient_table_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(65, u4_push_quotient_table(), "quotient_table")
+}
+
+pub fn u4_push_modulo_table_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(65, u4_push_modulo_table(), "modulo_table")
+}
+
+pub fn u4_arrange_nibbles_stack( nibble_count: u32, stack: &mut StackTracker, to_copy: Vec<StackVariable>, mut to_move: Vec<& mut StackVariable>, constants: Vec<u32> )  {
+
+    let mut constant_parts : Vec<Vec<u32>> = Vec::new();
+
+    for n in constants {
+        let parts = (0..8).rev().map(|i| (n >> (i * 4)) & 0xF ).collect();
+        constant_parts.push(parts);
+    }
+
+    for i in 0..nibble_count {
+
+        for var in to_copy.iter() {
+            stack.copy_var_sub_n(*var, i);
+        }
+
+        for var in to_move.iter_mut() {
+            stack.move_var_sub_n(var, 0);
+        }
+
+        for parts in constant_parts.iter() {
+            stack.number(parts[i as usize]);
+        }
+
+    }
+
+
+}   
+
+
+pub fn u4_add_internal_stack( stack: &mut StackTracker, nibble_count: u32, number_count: u32, quotient_table: StackVariable, modulo_table: StackVariable ) {
+
+    for i in 0..nibble_count {
+
+        //extra add to add the carry from previous addition
+        if i > 0 {
+            stack.op_add();
+        }
+
+        //add the column of nibbles (needs one less add than nibble count)
+        for _ in 0..number_count-1 {
+            stack.op_add();
+        }
+        
+        // duplicate the result to be used to get the carry except for the last nibble
+        if i < nibble_count -1 {
+            stack.op_dup();
+        }
+        
+        //get the modulo of the addition
+        stack.get_value_from_table(modulo_table, None);
+        stack.to_altstack();
+        
+        //we don't care about the last carry
+        if i < nibble_count - 1 {
+            //obtain the quotinent to be used as carry for the next addition
+            stack.get_value_from_table(quotient_table, None);
+        }
+    }
+
+}
+
+
+pub fn u4_add_no_table_stack( stack: &mut StackTracker, nibble_count: u32, number_count: u32) {
+    stack.custom(u4_add_no_table_internal(nibble_count, number_count), nibble_count*number_count, false, nibble_count, "add_no_table");
+}
+
+pub fn u4_add_stack( stack: &mut StackTracker, 
+            nibble_count: u32, 
+            number_count: u32, 
+            to_copy: Vec<StackVariable>, 
+            to_move: Vec<& mut StackVariable>, 
+            constants: Vec<u32>, 
+            quotient_table: StackVariable, 
+            modulo_table: StackVariable ) 
+{
+    u4_arrange_nibbles_stack(nibble_count, stack, to_copy, to_move, constants);
+    if !modulo_table.is_null() && !quotient_table.is_null() {
+        u4_add_internal_stack(stack, nibble_count, number_count, quotient_table, modulo_table);
+    } else { 
+        u4_add_no_table_stack(stack, nibble_count, number_count);
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+use crate::u4::{u4_add_stack::*, u4_std::verify_n};
+
+    #[test]
+    fn test_arrange_stack() {
+        let mut stack = StackTracker::new();
+
+        let mut x = stack.number_u32(0x00112233);
+        let y = stack.number_u32(0x99887766);
+        u4_arrange_nibbles_stack(8, &mut stack, vec![y], vec![&mut x], vec![0xaabbccdd]);
+
+        //0x998 877 66
+        //0x001 12 233
+        //0xaa bbc cdd
+        
+        stack.number_u32(0x90a90a81);
+        stack.number_u32(0xb81b72c7);
+        stack.number_u32(0x2c63d63d);
+
+        stack.custom(verify_n(24), 24+3, false, 0, "verify");
+        stack.drop(y);
+        stack.op_true();
+
+        let res = stack.run();
+        assert!(res.success);
+
+    }
+
+    #[test]
+    fn test_add_internal_stack() {
+        let mut stack = StackTracker::new();
+
+        let modulo = u4_push_modulo_table_stack(&mut stack);
+        let quotient = u4_push_quotient_table_stack(&mut stack);
+
+        let mut x = stack.number_u32(0x00112233);
+        let y = stack.number_u32(0x99887766);
+        u4_arrange_nibbles_stack(8, &mut stack, vec![y], vec![&mut x], vec![0xaabbccdd]);
+
+        u4_add_internal_stack(&mut stack, 8, 3, quotient, modulo);
+
+        let mut vars = stack.from_altstack_count(8);
+        stack.join_count(&mut vars[0], 7);
+
+        stack.number_u32(0x44556676);
+        stack.custom(verify_n(8), 2, false, 0, "verify");
+        stack.drop(y);
+        stack.drop(quotient);
+        stack.drop(modulo);
+        stack.op_true();
+
+
+        let res = stack.run();
+        assert!(res.success);
+
+
+    }
+
+
+    #[test]
+    fn test_add_no_table_stack() {
+        let mut stack = StackTracker::new();
+
+        let mut x = stack.number_u32(0x00112233);
+        let y = stack.number_u32(0x99887766);
+        u4_arrange_nibbles_stack(8, &mut stack, vec![y], vec![&mut x], vec![0xaabbccdd]);
+
+        u4_add_no_table_stack(&mut stack, 8, 3);
+
+        let mut vars = stack.from_altstack_count(8);
+        stack.join_count(&mut vars[0], 7);
+
+        stack.number_u32(0x44556676);
+        stack.custom(verify_n(8), 2, false, 0, "verify");
+        stack.drop(y);
+        stack.op_true();
+
+
+        let res = stack.run();
+        assert!(res.success);
+
+
+    }
+
+}

--- a/src/u4/u4_logic.rs
+++ b/src/u4/u4_logic.rs
@@ -4,14 +4,17 @@ use crate::u4::u4_add::u4_arrange_nibbles;
 
 use super::u4_std::u4_drop;
 
+
 // And / Or / Xor tables are created here and can be used for bitwise operations
 // Sadly for sha256 those does not fit well in memory at the same time and therefor
 // and optimized version that is called half table is used for the operations
 
 // As this operations are commutative there is no need to have the tables for both
-// i.e: 15 & 7  AND  7 & 15  as the result would be the same, so half of the values
+// i.e: 15 & 7  AND  7 & 15  as the result would be the same, so half of the values 
 // are stored on the tables, and to be used the values are ordered using min/max
 // before using the lookup table
+
+
 
 pub fn u4_push_or_table() -> Script {
     script! {
@@ -689,7 +692,9 @@ pub fn u4_push_and_table() -> Script {
     }
 }
 
-pub fn u4_drop_logic_table() -> Script { u4_drop(16 * 16) }
+pub fn u4_drop_logic_table() -> Script {
+    u4_drop(16 * 16)
+}
 
 pub fn u4_push_lookup() -> Script {
     script! {
@@ -710,6 +715,147 @@ pub fn u4_push_lookup() -> Script {
         32
         16
         OP_0   //zero is extra so it can be used as lshift4 changing the offset
+    }
+}
+
+pub fn u4_push_half_xor_table() -> Script {
+    script! {
+        OP_0
+        OP_1
+        OP_0
+        OP_2
+        OP_3
+        OP_0
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_0
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_1
+        OP_0
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_2
+        OP_3
+        OP_0
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_0
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_1
+        OP_0
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_2
+        OP_3
+        OP_0
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_3
+        OP_2
+        OP_1
+        OP_0
+        OP_12
+        OP_13
+        OP_14
+        OP_15
+        OP_8
+        OP_9
+        OP_10
+        OP_11
+        OP_4
+        OP_5
+        OP_6
+        OP_7
+        OP_0
+        OP_13
+        OP_12
+        OP_15
+        OP_14
+        OP_9
+        OP_8
+        OP_11
+        OP_10
+        OP_5
+        OP_4
+        OP_7
+        OP_6
+        OP_1
+        OP_0
+        OP_14
+        OP_15
+        OP_12
+        OP_13
+        OP_10
+        OP_11
+        OP_8
+        OP_9
+        OP_6
+        OP_7
+        OP_4
+        OP_5
+        OP_2
+        OP_3
+        OP_0
+        OP_15
+        OP_14
+        OP_13
+        OP_12
+        OP_11
+        OP_10
+        OP_9
+        OP_8
+        OP_7
+        OP_6
+        OP_5
+        OP_4
+        OP_3
+        OP_2
+        OP_1
+        OP_0
     }
 }
 
@@ -820,7 +966,9 @@ pub fn u4_push_half_and_table() -> Script {
     }
 }
 
-pub fn u4_drop_half_and() -> Script { u4_drop(136) }
+pub fn u4_drop_half_and() -> Script {
+    u4_drop(136)
+}
 
 pub fn u4_push_half_lookup() -> Script {
     script! {
@@ -843,9 +991,13 @@ pub fn u4_push_half_lookup() -> Script {
     }
 }
 
-pub fn u4_drop_half_lookup() -> Script { u4_drop(16) }
+pub fn u4_drop_half_lookup() -> Script {
+    u4_drop(16)
+}
 
-pub fn u4_drop_lookup() -> Script { u4_drop(17) }
+pub fn u4_drop_lookup() -> Script {
+    u4_drop(17)
+}
 
 pub fn u4_sort() -> Script {
     script! {
@@ -894,7 +1046,7 @@ pub fn u4_xor_with_and(lookup: u32, table: u32) -> Script {
     }
 }
 
-pub fn u4_xor_half_table(lookup: u32) -> Script {
+pub fn u4_xor_with_and_table(lookup: u32) -> Script {
     script! {
         OP_2DUP
         { u4_and_half_table( lookup+2) }
@@ -905,14 +1057,15 @@ pub fn u4_xor_half_table(lookup: u32) -> Script {
     }
 }
 
-pub fn u4_logic_nibs(nibble_count: u32, bases: Vec<u32>, offset: u32, is_xor: bool) -> Script {
+
+pub fn u4_logic_nibs(nibble_count: u32, bases: Vec<u32>, offset: u32, do_xor_with_and: bool ) -> Script {
     let numbers = bases.len() as u32;
     script! {
         { u4_arrange_nibbles(nibble_count, bases) }
         for nib in 0..nibble_count {
             for i in 0..numbers-1 {
-                if is_xor {
-                    { u4_xor_half_table( offset - i - nib * numbers ) }
+                if do_xor_with_and {
+                    { u4_xor_with_and_table( offset - i - nib * numbers ) }
                 } else {
                     { u4_and_half_table( offset - i - nib * numbers ) }
                 }
@@ -923,20 +1076,46 @@ pub fn u4_logic_nibs(nibble_count: u32, bases: Vec<u32>, offset: u32, is_xor: bo
     }
 }
 
-pub fn u4_and_u32(bases: Vec<u32>, offset: u32) -> Script { u4_logic_nibs(8, bases, offset, false) }
+pub fn u4_and_u32(bases: Vec<u32>, offset: u32) -> Script {
+    u4_logic_nibs(8, bases, offset, false)
+}
 
-pub fn u4_xor_u32(bases: Vec<u32>, offset: u32) -> Script { u4_logic_nibs(8, bases, offset, true) }
+pub fn u4_xor_u32(bases: Vec<u32>, offset: u32, do_xor_with_and: bool) -> Script {
+    u4_logic_nibs(8, bases, offset, do_xor_with_and)
+}
 
 #[cfg(test)]
 mod tests {
 
-    use crate::treepp::{execute_script, script};
     use crate::u4::u4_logic::*;
     use crate::u4::u4_shift::{u4_drop_rshift_tables, u4_push_rshift_tables};
     use crate::u4::u4_std::{u4_number_to_nibble, u4_u32_verify_from_altstack};
+    use crate::{execute_script, treepp::script};
 
     #[test]
     fn test_xor_u32() {
+        let script = script! {
+            { u4_push_half_xor_table() }
+            { u4_push_half_lookup()}
+            { u4_number_to_nibble(0x87878787)}
+            { u4_number_to_nibble(0xFF010203)}
+            { u4_number_to_nibble(0xAABBCCDD)}
+            { u4_logic_nibs( 8, vec![0,8,16], 24, false )}
+            { u4_drop_half_lookup() }
+            { u4_drop_half_and() }
+
+            { u4_number_to_nibble(0xD23D4959)}
+            { u4_u32_verify_from_altstack() }
+            OP_TRUE
+
+
+        };
+
+        let res = execute_script(script);
+        assert!(res.success);
+    }
+    #[test]
+    fn test_xor_u32_with_and() {
         let script = script! {
             { u4_push_half_and_table() }
             { u4_push_half_lookup()}
@@ -960,14 +1139,15 @@ mod tests {
 
     #[test]
     fn test_logic_u32_size() {
-        let xor_x2 = u4_logic_nibs(8, vec![0, 8], 24, true);
+        let xor_x2 = u4_logic_nibs( 8, vec![0,8], 24, true );
         println!("{}", xor_x2.len());
-        let xor_x3 = u4_logic_nibs(8, vec![0, 8, 16], 24, true);
+        let xor_x3 = u4_logic_nibs( 8, vec![0,8,16], 24, true );
         println!("{}", xor_x3.len());
-        let xor_x2 = u4_logic_nibs(8, vec![0, 8], 24, false);
+        let xor_x2 = u4_logic_nibs( 8, vec![0,8], 24, false );
         println!("{}", xor_x2.len());
-        let xor_x3 = u4_logic_nibs(8, vec![0, 8, 16], 24, false);
+        let xor_x3 = u4_logic_nibs( 8, vec![0,8,16], 24, false );
         println!("{}", xor_x3.len());
+
     }
 
     #[test]
@@ -1002,7 +1182,7 @@ mod tests {
                     { u4_push_half_lookup()}
                     {x}      // X
                     {y}       // Y
-                    { u4_xor_half_table(2)}
+                    { u4_xor_with_and_table(2)}
                     { x ^ y}
                     OP_EQUALVERIFY
                     { u4_drop_half_lookup() }

--- a/src/u4/u4_logic_stack.rs
+++ b/src/u4/u4_logic_stack.rs
@@ -1,0 +1,181 @@
+use bitcoin_script_stack::stack::{StackTracker, StackVariable};
+use crate::treepp::{pushable, script, Script};
+
+use crate::u4::u4_logic::u4_sort;
+
+use super::{u4_add_stack::u4_arrange_nibbles_stack, u4_logic::{u4_push_half_and_table, u4_push_half_xor_table}};
+
+
+pub fn u4_push_and_table_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(136, u4_push_half_and_table(), "and_table")
+}
+
+pub fn u4_push_xor_table_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(136, u4_push_half_xor_table(), "xor_table")
+}
+
+pub fn u4_push_half_lookup_0_based() -> Script {
+    script! {
+        120
+        119
+        117
+        114
+        110
+        105
+        99
+        92
+        84
+        75
+        65
+        54
+        42
+        29
+        15
+        0
+    }
+}
+
+pub fn u4_push_lookup_table_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(16, u4_push_half_lookup_0_based(), "lookup_table")
+}
+
+
+pub fn u4_logic_with_table_stack(stack: &mut StackTracker, lookup_table: StackVariable, logic_table: StackVariable) -> StackVariable {
+    stack.custom(u4_sort(), 0, false, 0, "sort");
+    stack.get_value_from_table(lookup_table, None);
+    stack.op_add();
+    stack.get_value_from_table(logic_table, None)
+}
+
+//(a xor b) = (a + b) - 2*(a & b)) = b - 2(a&b) + a
+pub fn u4_xor_with_and_stack(stack: &mut StackTracker, lookup_table: StackVariable, logic_table: StackVariable) -> StackVariable {
+    stack.op_2dup();
+    u4_logic_with_table_stack(stack, lookup_table, logic_table);
+    stack.op_dup();
+    stack.op_add();
+    stack.op_sub();
+    stack.op_add()
+}
+
+pub fn u4_logic_stack_nib(stack: &mut StackTracker, lookup_table: StackVariable, logic_table: StackVariable, do_xor_with_and: bool ) -> StackVariable {
+    if do_xor_with_and { 
+        u4_xor_with_and_stack(stack, lookup_table, logic_table)
+    } else {
+        u4_logic_with_table_stack(stack, lookup_table, logic_table)
+    }
+}
+
+pub fn u4_logic_stack(stack: &mut StackTracker, nibble_count: u32, numbers: Vec<StackVariable>, lookup_table: StackVariable, logic_table: StackVariable, do_xor_with_and: bool )  {
+
+    let numnber_count = numbers.len();
+    u4_arrange_nibbles_stack(nibble_count, stack, numbers, vec![] , vec![]);
+
+    for _ in 0..nibble_count {
+        for _ in 0..numnber_count-1 {
+            if do_xor_with_and { 
+                u4_xor_with_and_stack(stack, lookup_table, logic_table);
+            } else {
+                u4_logic_with_table_stack(stack, lookup_table, logic_table);
+            }
+            stack.to_altstack();
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_script_stack::stack::StackTracker;
+    use super::*;
+
+
+    #[test]
+    fn test_xor_half() {
+        for x in 0..16 {
+            for y in 0..16 {
+
+                let mut stack = StackTracker::new();
+                let xor = u4_push_xor_table_stack(&mut stack);
+                let lookup = u4_push_lookup_table_stack(&mut stack);
+
+                stack.number(x);
+                stack.number(y);
+
+                u4_logic_with_table_stack(&mut stack, lookup, xor);
+
+                stack.number( x^y);
+                
+                stack.op_equalverify();
+
+                stack.drop(lookup);
+                stack.drop(xor);
+
+                stack.op_true();
+
+                assert!(stack.run().success);
+
+            }
+        }
+    }
+
+
+    #[test]
+    fn test_xor_with_and_half() {
+        for x in 0..16 {
+            for y in 0..16 {
+
+                let mut stack = StackTracker::new();
+                let and = u4_push_and_table_stack(&mut stack);
+                let lookup = u4_push_lookup_table_stack(&mut stack);
+
+                stack.number(x);
+                stack.number(y);
+
+                u4_xor_with_and_stack(&mut stack, lookup, and);
+
+                stack.number( x^y);
+                
+                stack.op_equalverify();
+
+                stack.drop(lookup);
+                stack.drop(and);
+
+                stack.op_true();
+
+                assert!(stack.run().success);
+
+            }
+        }
+    }
+
+
+    #[test]
+    fn test_and_half() {
+        for x in 0..16 {
+            for y in 0..16 {
+
+                let mut stack = StackTracker::new();
+                let and = u4_push_and_table_stack(&mut stack);
+                let lookup = u4_push_lookup_table_stack(&mut stack);
+
+                stack.number(x);
+                stack.number(y);
+
+                u4_logic_with_table_stack(&mut stack, lookup, and);
+
+                stack.number( x&y);
+                
+                stack.op_equalverify();
+
+                stack.drop(lookup);
+                stack.drop(and);
+
+                stack.op_true();
+
+                assert!(stack.run().success);
+
+            }
+        }
+    }
+
+}

--- a/src/u4/u4_rot.rs
+++ b/src/u4/u4_rot.rs
@@ -3,12 +3,14 @@ use crate::u4::u4_shift::*;
 
 // rot right for n bits is constructed using shifting operations of two nibbles
 // also, there is a function to prepare the nibbles to be shifted
-// so if 0xff000001 is shifted right, then the nibble 1 is copied to the front to be shifted into f
+// so if 0xff000001 is shifted right, then the nibble 1 is copied in front to be shifted into f
+
 
 pub fn u4_push_rrot_tables() -> Script {
     script! {
-       {  u4_push_2_nib_rshift_tables() }
+       {  u4_push_2_nib_rshift_tables() } 
     }
+
 }
 
 pub fn u4_drop_rrot_tables() -> Script {
@@ -38,7 +40,8 @@ pub fn u4_prepare_number(shift: u32, number_pos: u32, is_shift: bool) -> Script 
     }
 }
 
-pub fn u4_rrot(shift: u32, number_pos: u32, shift_tables: u32, is_shift: bool) -> Script {
+
+pub fn u4_rrot(shift:u32, number_pos: u32, shift_tables: u32, is_shift: bool ) -> Script {
     let bit_shift = shift % 4;
     //TODO: to improve, some operations of shifting zero into zero can be removed
     script! {
@@ -46,30 +49,29 @@ pub fn u4_rrot(shift: u32, number_pos: u32, shift_tables: u32, is_shift: bool) -
 
         for i in 0..8 {
             if i == 7 {
-                OP_SWAP
+                OP_SWAP 
                 { u4_2_nib_shift_n(bit_shift, shift_tables - 2 + (9-i) ) }
             } else {
                 OP_OVER
                 { u4_2_nib_shift_n(bit_shift, shift_tables - 2 + (10-i) ) }
             }
-            OP_TOALTSTACK
+            OP_TOALTSTACK   
         }
     }
 }
 
+
 #[cfg(test)]
 mod tests {
 
-    use crate::treepp::{execute_script, script};
-    use crate::u4::{
-        u4_rot::*,
-        u4_std::{u4_drop, u4_number_to_nibble},
-    };
-    use rand::Rng;
+use crate::{execute_script, treepp::script};
+use rand::Rng;
+use crate::u4::{u4_std::{u4_drop, u4_number_to_nibble}, u4_rot::*}; 
 
     #[test]
     fn test_prepare_number() {
-        let script = script! {
+
+        let script  = script! {
             0
             255
             0
@@ -86,11 +88,13 @@ mod tests {
         };
 
         let _ = execute_script(script);
+    
     }
 
     #[test]
     fn test_prepare_number_for_shift() {
-        let script = script! {
+
+        let script  = script! {
             0
             255
             15
@@ -109,6 +113,8 @@ mod tests {
         let _ = execute_script(script);
     }
 
+
+
     fn rrot(x: u32, n: u32) -> u32 {
         if n == 0 {
             return x;
@@ -123,18 +129,20 @@ mod tests {
         x >> n
     }
 
+
     #[test]
     fn test_x() {
-        let script = script! {
+        let script  = script! {
             { u4_number_to_nibble(0x80_00_00_01) }
             { u4_prepare_number(3, 0, false) }
-            OP_OVER
+            OP_OVER 
         };
         let _ = execute_script(script);
     }
     #[test]
     fn test_rrot_shift() {
-        let script = script! {
+
+        let script  = script! {
             { u4_push_rrot_tables() }
             { u4_number_to_nibble(0xF0_FF_FF_FF) }
             { u4_rrot(10, 0, 8, true ) }
@@ -142,7 +150,7 @@ mod tests {
             { u4_drop(8) }
             { u4_drop_rrot_tables() }
 
-            { u4_number_to_nibble(rshift(0xF0FF_FFFF, 10)) }
+            { u4_number_to_nibble(rshift(0xF0FF_FFFF, 10)) } 
 
             for _ in 0..8 {
                 OP_FROMALTSTACK
@@ -152,7 +160,7 @@ mod tests {
                 OP_ROLL
                 OP_EQUALVERIFY
             }
-
+            
             OP_TRUE
         };
 
@@ -160,14 +168,17 @@ mod tests {
         assert!(res.success);
     }
 
+
     #[test]
     fn test_rrot() {
-        let script = script! {
+
+
+        let script  = script! {
             { u4_rrot(7, 0, 8, false ) }
         };
         println!("{}", script.len());
 
-        let script = script! {
+        let script  = script! {
             { u4_push_rrot_tables() }
             { u4_number_to_nibble(0xF0_00_10_01) }
 
@@ -186,13 +197,14 @@ mod tests {
                 OP_ROLL
                 OP_EQUALVERIFY
             }
-
+            
             OP_TRUE
         };
 
         let res = execute_script(script);
         assert!(res.success);
     }
+
 
     #[test]
     fn test_rrot_rand() {
@@ -202,10 +214,10 @@ mod tests {
             let mut n: u32 = rng.gen();
             n = n % 32;
             if n % 4 == 0 {
-                n += 1;
+                n+=1;
             }
 
-            let script = script! {
+            let script  = script! {
                 { u4_push_rrot_tables() }
                 { u4_number_to_nibble(x) }
 
@@ -224,7 +236,7 @@ mod tests {
                     OP_ROLL
                     OP_EQUALVERIFY
                 }
-
+                
                 OP_TRUE
             };
 
@@ -241,10 +253,10 @@ mod tests {
             let mut n: u32 = rng.gen();
             n = n % 32;
             if n % 4 == 0 {
-                n += 1;
+                n+=1;
             }
 
-            let script = script! {
+            let script  = script! {
                 { u4_push_rrot_tables() }
                 { u4_number_to_nibble(x) }
 
@@ -263,7 +275,7 @@ mod tests {
                     OP_ROLL
                     OP_EQUALVERIFY
                 }
-
+                
                 OP_TRUE
             };
 
@@ -271,4 +283,5 @@ mod tests {
             assert!(res.success);
         }
     }
+
 }

--- a/src/u4/u4_rot_stack.rs
+++ b/src/u4/u4_rot_stack.rs
@@ -1,0 +1,137 @@
+//use crate::treepp::{pushable, script, Script};
+//use sha2::digest::typenum::bit;
+
+use bitcoin_script_stack::stack::{StackTracker, StackVariable};
+
+use super::u4_shift_stack::{u4_2_nib_shift_stack, u4_rshift_stack};
+
+
+pub fn u4_rrot_nib_from_u32(stack: &mut StackTracker, tables: StackVariable, number: StackVariable, nib: u32, shift: u32, is_shift: bool) -> StackVariable {
+    let pos_shift = shift / 4;
+
+    if pos_shift > nib && is_shift {
+        return stack.number(0);
+    }
+
+    let y = (8 - pos_shift + nib - 1) % 8;
+    let x = (8 - pos_shift + nib ) % 8;
+
+    stack.copy_var_sub_n(number, x);
+
+    let bit_shift = shift % 4;
+
+    if y == 7 && is_shift {
+        u4_rshift_stack(stack, tables, bit_shift)
+    } else {
+        stack.copy_var_sub_n(number, y);
+        u4_2_nib_shift_stack(stack, tables, bit_shift )
+    }
+
+}
+
+pub fn u4_rrot_u32(stack: &mut StackTracker, tables: StackVariable, number: StackVariable, shift: u32, is_shift: bool) -> StackVariable {
+    let vars : Vec<StackVariable> = (0..8).map(|nib| u4_rrot_nib_from_u32(stack, tables, number, nib, shift, is_shift) ).collect();
+    let mut nib0 = vars[0].clone();
+    stack.join_count(&mut nib0, 7);
+    nib0
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use crate::treepp::{pushable, script};
+    use super::*;
+    use crate::u4::u4_shift_stack::u4_push_shift_tables_stack;
+    use bitcoin_script_stack::stack::StackTracker;
+    use rand::Rng;
+
+
+    fn rrot(x: u32, n: u32) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        (x >> n) | (x << (32 - n))
+    }
+
+    fn rshift(x: u32, n: u32) -> u32 {
+        if n == 0 {
+            return x;
+        }
+        x >> n
+    }
+
+    #[test]
+    fn test_rshift_rand() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..100 {
+            let x: u32 = rng.gen();
+            let mut n: u32 = rng.gen();
+            n = n % 32;
+            if n % 4 == 0 {
+                n+=1;
+            }
+
+
+            let mut stack = StackTracker::new();
+            let tables = u4_push_shift_tables_stack(&mut stack);
+            let pos = stack.number_u32(x);
+            u4_rrot_u32(&mut stack, tables, pos, n, true);
+
+            stack.number_u32( rshift(x, n) );
+
+            stack.custom(script!{
+                for i in 0..8 {
+                    { 8 - i}
+                    OP_ROLL
+                    OP_EQUALVERIFY
+                }
+            }, 2, false, 0, "verify");
+
+            stack.drop(pos);
+            stack.drop(tables);
+            stack.op_true();
+
+            assert!(stack.run().success);
+
+        }
+    }
+
+
+
+    #[test]
+    fn test_rrot_rand() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..100 {
+            let x: u32 = rng.gen();
+            let mut n: u32 = rng.gen();
+            n = n % 32;
+            if n % 4 == 0 {
+                n+=1;
+            }
+
+            let mut stack = StackTracker::new();
+            let tables = u4_push_shift_tables_stack(&mut stack);
+            let pos = stack.number_u32(x);
+            u4_rrot_u32(&mut stack, tables, pos, n, false);
+
+            stack.number_u32( rrot(x, n) );
+
+            stack.custom(script!{
+                for i in 0..8 {
+                    { 8 - i}
+                    OP_ROLL
+                    OP_EQUALVERIFY
+                }
+            }, 2, false, 0, "verify");
+
+            stack.drop(pos);
+            stack.drop(tables);
+            stack.op_true();
+
+            assert!(stack.run().success);
+
+        }
+    }
+
+}

--- a/src/u4/u4_shift.rs
+++ b/src/u4/u4_shift.rs
@@ -1,9 +1,11 @@
-use super::u4_std::u4_drop;
 use crate::treepp::{pushable, script, Script};
 
-// right and left shift tables for 3 bits options
+use super::u4_std::u4_drop;
+
+// right and left shfit tables for 3 bits options
 // compressed to reduce the size of the script
 // but in memory it will be 16*3 = 48
+
 
 pub fn u4_push_lshift_tables() -> Script {
     //lshift3, lshift2, lshift1
@@ -46,53 +48,58 @@ pub fn u4_push_lshift_tables() -> Script {
     }
 }
 
-pub fn u4_drop_lshift_tables() -> Script { u4_drop(16 * 3) }
+pub fn u4_drop_lshift_tables() -> Script {
+    u4_drop(16*3)
+}
 
 pub fn u4_push_rshift_tables() -> Script {
     //rshift3, rshift2, rshift1
     script! {
-    OP_1
-    OP_DUP
-    OP_2DUP
-    OP_2DUP
-    OP_2DUP
-    OP_0
-    OP_DUP
-    OP_2DUP
-    OP_2DUP
-    OP_2DUP
-    OP_3
-    OP_DUP
-    OP_2DUP
-    OP_2
-    OP_DUP
-    OP_2DUP
-    OP_1
-    OP_DUP
-    OP_2DUP
-    OP_0
-    OP_DUP
-    OP_2DUP
-    OP_7
-    OP_DUP
-    OP_6
-    OP_DUP
-    OP_5
-    OP_DUP
-    OP_4
-    OP_DUP
-    OP_3
-    OP_DUP
-    OP_2
-    OP_DUP
-    OP_1
-    OP_DUP
-    OP_0
-    OP_DUP
-      }
+        OP_1
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_2DUP
+        OP_2DUP
+        OP_3
+        OP_DUP
+        OP_2DUP
+        OP_2
+        OP_DUP
+        OP_2DUP
+        OP_1
+        OP_DUP
+        OP_2DUP
+        OP_0
+        OP_DUP
+        OP_2DUP
+        OP_7
+        OP_DUP
+        OP_6
+        OP_DUP
+        OP_5
+        OP_DUP
+        OP_4
+        OP_DUP
+        OP_3
+        OP_DUP
+        OP_2
+        OP_DUP
+        OP_1
+        OP_DUP
+        OP_0
+        OP_DUP
+          }
+
 }
 
-pub fn u4_drop_rshift_tables() -> Script { u4_drop(16 * 3) }
+pub fn u4_drop_rshift_tables() -> Script {
+    u4_drop(16*3)
+}
 
 pub fn u4_push_2_nib_rshift_tables() -> Script {
     script! {
@@ -108,8 +115,9 @@ pub fn u4_drop_2_nib_rshift_tables() -> Script {
     }
 }
 
+
 //It will process a nibble and shift it left 1,2 or 3 bits
-pub fn u4_lshift(n: u32, lshift_offset: u32) -> Script {
+pub fn u4_lshift(n: u32, lshift_offset: u32 ) -> Script {
     script! {
         { lshift_offset + (16*(n-1)) }
         OP_ADD
@@ -118,7 +126,7 @@ pub fn u4_lshift(n: u32, lshift_offset: u32) -> Script {
 }
 
 //It will process a nibble and shift it right 1,2 or 3 bits
-pub fn u4_rshift(n: u32, rshift_offset: u32) -> Script {
+pub fn u4_rshift(n: u32, rshift_offset: u32 ) -> Script {
     script! {
         { rshift_offset + (16*(n-1)) }
         OP_ADD
@@ -126,9 +134,11 @@ pub fn u4_rshift(n: u32, rshift_offset: u32) -> Script {
     }
 }
 
+
+
 // Assumes Y and X are on the stack and will produce YX >> n
 // It calculates the offset doing (Y << (4-n)) & 15 + (X >> n) & 15
-pub fn u4_2_nib_shift_n(n: u32, tables_offset: u32) -> Script {
+pub fn u4_2_nib_shift_n(n:u32, tables_offset: u32) -> Script {
     script! {
         { u4_lshift(4-n, tables_offset + (16*3) + 1)  }
         OP_SWAP
@@ -137,15 +147,16 @@ pub fn u4_2_nib_shift_n(n: u32, tables_offset: u32) -> Script {
     }
 }
 
+
 #[cfg(test)]
 mod tests {
 
-    use crate::treepp::{execute_script, script};
-    use crate::u4::u4_shift::*;
+use crate::{execute_script, treepp::script}; 
+use super::*;
 
     #[test]
     fn test_rshift() {
-        let script = script! {
+        let script  = script! {
             { u4_push_rshift_tables() }
             15
             16         // 16 is the size of rshift 1,2,3 choosing 2
@@ -160,16 +171,16 @@ mod tests {
         let res = execute_script(script);
         assert!(res.success);
     }
-
-    #[test]
+   
+   #[test]
     fn test_lshift() {
-        let script = script! {
+        let script  = script! {
             { u4_push_lshift_tables() }
-            7
+            7 
             0         // 16 is the size of rshift 1,2,3 choosing 1
             OP_ADD
             OP_PICK
-            14
+            14 
             OP_EQUALVERIFY
             { u4_drop_lshift_tables() }
             OP_TRUE
@@ -179,6 +190,7 @@ mod tests {
         assert!(res.success);
     }
 
+
     #[test]
     fn test_lshift_func() {
         for n in 1..4 {
@@ -186,10 +198,10 @@ mod tests {
                 let script = script! {
 
                     { u4_push_lshift_tables() }
-                    { x }           //  X
+                    { x }           //  X 
                     { u4_lshift(n , 0)}
                     { (x << n) % 16 }
-                    OP_EQUALVERIFY
+                    OP_EQUALVERIFY 
                     { u4_drop_lshift_tables() }
                     OP_TRUE
                 };
@@ -198,6 +210,7 @@ mod tests {
                 assert!(res.success);
             }
         }
+
     }
 
     #[test]
@@ -207,10 +220,10 @@ mod tests {
                 let script = script! {
 
                     { u4_push_rshift_tables() }
-                    { x }           //  X
+                    { x }           //  X 
                     { u4_lshift(n , 0)}
                     { (x >> n) % 16 }
-                    OP_EQUALVERIFY
+                    OP_EQUALVERIFY 
                     { u4_drop_rshift_tables() }
                     OP_TRUE
                 };
@@ -219,19 +232,23 @@ mod tests {
                 assert!(res.success);
             }
         }
+
     }
 
+
     #[test]
-    fn test_2_nib_rshift_function() {
+    fn test_2_nib_rshift_function () {
         for n in 1..4 {
             for y in 0..16 {
+
                 for x in 0..16 {
-                    let script = script! {
+
+                    let script  = script! {
                         { u4_push_2_nib_rshift_tables() }
-                        { x }           //  X
+                        { x }           //  X 
                         { y }          //  X  |  Y
                         { u4_2_nib_shift_n(n, 0) }
-                        { (((y << 4)+x) >> n) % 16 }
+                        { (((y << 4)+x) >> n) % 16 }         
                         OP_EQUALVERIFY
                         { u4_drop_2_nib_rshift_tables() }
                         OP_TRUE
@@ -242,5 +259,7 @@ mod tests {
                 }
             }
         }
+
     }
+
 }

--- a/src/u4/u4_shift_stack.rs
+++ b/src/u4/u4_shift_stack.rs
@@ -1,0 +1,104 @@
+use crate::treepp::{pushable, script};
+use bitcoin_script_stack::stack::{StackTracker, StackVariable};
+use super::u4_shift::{u4_push_lshift_tables, u4_push_rshift_tables};
+
+
+pub fn u4_push_shift_tables_stack(stack: &mut StackTracker) -> StackVariable {
+    stack.var(16*6, script! { {u4_push_lshift_tables()} {u4_push_rshift_tables()}}, "shift_tables"  )
+}
+
+pub fn u4_rshift_stack(stack: &mut StackTracker, tables: StackVariable, n: u32) -> StackVariable {
+    assert!(n >0 && n <= 3);
+    stack.get_value_from_table(tables, Some(16*(n-1)) )
+}
+
+pub fn u4_lshift_stack(stack: &mut StackTracker, tables: StackVariable, n: u32) -> StackVariable {
+    assert!(n >0 && n <= 3);
+    stack.get_value_from_table(tables, Some((16*3) + 16*(n-1)) )
+}
+
+// Assumes Y and X are on the stack and will produce YX >> n
+// It calculates the offset doing (Y << (4-n)) & 15 + (X >> n) & 15
+pub fn u4_2_nib_shift_stack(stack: &mut StackTracker, tables: StackVariable, n:u32) -> StackVariable {
+    assert!(n >0 && n <= 3);
+    u4_lshift_stack(stack, tables, 4-n);
+    stack.op_swap();
+    u4_rshift_stack(stack, tables, n);
+    stack.op_add()
+}
+
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use bitcoin_script_stack::stack::StackTracker;
+
+
+
+    #[test]
+    fn test_lshift() {
+        for n in 1..4 {
+            for x in 0..16 {
+
+                let mut stack = StackTracker::new();
+                let tables = u4_push_shift_tables_stack(&mut stack);
+                stack.number(x);
+                u4_lshift_stack(&mut stack, tables, n);
+                stack.number( (x << n) % 16 );
+                stack.op_equalverify();
+                stack.drop(tables);
+                stack.op_true();
+                assert!(stack.run().success);
+
+            }
+        }
+
+    }
+
+    #[test]
+    fn test_rshift_func() {
+        for n in 1..4 {
+            for x in 0..16 {
+
+                let mut stack = StackTracker::new();
+                let tables = u4_push_shift_tables_stack(&mut stack);
+                stack.number(x);
+                u4_rshift_stack(&mut stack, tables, n);
+                stack.number( (x >> n) % 16 );
+                stack.op_equalverify();
+                stack.drop(tables);
+                stack.op_true();
+                assert!(stack.run().success);
+
+            }
+        }
+
+    }
+
+    #[test]
+    fn test_2_nib_rshift_function () {
+        for n in 1..4 {
+            for y in 0..16 {
+
+                for x in 0..16 {
+
+                    let mut stack = StackTracker::new();
+                    let tables = u4_push_shift_tables_stack(&mut stack);
+                    stack.number(x);
+                    stack.number(y);
+                    u4_2_nib_shift_stack(&mut stack, tables, n);
+                    stack.number((((y << 4)+x) >> n) % 16);
+                    stack.op_equalverify();
+                    stack.drop(tables);
+                    stack.op_true();
+                    assert!(stack.run().success);
+
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/u4/u4_std.rs
+++ b/src/u4/u4_std.rs
@@ -1,7 +1,8 @@
-use crate::treepp::{pushable, script, Script};
+use crate::treepp::{script, pushable, Script};
 use bitcoin::{opcodes::all::*, Opcode};
 
 // helper functions used on the rest of the u4 code
+
 
 pub fn u4_toaltstack(n: u32) -> Script {
     script! {
@@ -37,6 +38,17 @@ pub fn u4_move_u32_from(address: u32) -> Script {
     }
 }
 
+pub fn verify_n(n: u32) -> Script {
+    script! {
+        for i in 0..n {
+            { n - i}
+            OP_ROLL
+            OP_EQUALVERIFY
+        }
+    }
+}
+
+
 pub fn u4_u32_verify_from_altstack() -> Script {
     script! {
         for _ in 0..8 {
@@ -51,7 +63,7 @@ pub fn u4_u32_verify_from_altstack() -> Script {
     }
 }
 
-pub fn u4_drop(n: u32) -> Script {
+pub fn u4_drop(n : u32 ) -> Script {
     script! {
         for _ in 0..n / 2 {
             OP_2DROP
@@ -62,20 +74,18 @@ pub fn u4_drop(n: u32) -> Script {
     }
 }
 
-pub fn u4_number_to_nibble(n: u32) -> Script {
-    //constant number used during "compile" time
+pub fn u4_number_to_nibble(n: u32) -> Script { //constant number used during "compile" time
     script! {
-       for i in (0..8).rev() {
-            { (n >> (i * 4)) & 0xF }
-        }
+       for i in (0..8).rev() { 
+            { (n >> (i * 4)) & 0xF } 
+        } 
     }
 }
 
 pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
-    let nibbles: Result<Vec<u8>, std::num::ParseIntError> = hex_str
-        .chars()
-        .map(|c| u8::from_str_radix(&c.to_string(), 16))
-        .collect();
+    let nibbles : Result<Vec<u8>, std::num::ParseIntError> = hex_str.chars().map(|c| {
+            u8::from_str_radix(&c.to_string(), 16)
+        }).collect();
     let nibbles = nibbles.unwrap();
     script! {
         for nibble in nibbles {
@@ -84,19 +94,20 @@ pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
     }
 }
 
+
+
 pub trait CalculateOffset {
-    fn modify(&mut self, element: Opcode) -> Script;
+    fn modify(&mut self, element: Opcode ) -> Script;
 }
 
 impl CalculateOffset for i32 {
-    fn modify(&mut self, element: Opcode) -> Script {
+    fn modify(&mut self, element: Opcode ) -> Script {
         match element {
-            OP_TOALTSTACK | OP_ADD => *self -= 1,
-            OP_PICK => {} //pick replaces the value so it does not change the stack count
+            OP_TOALTSTACK |
+            OP_ADD => *self -= 1,
+            OP_PICK => {}, //pick replaces the value so it does not change the stack count
             OP_DUP => *self += 1,
-            _ => {
-                panic!("unexpected opcode: {:?}", element);
-            }
+            _ =>  { panic!("unexpected opcode: {:?}", element); }
         }
 
         let mut s = Script::new();
@@ -107,15 +118,16 @@ impl CalculateOffset for i32 {
 #[cfg(test)]
 mod tests {
 
-    use crate::treepp::{execute_script, pushable, script};
+use crate::{execute_script, treepp::{script, pushable}};
 
-    use crate::u4::u4_std::u4_number_to_nibble;
+use crate::u4::u4_std::u4_number_to_nibble;
 
-    use super::u4_hex_to_nibbles;
+use super::u4_hex_to_nibbles;
 
     #[test]
     fn test_number_to_nibble() {
-        let script = script! {
+
+        let script  = script!{
             { u4_number_to_nibble(0xfedc8765) }
             5
             OP_EQUALVERIFY
@@ -139,6 +151,7 @@ mod tests {
         let res = execute_script(script);
         assert!(res.success);
     }
+
 
     #[test]
     fn test_hex_to_nibble() {
@@ -166,4 +179,6 @@ mod tests {
         let res = execute_script(script);
         assert!(res.success);
     }
+
+
 }


### PR DESCRIPTION
Hi!

I continued the work on optimizing SHA-256. It is still based on u4 as the basic unit, but these new numbers are obtained by reducing the number of unnecessary copies or movements of values on stack. 
To achieve this, I had to create a new library named [bitcoin-script-stack](https://github.com/FairgateLabs/rust-bitcoin-script-stack) that allows tracking parts of the stack as "named variables" and offers better debugging visualization, including some interactive debugging features.

These are the new results:

Algorithm | Reference | Sha256_u4 |  Sha256_stack | Improvement vs Reference | Improvement vs u4
-- | -- | -- | -- | -- | --
sha256(32) | 516K | 344K | **296K** | 42.6%|  14%
sha256(80) | 1043K | 759K | **638K** | 38.8% | 16%

