### PR TITLE
add batched_scalar_mul and reduce cost of fflonk verifier

### DIFF
--- a/src/fflonk/compute_f.rs
+++ b/src/fflonk/compute_f.rs
@@ -29,15 +29,11 @@ mod test {
             { Fr::toaltstack() }
             { Fr::toaltstack() }
 
-            { G1Projective::roll(1) }
+            { G1Projective::roll(1) } // [c0, c2, c1, q1; q2]
             { Fr::fromaltstack() }
-            { G1Projective::scalar_mul() }
-
-            { G1Projective::roll(1) }
-            { Fr::fromaltstack() }
-            { G1Projective::scalar_mul() }
-
-            { G1Projective::add() }
+            { Fq::roll(6)} {Fq::roll(6)} {Fq::roll(6)} // [c0, c1, q1, c2]
+            { Fr::fromaltstack() } // [c0, c1, q1, c2, q2]
+            { G1Projective::batched_scalar_mul::<2>() }
             { G1Projective::add() }
 
             { Fq::push_dec("10827057179016943379099096512257711381208881258335395636699788359889105647796") }


### PR DESCRIPTION
This PR reduces the cost of fflonk verifier from `7456022084` bytes (7.4Gb) to `5649799319` bytes (5.6Gb) and the max stack items number still is 905.

A new function `batched_scalar_mul` for multiple point multiplication is added to G1Projective, which calculates $xA+yB+zC+...$ simultaneously.
Each scalar multiplication currently costs ~0.95Gb, while the function `batched_scalar_mul` costs ~1.5Gb no matter how many items it has.

A example is $xA + yB$. The function first pre-compute some bases $\\{A+B, A, B, 0\\}$, then combine each bit of $x$ and $y$ to a list $\\{0, 1, 2, 3\\}^{254}$. Then, apply double-add to  the 2bit list with these bases.

For fflonk verifier, there are 5 scalar multiplications. This PR uses `batched_scalar_mul<2>` and `batched_scalar_mul<3>` to reduce the cost of fflonk verifier, which will be improved by ~(0.95\*5 - 1.5\*2 = 1.75Gb).

Can fflonk verifier use `batched_scalar_mul<5>` to reduce more? Because of the pre-compute, the bases will cost 2^5 * 27 = 864 stack items and the stack will not be enough.

> This work is inspired by @weikengchen and from bitlayer team, which is a Bitcoin Layer 2 based on the BitVM paradigm.