### PR TITLE
feat: better bitcoin script macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 exclude = ["tests"]
 
 [dependencies]
-bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
+bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script", branch= "better_scripts" }
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm", features = ["rand-std"]}
 strum = "0.26"
 strum_macros = "0.26"

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -3,10 +3,10 @@ use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fr::Fr;
 use crate::treepp::{pushable, script, Script};
-use std::sync::OnceLock;
-use num_bigint::BigUint;
 use ark_ff::Field;
+use num_bigint::BigUint;
 use num_traits::Num;
+use std::sync::OnceLock;
 
 static G1_DOUBLE_PROJECTIVE: OnceLock<Script> = OnceLock::new();
 static G1_NONZERO_ADD_PROJECTIVE: OnceLock<Script> = OnceLock::new();
@@ -335,14 +335,14 @@ impl G1Projective {
             // convert scalars to bit-style
             for i in 0..1 {
                 { Fq::roll(4*(TERMS - i - 1) as u32) }
-                
+
                 { Fr::decode_montgomery() }
                 { Fr::convert_to_le_bits_toaltstack() }
             }
 
             for term in 1..TERMS {
                 { Fq::roll(4*(TERMS - term - 1) as u32) }
-                
+
                 { Fr::decode_montgomery() }
                 { Fr::convert_to_le_bits_toaltstack() }
 
@@ -421,50 +421,10 @@ impl G1Projective {
     pub fn scalar_mul() -> Script {
         assert_eq!(Fq::N_BITS % 2, 0);
 
-        let loop_code = G1_SCALAR_MUL_LOOP
-            .get_or_init(|| {
-                script! {
-                    { G1Projective::double() }
-                    { G1Projective::double() }
-
-                    OP_FROMALTSTACK OP_FROMALTSTACK
-                    OP_IF
-                        OP_IF
-                            { G1Projective::copy(1) }
-                        OP_ELSE
-                            { G1Projective::copy(3) }
-                        OP_ENDIF
-                        OP_TRUE
-                    OP_ELSE
-                        OP_IF
-                            { G1Projective::copy(2) }
-                            OP_TRUE
-                        OP_ELSE
-                            OP_FALSE
-                        OP_ENDIF
-                    OP_ENDIF
-                    OP_IF
-                        { G1Projective::add() }
-                    OP_ENDIF
-                }
-            })
-            .as_bytes()
-            .to_vec();
-
-        let mut script_bytes = vec![];
-
-        script_bytes.extend(
+        let loop_code = G1_SCALAR_MUL_LOOP.get_or_init(|| {
             script! {
-                { Fr::decode_montgomery() }
-                { Fr::convert_to_le_bits_toaltstack() }
-
-                { G1Projective::copy(0) }
                 { G1Projective::double() }
-                { G1Projective::copy(1) }
-                { G1Projective::copy(1) }
-                { G1Projective::add() }
-
-                { G1Projective::push_zero() }
+                { G1Projective::double() }
 
                 OP_FROMALTSTACK OP_FROMALTSTACK
                 OP_IF
@@ -486,24 +446,50 @@ impl G1Projective {
                     { G1Projective::add() }
                 OP_ENDIF
             }
-            .as_bytes(),
-        );
+        });
 
-        for _ in 1..(Fq::N_BITS) / 2 {
-            script_bytes.extend(loop_code.clone());
-        }
+        script! {
+            { Fr::decode_montgomery() }
+            { Fr::convert_to_le_bits_toaltstack() }
 
-        script_bytes.extend_from_slice(
-            script! {
-                { G1Projective::toaltstack() }
-                { G1Projective::drop() }
-                { G1Projective::drop() }
-                { G1Projective::drop() }
-                { G1Projective::fromaltstack() }
+            { G1Projective::copy(0) }
+            { G1Projective::double() }
+            { G1Projective::copy(1) }
+            { G1Projective::copy(1) }
+            { G1Projective::add() }
+
+            { G1Projective::push_zero() }
+
+            OP_FROMALTSTACK OP_FROMALTSTACK
+            OP_IF
+                OP_IF
+                    { G1Projective::copy(1) }
+                OP_ELSE
+                    { G1Projective::copy(3) }
+                OP_ENDIF
+                OP_TRUE
+            OP_ELSE
+                OP_IF
+                    { G1Projective::copy(2) }
+                    OP_TRUE
+                OP_ELSE
+                    OP_FALSE
+                OP_ENDIF
+            OP_ENDIF
+            OP_IF
+                { G1Projective::add() }
+            OP_ENDIF
+
+            for _ in 1..(Fq::N_BITS) / 2 {
+                { loop_code.clone() }
             }
-            .as_bytes(),
-        );
-        Script::from(script_bytes)
+
+            { G1Projective::toaltstack() }
+            { G1Projective::drop() }
+            { G1Projective::drop() }
+            { G1Projective::drop() }
+            { G1Projective::fromaltstack() }
+        }
     }
 }
 
@@ -565,12 +551,11 @@ impl G1Affine {
 
 #[cfg(test)]
 mod test {
-    
+
     use crate::bn254::curves::{G1Affine, G1Projective};
     use crate::bn254::fq::Fq;
     use crate::execute_script;
     use crate::treepp::{pushable, script, Script};
-
 
     use crate::bn254::fp254impl::Fp254Impl;
     use ark_bn254::Fr;
@@ -579,9 +564,9 @@ mod test {
     use ark_std::{end_timer, start_timer, UniformRand};
     use core::ops::{Add, Mul};
     use num_bigint::BigUint;
-    use num_traits::{Zero, One};
+    use num_traits::{One, Zero};
     // use std::ops::Mul;
-    
+
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
     use std::ops::Neg;

--- a/src/bn254/fq12.rs
+++ b/src/bn254/fq12.rs
@@ -475,44 +475,34 @@ impl Fq12 {
 
         let loop_no_script = script! {
             { Fq12::cyclotomic_square() }
-        }
-        .to_bytes();
+        };
 
         let loop_yes_script = script! {
             { Fq12::cyclotomic_square() }
             { Fq12::copy(12) }
             { Fq12::mul(12, 0) }
-        }
-        .to_bytes();
+        };
 
-        let mut script_buf = script! {
+        script! {
             { Fq12::copy(0) }
             { Fq12::frobenius_map(1) }
             { Fq12::toaltstack() }
             { Fq12::copy(0) }
-        }
-        .to_bytes();
 
-        for bit in delta_bits.iter().rev().skip(1) {
-            if *bit {
-                script_buf.extend_from_slice(&loop_yes_script);
-            } else {
-                script_buf.extend_from_slice(&loop_no_script);
+            for bit in delta_bits.iter().rev().skip(1) {
+                if *bit {
+                    { loop_yes_script.clone() }
+                } else {
+                    { loop_no_script.clone() }
+                }
             }
+
+            { Fq12::roll(12) }
+            { Fq12::drop() }
+            { Fq12::cyclotomic_inverse() }
+            { Fq12::fromaltstack() }
+            { Fq12::mul(12, 0) }
         }
-
-        script_buf.extend(
-            script! {
-                { Fq12::roll(12) }
-                { Fq12::drop() }
-                { Fq12::cyclotomic_inverse() }
-                { Fq12::fromaltstack() }
-                { Fq12::mul(12, 0) }
-            }
-            .to_bytes(),
-        );
-
-        Script::from(script_buf)
     }
 
     pub fn move_to_cyclotomic() -> Script {

--- a/src/bn254/pairing.rs
+++ b/src/bn254/pairing.rs
@@ -433,7 +433,7 @@ impl Pairing {
 
             for i in (1..ark_bn254::Config::ATE_LOOP_COUNT.len()).rev() {
                 if i != ark_bn254::Config::ATE_LOOP_COUNT.len() - 1 {
-                    { Fq::square() }
+                    { Fq12::square() }
                 }
 
                 { Fq2::copy(12) }

--- a/src/bridge/transactions.rs
+++ b/src/bridge/transactions.rs
@@ -92,7 +92,7 @@ impl AssertTransaction {
         };
         let input = TxIn {
             previous_output: input,
-            script_sig: Script::new(),
+            script_sig: bitcoin::ScriptBuf::new(),
             sequence: Sequence(0xFFFFFFFF),
             witness: Witness::default(),
         };
@@ -137,14 +137,14 @@ impl DisproveTransaction {
 
         let connector_c_input = TxIn {
             previous_output: connector_c,
-            script_sig: Script::new(),
+            script_sig: bitcoin::ScriptBuf::new(),
             sequence: Sequence(0xFFFFFFFF),
             witness: Witness::default(),
         };
 
         let pre_sign_input = TxIn {
             previous_output: pre_sign,
-            script_sig: Script::new(),
+            script_sig: bitcoin::ScriptBuf::new(),
             sequence: Sequence(0xFFFFFFFF),
             witness: Witness::default(),
         };
@@ -232,7 +232,7 @@ impl BridgeTransaction for DisproveTransaction {
         // Unlocking script
         let mut witness_vec = (assert_leaf().unlock)(self.script_index);
         // Script and Control block
-        witness_vec.extend_from_slice(&[prevout_leaf.0.to_bytes(), control_block.serialize()]);
+        witness_vec.extend_from_slice(&[prevout_lbitcoino_bytes(), control_block.serialize()]);
 
         tx.input[1].witness = Witness::from(witness_vec);
         tx
@@ -276,11 +276,11 @@ pub fn generate_assert_leaves() -> Vec<Script> {
     leaves
 }
 
-pub fn generate_pre_sign_script(n_of_n_pubkey: XOnlyPublicKey) -> Script {
+pub fn generate_pre_sign_script(n_of_n_pubkey: XOnlyPublicKey) -> bitcoin::ScriptBuf {
     script! {
         { n_of_n_pubkey }
         OP_CHECKSIG
-    }
+    }.compile()
 }
 
 // Returns the TaprootSpendInfo for the Commitment Taptree and the corresponding pre_sign_output

--- a/src/groth16/offchain_checker.rs
+++ b/src/groth16/offchain_checker.rs
@@ -155,6 +155,7 @@ mod test {
     use crate::groth16::constants::{LAMBDA, P_POW3};
 
     #[test]
+    // TODO: Seems like this test is broken since it was first introduced in https://github.com/BitVM/BitVM/commit/38f91ef9f0e0d01a3adeae689fe854734d90664a
     fn test_checkpairing_with_c_wi_groth16() {
         // exp = 6x + 2 + p - p^2 = lambda - p^3
         let (exp, sign) = if LAMBDA.gt(&P_POW3) {

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,5 +1,5 @@
 pub mod blake3;
-pub mod blake3_u4;
+//pub mod blake3_u4;
 pub mod sha256;
 pub mod sha256_u4;
-pub mod sha256_u4_stack;
+//pub mod sha256_u4_stack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod treepp {
     pub use bitcoin_script::{define_pushable, script};
 
     define_pushable!();
-    pub use bitcoin::ScriptBuf as Script;
+    pub use pushable::Builder as Script;
 }
 
 use core::fmt;
@@ -15,7 +15,7 @@ use bitcoin_scriptexec::{Exec, ExecCtx, ExecError, ExecStats, Options, Stack, Tx
 
 pub mod bigint;
 pub mod bn254;
-pub mod bridge;
+//pub mod bridge;
 pub mod fflonk;
 pub mod groth16;
 pub mod hash;
@@ -95,7 +95,7 @@ impl fmt::Display for ExecuteInfo {
     }
 }
 
-pub fn execute_script(script: bitcoin::ScriptBuf) -> ExecuteInfo {
+pub fn execute_script(script: treepp::Script) -> ExecuteInfo {
     let mut exec = Exec::new(
         ExecCtx::Tapscript,
         Options::default(),
@@ -110,7 +110,7 @@ pub fn execute_script(script: bitcoin::ScriptBuf) -> ExecuteInfo {
             input_idx: 0,
             taproot_annex_scriptleaf: Some((TapLeafHash::all_zeros(), None)),
         },
-        script,
+        script.compile(),
         vec![],
     )
     .expect("error creating exec");
@@ -135,7 +135,7 @@ pub fn execute_script(script: bitcoin::ScriptBuf) -> ExecuteInfo {
 // This function is only used for script test, not for production.
 //
 // NOTE: Only for test purposes.
-pub fn execute_script_without_stack_limit(script: bitcoin::ScriptBuf) -> ExecuteInfo {
+pub fn execute_script_without_stack_limit(script: treepp::Script) -> ExecuteInfo {
     // Get the default options for the script exec.
     let mut opts = Options::default();
     // Do not enforce the stack limit.
@@ -155,7 +155,7 @@ pub fn execute_script_without_stack_limit(script: bitcoin::ScriptBuf) -> Execute
             input_idx: 0,
             taproot_annex_scriptleaf: Some((TapLeafHash::all_zeros(), None)),
         },
-        script,
+        script.compile(),
         vec![],
     )
     .expect("error creating exec");
@@ -218,10 +218,10 @@ mod test {
     #[test]
     fn test_execute_script_without_stack_limit() {
         let script = script! {
-            for i in 0..1001 {
+            for _ in 0..1001 {
                 OP_1
             }
-            for i in 0..1001 {
+            for _ in 0..1001 {
                 OP_DROP
             }
             OP_1

--- a/src/u4/mod.rs
+++ b/src/u4/mod.rs
@@ -1,9 +1,9 @@
 pub mod u4_add;
-pub mod u4_add_stack;
+//pub mod u4_add_stack;
 pub mod u4_logic;
-pub mod u4_logic_stack;
+//pub mod u4_logic_stack;
 pub mod u4_rot;
-pub mod u4_rot_stack;
+//pub mod u4_rot_stack;
 pub mod u4_shift;
-pub mod u4_shift_stack;
+//pub mod u4_shift_stack;
 pub mod u4_std;

--- a/src/u4/u4_std.rs
+++ b/src/u4/u4_std.rs
@@ -130,10 +130,8 @@ impl CalculateOffset for i32 {
                 panic!("unexpected opcode: {:?}", element);
             }
         }
-
-        let mut s = Script::new();
-        s.push_opcode(element);
-        s
+        
+        Script::new().push_opcode(element)
     }
 }
 #[cfg(test)]


### PR DESCRIPTION
We have a better script macro at https://github.com/BitVM/rust-bitcoin-script/tree/better_scripts that compiles the fflonk and groth16 scripts in less than 5 minutes.

The underlying data structure changed and scripts now have to be compiled before execution (`execute_script()` does that).
All `script!` usage remains the same but it can no longer be modified with `.as_bytes()` and the like.

Progress:
- [x] Refactor groth16
- [x] Refactor fflonk
- [ ] ~Adjust https://github.com/FairgateLabs/rust-bitcoin-script-stack~
- [ ] ~Refactor `u4_*_stack.rs`~
- [ ] ~Confirm `sha256_u4_stack.rs` works~

Edit: I will postpone the integration for the `u4_*` methods and the optimized sha256 script for now.