### PR TITLE
optimize U254 (add1, add, sub, double, mul) and Fq (add, sub, neg, double)

### DIFF
--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -11,7 +11,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_add_carry2
+                limb_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -20,7 +20,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     OP_DUP
                     OP_ADD
-                    limb_add_carry3 OP_TOALTSTACK
+                    OP_ADD limb_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -42,7 +42,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_add_carry2
+                limb_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -50,7 +50,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 for _ in 0..Self::N_LIMBS - 2 {
                     OP_2SWAP
                     OP_ADD
-                    limb_add_carry3 OP_TOALTSTACK
+                    OP_ADD limb_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -75,7 +75,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
     
-                limb_add_carry2
+                limb_create_carry
                 OP_TOALTSTACK
     
                 // from     A1      + B1        + carry_0
@@ -84,7 +84,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     {a * Self::N_LIMBS - i + 1} OP_ROLL
                     OP_ADD
-                    limb_add_carry3 OP_TOALTSTACK
+                    OP_ADD limb_create_carry OP_TOALTSTACK
                 }
     
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -105,7 +105,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_add_carry2
+                limb_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -113,7 +113,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 for _ in 0..Self::N_LIMBS - 2 {
                     OP_2SWAP
                     OP_ADD
-                    limb_add_carry3 OP_TOALTSTACK
+                    OP_ADD limb_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -134,14 +134,14 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             { 1 << LIMB_SIZE }
             OP_SWAP
 
-            limb_add_carry2
+            limb_create_carry
             OP_TOALTSTACK
 
             // from     A1        + carry_0
             //   to     A{N-2}    + carry_{N-3}
             for _ in 0..Self::N_LIMBS - 2 {
                 OP_ROT
-                limb_add_carry3 OP_TOALTSTACK
+                OP_ADD limb_create_carry OP_TOALTSTACK
             }
 
             // A{N-1} + carry_{N-2}
@@ -155,51 +155,14 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     }
 }
 
-/// Compute the sum of two limbs, including the carry bit
-///
-/// Optimized by: @stillsaiko
-pub fn limb_add_carry() -> Script {
-    script! {
-        OP_ROT OP_ROT
-        OP_ADD OP_2DUP
-        OP_LESSTHANOREQUAL
-        OP_TUCK
-        OP_IF
-            2 OP_PICK OP_SUB
-        OP_ENDIF
-    }
-}
-
-
-pub fn limb_add_carry2() -> Script {
+/// Create the carry bit for the addition operation
+pub fn limb_create_carry() -> Script {
     script! {
         OP_2DUP
         OP_LESSTHANOREQUAL
         OP_TUCK
         OP_IF
             2 OP_PICK OP_SUB
-        OP_ENDIF
-    }
-}
-
-pub fn limb_add_carry3() -> Script {
-    script! {
-        OP_ADD OP_2DUP
-        OP_LESSTHANOREQUAL
-        OP_TUCK
-        OP_IF
-            2 OP_PICK OP_SUB
-        OP_ENDIF
-    }
-}
-
-pub fn limb_add_carry4() -> Script {
-    script! {
-        OP_ADD OP_2DUP
-        OP_LESSTHANOREQUAL
-        OP_TUCK
-        OP_IF
-            3 OP_PICK OP_SUB
         OP_ENDIF
     }
 }

--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -193,6 +193,17 @@ pub fn limb_add_carry3() -> Script {
     }
 }
 
+pub fn limb_add_carry4() -> Script {
+    script! {
+        OP_ADD OP_2DUP
+        OP_LESSTHANOREQUAL
+        OP_TUCK
+        OP_IF
+            3 OP_PICK OP_SUB
+        OP_ENDIF
+    }
+}
+
 /// Compute the sum of two limbs, dropping the carry bit
 ///
 /// Optimized by: @wz14

--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -11,7 +11,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_create_carry
+                limb_add_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -20,7 +20,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     OP_DUP
                     OP_ADD
-                    OP_ADD limb_create_carry OP_TOALTSTACK
+                    OP_ADD limb_add_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -42,7 +42,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_create_carry
+                limb_add_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -50,7 +50,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 for _ in 0..Self::N_LIMBS - 2 {
                     OP_2SWAP
                     OP_ADD
-                    OP_ADD limb_create_carry OP_TOALTSTACK
+                    OP_ADD limb_add_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -75,7 +75,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
     
-                limb_create_carry
+                limb_add_create_carry
                 OP_TOALTSTACK
     
                 // from     A1      + B1        + carry_0
@@ -84,7 +84,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     {a * Self::N_LIMBS - i + 1} OP_ROLL
                     OP_ADD
-                    OP_ADD limb_create_carry OP_TOALTSTACK
+                    OP_ADD limb_add_create_carry OP_TOALTSTACK
                 }
     
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -105,7 +105,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 { 1 << LIMB_SIZE }
                 OP_SWAP
 
-                limb_create_carry
+                limb_add_create_carry
                 OP_TOALTSTACK
 
                 // from     A1      + B1        + carry_0
@@ -113,7 +113,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 for _ in 0..Self::N_LIMBS - 2 {
                     OP_2SWAP
                     OP_ADD
-                    OP_ADD limb_create_carry OP_TOALTSTACK
+                    OP_ADD limb_add_create_carry OP_TOALTSTACK
                 }
 
                 // A{N-1} + B{N-1} + carry_{N-2}
@@ -134,14 +134,14 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             { 1 << LIMB_SIZE }
             OP_SWAP
 
-            limb_create_carry
+            limb_add_create_carry
             OP_TOALTSTACK
 
             // from     A1        + carry_0
             //   to     A{N-2}    + carry_{N-3}
             for _ in 0..Self::N_LIMBS - 2 {
                 OP_ROT
-                OP_ADD limb_create_carry OP_TOALTSTACK
+                OP_ADD limb_add_create_carry OP_TOALTSTACK
             }
 
             // A{N-1} + carry_{N-2}
@@ -156,7 +156,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
 }
 
 /// Create the carry bit for the addition operation
-pub fn limb_create_carry() -> Script {
+pub fn limb_add_create_carry() -> Script {
     script! {
         OP_2DUP
         OP_LESSTHANOREQUAL

--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -103,6 +103,18 @@ pub fn limb_add_carry() -> Script {
     }
 }
 
+
+pub fn limb_add_carry3() -> Script {
+    script! {
+        OP_ADD OP_2DUP
+        OP_LESSTHANOREQUAL
+        OP_TUCK
+        OP_IF
+            2 OP_PICK OP_SUB
+        OP_ENDIF
+    }
+}
+
 /// Compute the sum of two limbs, dropping the carry bit
 ///
 /// Optimized by: @wz14

--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -156,6 +156,8 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
 }
 
 /// Create the carry bit for the addition operation
+/// INPUT STACK: [2^LIMB_SIZE A]
+/// OUTPUT STACK: [2^LIMB_SIZE (LIMB_SIZE <= A) A-((LIMB_SIZE <= A)*(2^LIMB_SIZE))]
 pub fn limb_add_create_carry() -> Script {
     script! {
         OP_2DUP

--- a/src/bigint/add.rs
+++ b/src/bigint/add.rs
@@ -4,77 +4,144 @@ use crate::treepp::*;
 impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     /// Double a BigInt
     pub fn double(a: u32) -> Script {
-        script! {
-            { Self::dup_zip(a) }
-
-            { 1 << LIMB_SIZE }
-
-            // A0 + B0
-            limb_add_carry OP_TOALTSTACK
-
-            // from     A1      + B1        + carry_0
-            //   to     A{N-2}  + B{N-2}    + carry_{N-3}
-            for _ in 0..Self::N_LIMBS - 2 {
-                OP_ROT
+        if a == 0 {
+            script! {
+                OP_DUP
                 OP_ADD
+                { 1 << LIMB_SIZE }
                 OP_SWAP
-                limb_add_carry OP_TOALTSTACK
+
+                limb_add_carry2
+                OP_TOALTSTACK
+
+                // from     A1      + B1        + carry_0
+                //   to     A{N-2}  + B{N-2}    + carry_{N-3}
+                for _ in 0..Self::N_LIMBS - 2 {
+                    OP_ROT
+                    OP_DUP
+                    OP_ADD
+                    limb_add_carry3 OP_TOALTSTACK
+                }
+
+                // A{N-1} + B{N-1} + carry_{N-2}
+                OP_NIP
+                OP_SWAP
+                OP_DUP
+                OP_ADD
+                { limb_add_nocarry(Self::HEAD_OFFSET) }
+
+                for _ in 0..Self::N_LIMBS - 1 {
+                    OP_FROMALTSTACK
+                }
             }
+        } else {
+            script! {
+                { Self::dup_zip(a) }
 
-            // A{N-1} + B{N-1} + carry_{N-2}
-            OP_NIP
-            OP_ADD
-            { limb_add_nocarry(Self::HEAD_OFFSET) }
+                OP_ADD
+                { 1 << LIMB_SIZE }
+                OP_SWAP
 
-            for _ in 0..Self::N_LIMBS - 1 {
-                OP_FROMALTSTACK
+                limb_add_carry2
+                OP_TOALTSTACK
+
+                // from     A1      + B1        + carry_0
+                //   to     A{N-2}  + B{N-2}    + carry_{N-3}
+                for _ in 0..Self::N_LIMBS - 2 {
+                    OP_2SWAP
+                    OP_ADD
+                    limb_add_carry3 OP_TOALTSTACK
+                }
+
+                // A{N-1} + B{N-1} + carry_{N-2}
+                OP_NIP
+                OP_ADD
+                { limb_add_nocarry(Self::HEAD_OFFSET) }
+
+                for _ in 0..Self::N_LIMBS - 1 {
+                    OP_FROMALTSTACK
+                }
             }
         }
     }
 
     /// Compute the sum of two BigInts
     pub fn add(a: u32, b: u32) -> Script {
-        script! {
-            { Self::zip(a, b) }
-
-            { 1 << LIMB_SIZE }
-
-            // A0 + B0
-            limb_add_carry OP_TOALTSTACK
-
-            // from     A1      + B1        + carry_0
-            //   to     A{N-2}  + B{N-2}    + carry_{N-3}
-            for _ in 0..Self::N_LIMBS - 2 {
-                OP_ROT
+        if b == 0 {
+            script! {
+                {a * Self::N_LIMBS} OP_ROLL
                 OP_ADD
+    
+                { 1 << LIMB_SIZE }
                 OP_SWAP
-                limb_add_carry OP_TOALTSTACK
+    
+                limb_add_carry2
+                OP_TOALTSTACK
+    
+                // from     A1      + B1        + carry_0
+                //   to     A{N-2}  + B{N-2}    + carry_{N-3}
+                for i in 0..Self::N_LIMBS - 2 {
+                    OP_ROT
+                    {a * Self::N_LIMBS - i + 1} OP_ROLL
+                    OP_ADD
+                    limb_add_carry3 OP_TOALTSTACK
+                }
+    
+                // A{N-1} + B{N-1} + carry_{N-2}
+                OP_NIP
+                {(a-1) * Self::N_LIMBS + 2} OP_ROLL
+                OP_ADD
+                { limb_add_nocarry(Self::HEAD_OFFSET) }
+    
+                for _ in 0..Self::N_LIMBS - 1 {
+                    OP_FROMALTSTACK
+                }
             }
+        } else {
+            script! {
+                { Self::zip(a, b) }
 
-            // A{N-1} + B{N-1} + carry_{N-2}
-            OP_NIP
-            OP_ADD
-            { limb_add_nocarry(Self::HEAD_OFFSET) }
+                OP_ADD
+                { 1 << LIMB_SIZE }
+                OP_SWAP
 
-            for _ in 0..Self::N_LIMBS - 1 {
-                OP_FROMALTSTACK
+                limb_add_carry2
+                OP_TOALTSTACK
+
+                // from     A1      + B1        + carry_0
+                //   to     A{N-2}  + B{N-2}    + carry_{N-3}
+                for _ in 0..Self::N_LIMBS - 2 {
+                    OP_2SWAP
+                    OP_ADD
+                    limb_add_carry3 OP_TOALTSTACK
+                }
+
+                // A{N-1} + B{N-1} + carry_{N-2}
+                OP_NIP
+                OP_ADD
+                { limb_add_nocarry(Self::HEAD_OFFSET) }
+
+                for _ in 0..Self::N_LIMBS - 1 {
+                    OP_FROMALTSTACK
+                }
             }
         }
     }
 
     pub fn add1() -> Script {
         script! {
-            1
+            OP_1ADD
             { 1 << LIMB_SIZE }
+            OP_SWAP
 
-            // A0 + 1
-            limb_add_carry OP_TOALTSTACK
+            limb_add_carry2
+            OP_TOALTSTACK
 
             // from     A1        + carry_0
             //   to     A{N-2}    + carry_{N-3}
             for _ in 0..Self::N_LIMBS - 2 {
-                OP_SWAP
-                limb_add_carry OP_TOALTSTACK
+                OP_ROT
+                limb_add_carry3 OP_TOALTSTACK
             }
 
             // A{N-1} + carry_{N-2}
@@ -103,6 +170,17 @@ pub fn limb_add_carry() -> Script {
     }
 }
 
+
+pub fn limb_add_carry2() -> Script {
+    script! {
+        OP_2DUP
+        OP_LESSTHANOREQUAL
+        OP_TUCK
+        OP_IF
+            2 OP_PICK OP_SUB
+        OP_ENDIF
+    }
+}
 
 pub fn limb_add_carry3() -> Script {
     script! {
@@ -142,7 +220,10 @@ mod test {
 
     #[test]
     fn test_add() {
-        println!("U254.add: {} bytes", U254::add(1, 0).len());
+        println!("U254.add(1, 0): {} bytes", U254::add(1, 0).len());
+        println!("U254.add(2, 0): {} bytes", U254::add(2, 0).len());
+        println!("U254.add(2, 1): {} bytes", U254::add(2, 1).len());
+
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
@@ -155,6 +236,32 @@ mod test {
                 { U254::add(1, 0) }
                 { U254::push_u32_le(&c.to_u32_digits()) }
                 { U254::equalverify(1, 0) }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+
+            let script = script! {
+                { U254::push_u32_le(&a.to_u32_digits()) }
+                { U254::push_u32_le(&b.to_u32_digits()) }
+                { U254::push_u32_le(&b.to_u32_digits()) }
+                { U254::add(2, 0) }
+                { U254::push_u32_le(&c.to_u32_digits()) }
+                { U254::equalverify(1, 0) }
+                { U254::drop() }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+
+            let script = script! {
+                { U254::push_u32_le(&a.to_u32_digits()) }
+                { U254::push_u32_le(&b.to_u32_digits()) }
+                { U254::push_u32_le(&b.to_u32_digits()) }
+                { U254::add(2, 1) }
+                { U254::push_u32_le(&c.to_u32_digits()) }
+                { U254::equalverify(1, 0) }
+                { U254::drop() }
                 OP_TRUE
             };
             let exec_result = execute_script(script);
@@ -181,7 +288,8 @@ mod test {
 
     #[test]
     fn test_double() {
-        println!("U254.double: {} bytes", U254::double(0).len());
+        println!("U254.double(0): {} bytes", U254::double(0).len());
+        println!("U254.double(1): {} bytes", U254::double(1).len());
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         for _ in 0..100 {
             let a: BigUint = prng.sample(RandomBits::new(254));
@@ -192,6 +300,18 @@ mod test {
                 { U254::double(0) }
                 { U254::push_u32_le(&c.to_u32_digits()) }
                 { U254::equalverify(1, 0) }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script);
+            assert!(exec_result.success);
+
+            let script = script! {
+                { U254::push_u32_le(&a.to_u32_digits()) }
+                { U254::push_zero() }
+                { U254::double(1) }
+                { U254::push_u32_le(&c.to_u32_digits()) }
+                { U254::equalverify(1, 0) }
+                { U254::drop() }
                 OP_TRUE
             };
             let exec_result = execute_script(script);

--- a/src/bigint/sub.rs
+++ b/src/bigint/sub.rs
@@ -13,7 +13,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 OP_SWAP
 
                 // A0 - B0
-                {limb_create_borrow(2)} OP_TOALTSTACK
+                {limb_sub_create_borrow(2)} OP_TOALTSTACK
 
                 // from     A1      - (B1        + borrow_0)
                 //   to     A{N-2}  - (B{N-2}    + borrow_{N-3})
@@ -21,7 +21,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     OP_ADD
                     {a * Self::N_LIMBS - i} OP_ROLL OP_SWAP
-                    OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+                    OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
                 }
 
                 // A{N-1} - (B{N-1} + borrow_{N-2})
@@ -43,7 +43,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 OP_SWAP
 
                 // A0 - B0
-                {limb_create_borrow(2)} OP_TOALTSTACK
+                {limb_sub_create_borrow(2)} OP_TOALTSTACK
 
                 // from     A1      - (B1        + borrow_0)
                 //   to     A{N-2}  - (B{N-2}    + borrow_{N-3})
@@ -51,7 +51,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_2SWAP
                     OP_SUB
                     OP_SWAP
-                    OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+                    OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
                 }
 
                 // A{N-1} - (B{N-1} + borrow_{N-2})
@@ -67,8 +67,8 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     }
 }
 
-/// Create the borrow bit for the substitution operation
-pub fn limb_create_borrow(a: u32) -> Script {
+/// Create the borrow bit for the substraction operation
+pub fn limb_sub_create_borrow(a: u32) -> Script {
     script! {
         OP_DUP
         0

--- a/src/bigint/sub.rs
+++ b/src/bigint/sub.rs
@@ -50,6 +50,19 @@ pub fn limb_sub_borrow() -> Script {
     }
 }
 
+pub fn limb_sub_borrow3() -> Script {
+    script! {
+        OP_SUB
+        OP_DUP
+        0
+        OP_LESSTHAN
+        OP_TUCK
+        OP_IF
+            3 OP_PICK OP_ADD
+        OP_ENDIF
+    }
+}
+
 /// Compute the sum of two limbs, dropping the carry bit
 ///
 /// Author: @weikengchen

--- a/src/bigint/sub.rs
+++ b/src/bigint/sub.rs
@@ -68,6 +68,8 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
 }
 
 /// Create the borrow bit for the substraction operation
+/// INPUT STACK: [2^LIMB_SIZE A]
+/// OUTPUT STACK: [2^LIMB_SIZE (A < 0) A+((A < 0)*(2^LIMB_SIZE))]
 pub fn limb_sub_create_borrow(a: u32) -> Script {
     script! {
         OP_DUP

--- a/src/bigint/sub.rs
+++ b/src/bigint/sub.rs
@@ -13,7 +13,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 OP_SWAP
 
                 // A0 - B0
-                limb_sub_borrow2 OP_TOALTSTACK
+                {limb_create_borrow(2)} OP_TOALTSTACK
 
                 // from     A1      - (B1        + borrow_0)
                 //   to     A{N-2}  - (B{N-2}    + borrow_{N-3})
@@ -21,7 +21,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_ROT
                     OP_ADD
                     {a * Self::N_LIMBS - i} OP_ROLL OP_SWAP
-                    limb_sub_borrow4 OP_TOALTSTACK
+                    OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
                 }
 
                 // A{N-1} - (B{N-1} + borrow_{N-2})
@@ -43,7 +43,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 OP_SWAP
 
                 // A0 - B0
-                limb_sub_borrow2 OP_TOALTSTACK
+                {limb_create_borrow(2)} OP_TOALTSTACK
 
                 // from     A1      - (B1        + borrow_0)
                 //   to     A{N-2}  - (B{N-2}    + borrow_{N-3})
@@ -51,7 +51,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     OP_2SWAP
                     OP_SUB
                     OP_SWAP
-                    limb_sub_borrow4 OP_TOALTSTACK
+                    OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
                 }
 
                 // A{N-1} - (B{N-1} + borrow_{N-2})
@@ -67,57 +67,15 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     }
 }
 
-/// Compute the difference of two limbs, including the carry bit
-///
-/// Author: @stillsaiko
-pub fn limb_sub_borrow() -> Script {
-    script! {
-        OP_ROT OP_ROT
-        OP_SUB
-        OP_DUP
-        0
-        OP_LESSTHAN
-        OP_TUCK
-        OP_IF
-            2 OP_PICK OP_ADD
-        OP_ENDIF
-    }
-}
-
-pub fn limb_sub_borrow2() -> Script {
+/// Create the borrow bit for the substitution operation
+pub fn limb_create_borrow(a: u32) -> Script {
     script! {
         OP_DUP
         0
         OP_LESSTHAN
         OP_TUCK
         OP_IF
-            2 OP_PICK OP_ADD
-        OP_ENDIF
-    }
-}
-
-pub fn limb_sub_borrow3() -> Script {
-    script! {
-        OP_SUB
-        OP_DUP
-        0
-        OP_LESSTHAN
-        OP_TUCK
-        OP_IF
-            3 OP_PICK OP_ADD
-        OP_ENDIF
-    }
-}
-
-pub fn limb_sub_borrow4() -> Script {
-    script! {
-        OP_SUB
-        OP_DUP
-        0
-        OP_LESSTHAN
-        OP_TUCK
-        OP_IF
-            2 OP_PICK OP_ADD
+            {a} OP_PICK OP_ADD
         OP_ENDIF
     }
 }

--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -1,12 +1,11 @@
-use crate::bigint::add::{limb_add_carry, limb_add_carry4, limb_add_carry3};
+use crate::bigint::add::limb_create_carry;
 use crate::bigint::bits::limb_to_be_bits;
-use crate::bigint::sub::{limb_sub_borrow, limb_sub_borrow3, limb_sub_borrow4, limb_sub_borrow2};
+use crate::bigint::sub::limb_create_borrow;
 use crate::bigint::U254;
 use crate::bigint::u29x9::{u29x9_mul_karazuba, u29x9_mul_karazuba_imm, u29x9_mulhi_karazuba_imm, u29x9_mullo_karazuba_imm, u29x9_square};
 use crate::pseudo::OP_256MUL;
 use crate::treepp::*;
 use ark_ff::{BigInteger, PrimeField};
-use bitcoin::opcodes::all::{OP_DROP, OP_LESSTHANOREQUAL, OP_SWAP};
 use bitcoin_script::script;
 use num_bigint::BigUint;
 use num_traits::{Num, One};
@@ -128,50 +127,67 @@ pub trait Fp254Impl {
                 OP_ADD
                 { 0x20000000 }
                 OP_SWAP
-                OP_2DUP
-                OP_LESSTHANOREQUAL
-                OP_TUCK
-                OP_IF
-                    2 OP_PICK OP_SUB
-                OP_ENDIF
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ A₀+B₀
+
+                limb_create_carry
                 OP_DUP
                 OP_TOALTSTACK
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀ | A₀+B₀
 
                 { Self::MODULUS_LIMBS[0] }
-                limb_sub_borrow3
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀ M₀
+                OP_SUB {limb_create_borrow(3)}
                 OP_TOALTSTACK
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ C₀⁻ | (A₀+B₀)-M₀
 
+                // from     A₁ B₁ 2²⁹ C₀⁺ C₀⁻
+                //   to     A₈ B₈ 2²⁹ C₇⁺ C₇⁻
                 for i in 1..Self::N_LIMBS-1 {
                     { Self::MODULUS_LIMBS[i as usize] }
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ C₀⁻ M₁
                     OP_ADD
                     OP_SWAP
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁻+M₁ C₀⁺ 
                     OP_2SWAP
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ C₀⁻+M₁ C₀⁺ B₁ 2²⁹ 
                     OP_4 OP_ROLL
                     OP_2SWAP
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ A₁ C₀⁺ B₁ 
                     OP_ADD
-                    limb_add_carry3
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ A₁ C₀⁺+B₁ 
+                    OP_ADD limb_create_carry
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁)
                     OP_DUP
                     OP_TOALTSTACK
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁) | A₁+(C₀⁺+B₁) 
                     OP_3 OP_ROLL
-                    limb_sub_borrow3
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁) C₀⁻+M₁ 
+                    OP_SUB {limb_create_borrow(3)}
                     OP_TOALTSTACK
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ 2²⁹ C₁⁺ C₁⁻ | (A₁+(C₀⁺+B₁))-(C₀⁻+M₁) 
 
                 }
+
+                // ⋯ A₈ B₈ 2²⁹ C₇⁺ C₇⁻
                 { *Self::MODULUS_LIMBS.last().unwrap() }
                 OP_ADD
                 OP_SWAP
+                // ⋯ A₈ B₈ 2²⁹ C₇⁻+M₈ C₇⁺
                 OP_2SWAP
+                // ⋯ A₈ C₇⁻+M₈ C₇⁺ B₈ 2²⁹
                 OP_4 OP_ROLL
                 OP_2SWAP
+                // ⋯ C₇⁻+M₈ 2²⁹ A₈ C₇⁺ B₈
                 OP_ADD
                 OP_ADD
                 OP_DUP
                 OP_TOALTSTACK
+                // ⋯ C₇⁻+M₈ 2²⁹ A₈+(C₇⁺+B₈) | A₈+(C₇⁺+B₈) 
                 OP_ROT
-                limb_sub_borrow4
+                // ⋯ 2²⁹ A₈+(C₇⁺+B₈) C₇⁻+M₈ 
+                OP_SUB {limb_create_borrow(2)}
                 OP_TOALTSTACK
-
-                // ⋯ 2²⁹ C₈⁻ | ((B₈+C₇⁺)+A₈)-(C₇⁻+M₈)
+                // ⋯ 2²⁹  C₈⁻ | (A₈+(C₇⁺+B₈))-(C₇⁻+M₈)
                 OP_NIP
                 OP_DUP
                 // ⋯ C₈⁻ C₈⁻
@@ -181,22 +197,22 @@ pub trait Fp254Impl {
                 OP_ENDIF
 
                 OP_FROMALTSTACK
-                // ⋯ (B₈+C₇⁺)+A₈ C₈⁻ | ((B₇+C₆⁺)+A₇)-(C₆⁻+M₇)
-                // ⋯ ((B₈+C₇⁺)+A₈)-(C₇⁻+M₈) C₈⁻ | (B₈+C₇⁺)+A₈
+                // ⋯ (A₈+C₇⁺)+B₈ C₈⁻ | ((A₇+C₆⁺)+B₇)-(C₆⁻+M₇)
+                // ⋯ ((A₈+C₇⁺)+B₈)-(C₇⁻+M₈) C₈⁻ | (A₈+C₇⁺)+B₈
                 for _ in 0..Self::N_LIMBS-1 {
                     OP_FROMALTSTACK  OP_DROP
                     OP_FROMALTSTACK
                 }
-                // ⋯ (B₈+C₇⁺)+A₈ (B₇+C₆⁺)+A₇ ... (B₂+C₁⁺)+A₂ (B₁+C₀⁺)+A₁ A₀+B₀ C₈⁻
-                // ⋯ ((B₈+C₇⁺)+A₈)-(C₇⁻+M₈) ... (A₀+B₀)-M₀ C₈⁻ | A₀+B₀
+                // ⋯ (A₈+C₇⁺)+B₈ (A₇+C₆⁺)+B₇ ... (A₂+C₁⁺)+B₂ (A₁+C₀⁺)+B₁ A₀+B₀ C₈⁻
+                // ⋯ ((A₈+C₇⁺)+B₈)-(C₇⁻+M₈) ... (A₀+B₀)-M₀ C₈⁻ | A₀+B₀
                 { Self::N_LIMBS }
                 OP_ROLL
                 OP_NOTIF
                     OP_FROMALTSTACK
                     OP_DROP
                 OP_ENDIF
-                // ⋯ (B₈+C₇⁺)+A₈ (B₇+C₆⁺)+A₇ ... (B₁+C₀⁺)+A₁ A₀+B₀
-                // ⋯ ((B₈+C₇⁺)+A₈)-(C₇⁻+M₈) ... (A₀+B₀)-M₀
+                // ⋯ (A₈+C₇⁺)+B₈ (A₇+C₆⁺)+B₇ ... (A₁+C₀⁺)+B₁ A₀+B₀
+                // ⋯ ((A₈+C₇⁺)+B₈)-(C₇⁻+M₈) ... (A₀+B₀)-M₀
             }
         });
         script! {
@@ -210,43 +226,44 @@ pub trait Fp254Impl {
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀ ⋯
             { Self::roll(a) }
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀
-            { Self::MODULUS_LIMBS[0] } OP_SWAP { 0x20000000 }
-            limb_sub_borrow OP_TOALTSTACK
+            { 0x20000000 }
+            { Self::MODULUS_LIMBS[0] } OP_ROT OP_SUB 
+            {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁻ | M₀-A₀ ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₀⁻+A₁
-            { Self::MODULUS_LIMBS[1] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[1] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁻ | M₁-(C₀⁻+A₁) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₁⁻+A₂
-            { Self::MODULUS_LIMBS[2] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[2] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₂⁻ | M₂-(C₁⁻+A₂) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₂⁻+A₃
-            { Self::MODULUS_LIMBS[3] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[3] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₃⁻ | M₃-(C₂⁻+A₃) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₃⁻+A₄
-            { Self::MODULUS_LIMBS[4] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[4] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₄⁻ | M₄-(C₃⁻+A₄) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ 2²⁹ C₄⁻+A₅
-            { Self::MODULUS_LIMBS[5] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[5] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ 2²⁹ C₅⁻ | M₅-(C₄⁻+A₅) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ 2²⁹ C₅⁻+A₆
-            { Self::MODULUS_LIMBS[6] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[6] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ 2²⁹ C₆⁻ | M₆-(C₅⁻+A₆) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ 2²⁹ C₆⁻+A₇
-            { Self::MODULUS_LIMBS[7] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
+            { Self::MODULUS_LIMBS[7] } OP_SWAP
+            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ 2²⁹ C₇⁻ | M₇-(C₆⁻+A₇) ⋯
             OP_NIP OP_ADD
             // ⋯ C₇⁻+A₈
@@ -269,54 +286,74 @@ pub trait Fp254Impl {
                 OP_SUB
                 { 0x20000000 }
                 OP_SWAP
-                limb_sub_borrow2
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ A₀-B₀
+                {limb_create_borrow(2)}
                 OP_DUP
                 OP_TOALTSTACK
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁻ A₀-B₀ | A₀-B₀ 
 
                 OP_ROT
                 OP_SWAP
                 { Self::MODULUS_LIMBS[0] }
-                limb_add_carry3
-                OP_TOALTSTACK
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ A₀-B₀ M₀ 
 
+                OP_ADD limb_create_carry
+                OP_TOALTSTACK
+                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ C₀⁺ | (A₀-B₀)+M₀ 
+
+                // from     A₁ B₁ C₀⁻ 2²⁹ C₀⁺
+                //   to     A₈ B₈ C₇⁻ 2²⁹ C₇⁺
                 for i in 1..Self::N_LIMBS-1 {
                     { Self::MODULUS_LIMBS[i as usize] }
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ C₀⁺ M₁
                     OP_ADD
                     OP_SWAP
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ C₀⁺+M₁ 2²⁹
                     OP_2SWAP
                     OP_4 OP_ROLL
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺+M₁ 2²⁹ B₁ C₀⁻ A₁
                     OP_ROT
                     OP_ROT
                     OP_ADD
-                    limb_sub_borrow4
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺+M₁ 2²⁹ A₁ B₁+C₀⁻
+                    OP_SUB {limb_create_borrow(2)}
                     OP_DUP
                     OP_TOALTSTACK
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺+M₁ 2²⁹ C₁⁻ A₁-(B₁+C₀⁻) | A₁-(B₁+C₀⁻)
                     OP_2SWAP
                     OP_ROT OP_ROT
-                    limb_add_carry3
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ 2²⁹ A₁-(B₁+C₀⁻) C₀⁺+M₁
+                    OP_ADD limb_create_carry
                     OP_TOALTSTACK
-
+                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ 2²⁹ C₁⁺ | (A₁-(B₁+C₀⁻))+(C₀⁺+M₁)
                 }
+                // ⋯ A₈ B₈ C₇⁻ 2²⁹ C₇⁺
                 { *Self::MODULUS_LIMBS.last().unwrap() }
                 OP_ADD
                 OP_SWAP
+                // ⋯ A₈ B₈ C₇⁻ C₇⁺+M₈ 2²⁹
                 OP_2SWAP
                 OP_4 OP_ROLL
+                // ⋯ C₇⁺+M₈ 2²⁹ B₈ C₇⁻ A₈
                 OP_ROT
                 OP_ROT
                 OP_ADD
-                limb_sub_borrow4
+                // ⋯ C₇⁺+M₈ 2²⁹ A₈ B₈+C₇⁻ 
+                OP_SUB {limb_create_borrow(2)}
                 OP_DUP
                 OP_TOALTSTACK
+                // ⋯ C₇⁺+M₈ 2²⁹ C₈⁻ A₈-(B₈+C₇⁻) | A₈-(B₈+C₇⁻)
                 OP_2SWAP
                 OP_ROT
                 OP_ROT
+                // ⋯ C₈⁻ 2²⁹ A₈-(B₈+C₇⁻) C₇⁺+M₈
                 OP_ADD OP_2DUP
                 OP_LESSTHANOREQUAL
                 OP_IF
                     OP_OVER OP_SUB
                 OP_ENDIF
                 OP_TOALTSTACK
+                // ⋯ C₈⁻ 2²⁹ | (A₈-(B₈+C₇⁻))+(C₇⁺+M₈)
                 OP_DROP
 
                 // ⋯ C₈⁻ | (A₈-(B₈+C₇⁻))+(C₇⁺+M)₈ A₈-(B₈+C₇⁻)
@@ -361,58 +398,63 @@ pub trait Fp254Impl {
             OP_ADD
             { 0x20000000 }
             OP_SWAP
-            OP_2DUP
-            OP_LESSTHANOREQUAL
-            OP_TUCK
-            OP_IF
-                2 OP_PICK OP_SUB
-            OP_ENDIF
+            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ 2⋅A₀
+            limb_create_carry
             OP_DUP
             OP_TOALTSTACK
+            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀
 
+            
             { Self::MODULUS_LIMBS[0] }
-            limb_sub_borrow3
+            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀ M₀
+            OP_SUB {limb_create_borrow(3)}
             OP_TOALTSTACK
+            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ C₀⁻ | 2⋅A₀-M₀
 
+            // from     A₁ 2²⁹ C₀⁺ C₀⁻
+            //   to     A₈ 2²⁹ C₇⁺ C₇⁻
             for i in 1..Self::N_LIMBS-1 {
                 { Self::MODULUS_LIMBS[i as usize] }
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ C₀⁻ M₁
                 OP_ADD
                 OP_SWAP
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁻+M₁ C₀⁺
                 OP_2SWAP
                 OP_ROT OP_ROT
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻+M₁ 2²⁹ C₀⁺ A₁
                 OP_DUP
                 OP_ADD
-                limb_add_carry3
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻+M₁ 2²⁹ C₀⁺ 2⋅A₁
+                OP_ADD limb_create_carry
                 OP_DUP
                 OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻+M₁ 2²⁹ C₁⁺ C₀⁺+2⋅A₁ | C₀⁺+2⋅A₁
                 OP_3 OP_ROLL
-                limb_sub_borrow3
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁺ C₀⁺+2⋅A₁ C₀⁻+M₁
+                OP_SUB {limb_create_borrow(3)}
                 OP_TOALTSTACK
-
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁺ C₁⁻| (C₀⁺+2⋅A₁)-(C₀⁻+M₁)
             }
+            // ⋯ A₈ 2²⁹ C₇⁺ C₇⁻ 
             { *Self::MODULUS_LIMBS.last().unwrap() }
             OP_ADD
             OP_SWAP
+            // ⋯ A₈ 2²⁹ C₇⁻+M₈ C₇⁺
             OP_2SWAP
             OP_ROT OP_ROT
+            // ⋯ C₇⁻+M₈ 2²⁹ C₇⁺ A₈
             OP_DUP
             OP_ADD
             OP_ADD
+            // ⋯ C₇⁻+M₈ 2²⁹ C₇⁺+2⋅A₈
             OP_DUP
             OP_TOALTSTACK
+            // ⋯ C₇⁻+M₈ 2²⁹ C₇⁺+2⋅A₈ | C₇⁺+2⋅A₈
             OP_ROT
-            OP_SUB
-            OP_DUP
-            0
-            OP_LESSTHAN
-            OP_TUCK
-            OP_IF
-                2 OP_PICK OP_ADD
-            OP_ENDIF
+            OP_SUB {limb_create_borrow(2)}
             OP_TOALTSTACK
+            // ⋯ 2²⁹ C₈⁻ | (C₇⁺+2⋅A₈)-(C₇⁻+M₈)
 
-
-            // ⋯ 2²⁹ C₈⁻ | (2⋅A₈+C₇⁺)-(C₇⁻+M₈)
             OP_NIP
             OP_DUP
             // ⋯ C₈⁻ C₈⁻
@@ -422,22 +464,22 @@ pub trait Fp254Impl {
             OP_ENDIF
 
             OP_FROMALTSTACK
-            // ⋯ 2⋅A₈+C₇⁺ C₈⁻ | (2⋅A₇+C₆⁺)-(C₆⁻+M₇)
-            // ⋯ (2⋅A₈+C₇⁺)-(C₇⁻+M₈) C₈⁻ | 2⋅A₈+C₇⁺
+            // ⋯ C₇+2⋅A₈⁺ C₈⁻ | (C₆⁺+2⋅A₇)-(C₆⁻+M₇)
+            // ⋯ (C₇+2⋅A₈⁺)-(C₇⁻+M₈) C₈⁻ | C₇+2⋅A₈⁺
             for _ in 0..Self::N_LIMBS-1 {
                 OP_FROMALTSTACK  OP_DROP
                 OP_FROMALTSTACK
             }
-            // ⋯ 2⋅A₈+C₇⁺ 2⋅A₇+C₆⁺ ... 2⋅A₂+C₁⁺ 2⋅A₁+C₀⁺ 2⋅A₀ C₈⁻
-            // ⋯ (2⋅A₈+C₇⁺)-(C₇⁻+M₈) ... 2⋅A₀-M₀ C₈⁻ | 2⋅A₀
+            // ⋯ C₇+2⋅A₈⁺ C₆⁺+2⋅A₇ ... C₁+2⋅A₂⁺ C₀⁺+2⋅A₁ 2⋅A₀ C₈⁻
+            // ⋯ (C₇+2⋅A₈⁺)-(C₇⁻+M₈) ... 2⋅A₀-M₀ C₈⁻ | 2⋅A₀
             { Self::N_LIMBS }
             OP_ROLL
             OP_NOTIF
                 OP_FROMALTSTACK
                 OP_DROP
             OP_ENDIF
-            // ⋯ 2⋅A₈+C₇⁺ 2⋅A₇+C₆⁺ ... 2⋅A₁+C₀⁺ 2⋅A₀
-            // ⋯ (2⋅A₈+C₇⁺)-(C₇⁻+M₈) ... 2⋅A₀-M₀
+            // ⋯ C₇+2⋅A₈⁺ C₆⁺+2⋅A₇ ... C₀⁺+2⋅A₁ 2⋅A₀
+            // ⋯ (C₇+2⋅A₈⁺)-(C₇⁻+M₈) ... 2⋅A₀-M₀
         }
     }
 

--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -1,6 +1,6 @@
-use crate::bigint::add::limb_create_carry;
+use crate::bigint::add::limb_add_create_carry;
 use crate::bigint::bits::limb_to_be_bits;
-use crate::bigint::sub::limb_create_borrow;
+use crate::bigint::sub::limb_sub_create_borrow;
 use crate::bigint::U254;
 use crate::bigint::u29x9::{u29x9_mul_karazuba, u29x9_mul_karazuba_imm, u29x9_mulhi_karazuba_imm, u29x9_mullo_karazuba_imm, u29x9_square};
 use crate::pseudo::OP_256MUL;
@@ -129,14 +129,14 @@ pub trait Fp254Impl {
                 OP_SWAP
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ A₀+B₀
 
-                limb_create_carry
+                limb_add_create_carry
                 OP_DUP
                 OP_TOALTSTACK
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀ | A₀+B₀
 
                 { Self::MODULUS_LIMBS[0] }
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀ M₀
-                OP_SUB {limb_create_borrow(3)}
+                OP_SUB {limb_sub_create_borrow(3)}
                 OP_TOALTSTACK
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ C₀⁻ | (A₀+B₀)-M₀
 
@@ -155,14 +155,14 @@ pub trait Fp254Impl {
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ A₁ C₀⁺ B₁ 
                     OP_ADD
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ A₁ C₀⁺+B₁ 
-                    OP_ADD limb_create_carry
+                    OP_ADD limb_add_create_carry
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁)
                     OP_DUP
                     OP_TOALTSTACK
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻+M₁ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁) | A₁+(C₀⁺+B₁) 
                     OP_3 OP_ROLL
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ 2²⁹ C₁⁺ A₁+(C₀⁺+B₁) C₀⁻+M₁ 
-                    OP_SUB {limb_create_borrow(3)}
+                    OP_SUB {limb_sub_create_borrow(3)}
                     OP_TOALTSTACK
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ 2²⁹ C₁⁺ C₁⁻ | (A₁+(C₀⁺+B₁))-(C₀⁻+M₁) 
 
@@ -185,7 +185,7 @@ pub trait Fp254Impl {
                 // ⋯ C₇⁻+M₈ 2²⁹ A₈+(C₇⁺+B₈) | A₈+(C₇⁺+B₈) 
                 OP_ROT
                 // ⋯ 2²⁹ A₈+(C₇⁺+B₈) C₇⁻+M₈ 
-                OP_SUB {limb_create_borrow(2)}
+                OP_SUB {limb_sub_create_borrow(2)}
                 OP_TOALTSTACK
                 // ⋯ 2²⁹  C₈⁻ | (A₈+(C₇⁺+B₈))-(C₇⁻+M₈)
                 OP_NIP
@@ -228,42 +228,42 @@ pub trait Fp254Impl {
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀
             { 0x20000000 }
             { Self::MODULUS_LIMBS[0] } OP_ROT OP_SUB 
-            {limb_create_borrow(2)} OP_TOALTSTACK
+            {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁻ | M₀-A₀ ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₀⁻+A₁
             { Self::MODULUS_LIMBS[1] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁻ | M₁-(C₀⁻+A₁) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₁⁻+A₂
             { Self::MODULUS_LIMBS[2] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₂⁻ | M₂-(C₁⁻+A₂) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₂⁻+A₃
             { Self::MODULUS_LIMBS[3] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₃⁻ | M₃-(C₂⁻+A₃) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₃⁻+A₄
             { Self::MODULUS_LIMBS[4] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₄⁻ | M₄-(C₃⁻+A₄) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ A₆ 2²⁹ C₄⁻+A₅
             { Self::MODULUS_LIMBS[5] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ 2²⁹ C₅⁻ | M₅-(C₄⁻+A₅) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ A₇ 2²⁹ C₅⁻+A₆
             { Self::MODULUS_LIMBS[6] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ A₇ 2²⁹ C₆⁻ | M₆-(C₅⁻+A₆) ⋯
             OP_ROT OP_ADD
             // ⋯ A₈ 2²⁹ C₆⁻+A₇
             { Self::MODULUS_LIMBS[7] } OP_SWAP
-            OP_SUB {limb_create_borrow(2)} OP_TOALTSTACK
+            OP_SUB {limb_sub_create_borrow(2)} OP_TOALTSTACK
             // ⋯ A₈ 2²⁹ C₇⁻ | M₇-(C₆⁻+A₇) ⋯
             OP_NIP OP_ADD
             // ⋯ C₇⁻+A₈
@@ -287,7 +287,7 @@ pub trait Fp254Impl {
                 { 0x20000000 }
                 OP_SWAP
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ A₀-B₀
-                {limb_create_borrow(2)}
+                {limb_sub_create_borrow(2)}
                 OP_DUP
                 OP_TOALTSTACK
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁻ A₀-B₀ | A₀-B₀ 
@@ -297,7 +297,7 @@ pub trait Fp254Impl {
                 { Self::MODULUS_LIMBS[0] }
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ A₀-B₀ M₀ 
 
-                OP_ADD limb_create_carry
+                OP_ADD limb_add_create_carry
                 OP_TOALTSTACK
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ C₀⁺ | (A₀-B₀)+M₀ 
 
@@ -316,14 +316,14 @@ pub trait Fp254Impl {
                     OP_ROT
                     OP_ADD
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺+M₁ 2²⁹ A₁ B₁+C₀⁻
-                    OP_SUB {limb_create_borrow(2)}
+                    OP_SUB {limb_sub_create_borrow(2)}
                     OP_DUP
                     OP_TOALTSTACK
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺+M₁ 2²⁹ C₁⁻ A₁-(B₁+C₀⁻) | A₁-(B₁+C₀⁻)
                     OP_2SWAP
                     OP_ROT OP_ROT
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ 2²⁹ A₁-(B₁+C₀⁻) C₀⁺+M₁
-                    OP_ADD limb_create_carry
+                    OP_ADD limb_add_create_carry
                     OP_TOALTSTACK
                     // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ 2²⁹ C₁⁺ | (A₁-(B₁+C₀⁻))+(C₀⁺+M₁)
                 }
@@ -339,7 +339,7 @@ pub trait Fp254Impl {
                 OP_ROT
                 OP_ADD
                 // ⋯ C₇⁺+M₈ 2²⁹ A₈ B₈+C₇⁻ 
-                OP_SUB {limb_create_borrow(2)}
+                OP_SUB {limb_sub_create_borrow(2)}
                 OP_DUP
                 OP_TOALTSTACK
                 // ⋯ C₇⁺+M₈ 2²⁹ C₈⁻ A₈-(B₈+C₇⁻) | A₈-(B₈+C₇⁻)
@@ -399,7 +399,7 @@ pub trait Fp254Impl {
             { 0x20000000 }
             OP_SWAP
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ 2⋅A₀
-            limb_create_carry
+            limb_add_create_carry
             OP_DUP
             OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀
@@ -407,7 +407,7 @@ pub trait Fp254Impl {
             
             { Self::MODULUS_LIMBS[0] }
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀ M₀
-            OP_SUB {limb_create_borrow(3)}
+            OP_SUB {limb_sub_create_borrow(3)}
             OP_TOALTSTACK
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ C₀⁻ | 2⋅A₀-M₀
 
@@ -425,13 +425,13 @@ pub trait Fp254Impl {
                 OP_DUP
                 OP_ADD
                 // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻+M₁ 2²⁹ C₀⁺ 2⋅A₁
-                OP_ADD limb_create_carry
+                OP_ADD limb_add_create_carry
                 OP_DUP
                 OP_TOALTSTACK
                 // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻+M₁ 2²⁹ C₁⁺ C₀⁺+2⋅A₁ | C₀⁺+2⋅A₁
                 OP_3 OP_ROLL
                 // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁺ C₀⁺+2⋅A₁ C₀⁻+M₁
-                OP_SUB {limb_create_borrow(3)}
+                OP_SUB {limb_sub_create_borrow(3)}
                 OP_TOALTSTACK
                 // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁺ C₁⁻| (C₀⁺+2⋅A₁)-(C₀⁻+M₁)
             }
@@ -451,7 +451,7 @@ pub trait Fp254Impl {
             OP_TOALTSTACK
             // ⋯ C₇⁻+M₈ 2²⁹ C₇⁺+2⋅A₈ | C₇⁺+2⋅A₈
             OP_ROT
-            OP_SUB {limb_create_borrow(2)}
+            OP_SUB {limb_sub_create_borrow(2)}
             OP_TOALTSTACK
             // ⋯ 2²⁹ C₈⁻ | (C₇⁺+2⋅A₈)-(C₇⁻+M₈)
 

--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -1,12 +1,12 @@
-use crate::bigint::add::{limb_add_carry, limb_add_carry3};
+use crate::bigint::add::{limb_add_carry, limb_add_carry4, limb_add_carry3};
 use crate::bigint::bits::limb_to_be_bits;
-use crate::bigint::sub::{limb_sub_borrow, limb_sub_borrow3};
+use crate::bigint::sub::{limb_sub_borrow, limb_sub_borrow3, limb_sub_borrow4, limb_sub_borrow2};
 use crate::bigint::U254;
 use crate::bigint::u29x9::{u29x9_mul_karazuba, u29x9_mul_karazuba_imm, u29x9_mulhi_karazuba_imm, u29x9_mullo_karazuba_imm, u29x9_square};
 use crate::pseudo::OP_256MUL;
 use crate::treepp::*;
 use ark_ff::{BigInteger, PrimeField};
-use bitcoin::opcodes::all::{OP_LESSTHANOREQUAL, OP_SWAP};
+use bitcoin::opcodes::all::{OP_DROP, OP_LESSTHANOREQUAL, OP_SWAP};
 use bitcoin_script::script;
 use num_bigint::BigUint;
 use num_traits::{Num, One};
@@ -141,29 +141,6 @@ pub trait Fp254Impl {
                 limb_sub_borrow3
                 OP_TOALTSTACK
 
-
-                // { 0x20000000 }
-                // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ A₀ B₀ 2²⁹
-
-                // // A₀ + B₀
-                // limb_add_carry
-                // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀
-                // OP_DUP
-                // OP_TOALTSTACK
-                // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁺ A₀+B₀ | A₀+B₀
-                // OP_ROT
-                // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁺ A₀+B₀ 2²⁹
-                // { Self::MODULUS_LIMBS[0] }
-                // // OP_SWAP
-                // // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁺ A₀+B₀ M₀ 2²⁹
-                // // limb_sub_borrow
-                // limb_sub_borrow2
-                // OP_TOALTSTACK
-                
-                // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁺ 2²⁹ C₀⁻ | (A₀+B₀)-M₀
-
-                // from     A₁      + B₁        + carry_0
-                //   to     A{N-2}  + B{N-2}    + carry_{N-3}
                 for i in 1..Self::N_LIMBS-1 {
                     { Self::MODULUS_LIMBS[i as usize] }
                     OP_ADD
@@ -179,33 +156,6 @@ pub trait Fp254Impl {
                     limb_sub_borrow3
                     OP_TOALTSTACK
 
-                    // OP_2SWAP
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ 2²⁹ C₀⁻ B₁ C₀⁺
-                    // OP_ADD
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ 2²⁹ C₀⁻ B₁+C₀⁺
-                    // OP_2SWAP
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻ B₁+C₀⁺ A₁ 2²⁹
-                    // limb_add_carry
-                    // OP_DUP
-                    // OP_TOALTSTACK
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁻ 2²⁹ C₁⁺ (B₁+C₀)+A₁ | (B₁+C₀)+A₁
-                    // OP_2SWAP
-                    // OP_SWAP
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁺ (B₁+C₀)+A₁ 2²⁹ C₀⁻
-                    // { Self::MODULUS_LIMBS[i as usize] }
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁺ (B₁+C₀)+A₁ 2²⁹ C₀⁻ M₁
-                    // OP_ADD
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁺ (B₁+C₀)+A₁ 2²⁹ C₀⁻+M₁
-                    // // OP_ROT
-                    // // OP_SWAP
-                    // // OP_ROT
-                    // // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁺ (B₁+C₀)+A₁ C₀⁻+M₁ 2²⁹
-                    // // limb_sub_borrow
-                    // limb_sub_borrow2
-                    // // if i != num-1{
-                    //     OP_TOALTSTACK
-                    // // }
-                    // // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁺ 2²⁹ C₁⁻ | ((B₁+C₀)+A₁)-(C₀⁻+M₁)
                 }
                 { *Self::MODULUS_LIMBS.last().unwrap() }
                 OP_ADD
@@ -218,39 +168,9 @@ pub trait Fp254Impl {
                 OP_DUP
                 OP_TOALTSTACK
                 OP_ROT
-                OP_SUB
-                OP_DUP
-                0
-                OP_LESSTHAN
-                OP_TUCK
-                OP_IF
-                    2 OP_PICK OP_ADD
-                OP_ENDIF
+                limb_sub_borrow4
                 OP_TOALTSTACK
 
-                // // ⋯ A₈ B₈ C₇⁺ 2²⁹ C₇⁻
-                // OP_2SWAP
-                // OP_ADD
-                // // ⋯ A₈ 2²⁹ C₇⁻ B₈+C₇⁺
-                // OP_2SWAP
-                // OP_ROT
-                // OP_ROT
-                // // ⋯ C₇⁻ 2²⁹ B₈+C₇⁺ A₈
-                // OP_ADD
-                // // ⋯ C₇⁻ 2²⁹ (B₈+C₇⁺)+A₈
-                // OP_DUP
-                // OP_TOALTSTACK
-                // OP_ROT
-                // // ⋯ 2²⁹ (B₈+C₇⁺)+A₈ C₇⁻
-                // { *Self::MODULUS_LIMBS.last().unwrap() }
-                // // ⋯ 2²⁹ (B₈+C₇⁺)+A₈ C₇⁻ M₈
-                // OP_ADD
-                // OP_ROT
-                // // ⋯ (B₈+C₇⁺)+A₈ C₇⁻+M₈ 2²⁹
-                // limb_sub_borrow
-                // OP_TOALTSTACK
-
-                
                 // ⋯ 2²⁹ C₈⁻ | ((B₈+C₇⁺)+A₈)-(C₇⁻+M₈)
                 OP_NIP
                 OP_DUP
@@ -346,74 +266,59 @@ pub trait Fp254Impl {
         let sub_script = binding.get_or_init(|| {
             script! {
                 // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ A₀ B₀
+                OP_SUB
                 { 0x20000000 }
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ A₀ B₀ 2²⁹
-
-                // A₀ - B₀
-                limb_sub_borrow
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁻ A₀-B₀
+                OP_SWAP
+                limb_sub_borrow2
                 OP_DUP
                 OP_TOALTSTACK
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ 2²⁹ C₀⁻ A₀-B₀ | A₀-B₀
-                OP_ROT
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ A₀-B₀ 2²⁹
-                { Self::MODULUS_LIMBS[0] }
-                OP_SWAP
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ A₀-B₀ M₀ 2²⁹
-                limb_add_carry
-                OP_TOALTSTACK
-                // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ C₀⁺ | (A₀-B₀)+M₀
 
-                // from     A₁      - B₁        - carry_0
-                //   to     A{N-2}  - B{N-2}    - carry_{N-3}
+                OP_ROT
+                OP_SWAP
+                { Self::MODULUS_LIMBS[0] }
+                limb_add_carry3
+                OP_TOALTSTACK
+
                 for i in 1..Self::N_LIMBS-1 {
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ B₁ C₀⁻ 2²⁹ C₀⁺
-                    OP_2SWAP
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ 2²⁹ C₀⁺ B₁ C₀⁻
+                    { Self::MODULUS_LIMBS[i as usize] }
                     OP_ADD
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ A₁ 2²⁹ C₀⁺ B₁+C₀⁻
+                    OP_SWAP
                     OP_2SWAP
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺ B₁+C₀⁻ A₁ 2²⁹
-                    OP_TOALTSTACK OP_SWAP OP_FROMALTSTACK
-                    limb_sub_borrow
+                    OP_4 OP_ROLL
+                    OP_ROT
+                    OP_ROT
+                    OP_ADD
+                    limb_sub_borrow4
                     OP_DUP
                     OP_TOALTSTACK
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₀⁺ 2²⁹ C₁⁻ A₁-(B₁+C₀) | A₁-(B₁+C₀)
                     OP_2SWAP
-                    OP_SWAP
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ A₁-(B₁+C₀) 2²⁹ C₀⁺
-                    { Self::MODULUS_LIMBS[i as usize] }
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ A₁-(B₁+C₀) 2²⁹ C₀⁺ M₁
-                    OP_ADD
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ A₁-(B₁+C₀) 2²⁹ C₀⁺+M₁
-                    OP_SWAP
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ A₁-(B₁+C₀) C₀⁺+M₁ 2²⁹
-                    limb_add_carry
+                    OP_ROT OP_ROT
+                    limb_add_carry3
                     OP_TOALTSTACK
-                    // ⋯ A₈ B₈ A₇ B₇ A₆ B₆ A₅ B₅ A₄ B₄ A₃ B₃ A₂ B₂ C₁⁻ 2²⁹ C₁⁺ | (A₁-(B₁+C₀))+(C₀⁺+M₁)
+
                 }
-                // ⋯ A₈ B₈ C₇⁻ 2²⁹ C₇⁺
-                OP_2SWAP
+                { *Self::MODULUS_LIMBS.last().unwrap() }
                 OP_ADD
-                // ⋯ A₈ 2²⁹ C₇⁺ B₈+C₇⁻
+                OP_SWAP
                 OP_2SWAP
-                // ⋯ C₇⁺ B₈+C₇⁻ A₈ 2²⁹
-                OP_TOALTSTACK OP_SWAP OP_FROMALTSTACK
-                // ⋯ C₇⁺ A₈ B₈+C₇⁻ 2²⁹
-                limb_sub_borrow
-                // ⋯ C₇⁺ 2²⁹ C₈⁻ A₈-(B₈+C₇⁻)
+                OP_4 OP_ROLL
+                OP_ROT
+                OP_ROT
+                OP_ADD
+                limb_sub_borrow4
                 OP_DUP
                 OP_TOALTSTACK
-                // ⋯ C₇⁺ 2²⁹ C₈⁻ A₈-(B₈+C₇⁻) | A₈-(B₈+C₇⁻)
-                OP_ROT OP_TOALTSTACK
-                // ⋯ C₇⁺ C₈⁻ A₈-(B₈+C₇⁻) | 2²⁹ A₈-(B₈+C₇⁻)
-                OP_ROT { *Self::MODULUS_LIMBS.last().unwrap() }
-                // ⋯ C₈⁻ (A₈-(B₈+C₇⁻)) C₇⁺ M₈
-                OP_ADD OP_ADD
-                // ⋯ C₈⁻ (A₈-(B₈+C₇⁻))+(C₇⁺+M₈)
-                OP_FROMALTSTACK OP_2DUP OP_GREATERTHANOREQUAL
-                OP_IF OP_SUB OP_ELSE OP_DROP OP_ENDIF
+                OP_2SWAP
+                OP_ROT
+                OP_ROT
+                OP_ADD OP_2DUP
+                OP_LESSTHANOREQUAL
+                OP_IF
+                    OP_OVER OP_SUB
+                OP_ENDIF
                 OP_TOALTSTACK
+                OP_DROP
+
                 // ⋯ C₈⁻ | (A₈-(B₈+C₇⁻))+(C₇⁺+M)₈ A₈-(B₈+C₇⁻)
                 OP_DUP
                 // ⋯ C₈⁻ C₈⁻
@@ -451,70 +356,62 @@ pub trait Fp254Impl {
         script! {
             { Self::roll(a) }
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀
+
             OP_DUP
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀ A₀
+            OP_ADD
             { 0x20000000 }
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀ A₀ 2²⁹
-
-            // A₀ + A₀
-            limb_add_carry
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀
+            OP_SWAP
+            OP_2DUP
+            OP_LESSTHANOREQUAL
+            OP_TUCK
+            OP_IF
+                2 OP_PICK OP_SUB
+            OP_ENDIF
             OP_DUP
             OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁺ 2⋅A₀ | 2⋅A₀
-            OP_ROT
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ C₀⁺ 2⋅A₀ 2²⁹
-            { Self::MODULUS_LIMBS[0] }
-            OP_SWAP
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ C₀⁺ 2⋅A₀ M₀ 2²⁹
-            limb_sub_borrow
-            OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ C₀⁺ 2²⁹ C₀⁻ | 2⋅A₀-M₀
 
-            // from     A₁      + A₁        + carry_0
-            //   to     A{N-2}  + A{N-2}    + carry_{N-3}
+            { Self::MODULUS_LIMBS[0] }
+            limb_sub_borrow3
+            OP_TOALTSTACK
+
             for i in 1..Self::N_LIMBS-1 {
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ C₀⁺ 2²⁹ C₀⁻
-                OP_SWAP OP_2SWAP
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻ 2²⁹ A₁ C₀⁺
-                OP_OVER OP_ADD
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻ 2²⁹ A₁ A₁+C₀⁺
-                OP_ROT
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻ A₁ A₁+C₀⁺ 2²⁹
-                limb_add_carry
+                { Self::MODULUS_LIMBS[i as usize] }
+                OP_ADD
+                OP_SWAP
+                OP_2SWAP
+                OP_ROT OP_ROT
+                OP_DUP
+                OP_ADD
+                limb_add_carry3
                 OP_DUP
                 OP_TOALTSTACK
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₀⁻ 2²⁹ C₁⁺ 2⋅A₁+C₀⁺ | 2⋅A₁+C₀⁺
-                OP_ROT OP_TOALTSTACK OP_ROT
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₁⁺ 2⋅A₁+C₀⁺ C₀⁻ | 2²⁹
-                { Self::MODULUS_LIMBS[i as usize] }
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₁⁺ 2⋅A₁+C₀⁺ C₀⁻ M₁
-                OP_ADD
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₁⁺ 2⋅A₁+C₀⁺ C₀⁻+M₁
-                OP_FROMALTSTACK
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₁⁺ 2⋅A₁+C₀⁺ C₀⁻+M₁ 2²⁹
-                limb_sub_borrow
+                OP_3 OP_ROLL
+                limb_sub_borrow3
                 OP_TOALTSTACK
-                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ C₁⁺ 2²⁹ C₁⁻ | (2⋅A₁+C₀⁺)-(C₀⁻+M₁)
+
             }
-            // ⋯ A₈ C₇⁺ 2²⁹ C₇⁻
-            OP_2SWAP
-            // ⋯ 2²⁹ C₇⁻ A₈ C₇⁺
-            OP_OVER OP_ADD
-            // ⋯ 2²⁹ C₇⁻ A₈ A₈+C₇⁺
-            OP_ADD
-            // ⋯ 2²⁹ C₇⁻ 2⋅A₈+C₇⁺
-            OP_DUP OP_TOALTSTACK
-            // ⋯ 2²⁹ C₇⁻ 2⋅A₈+C₇⁺ | 2⋅A₈+C₇⁺
-            OP_SWAP
-            // ⋯ 2²⁹ 2⋅A₈+C₇⁺ C₇⁻
             { *Self::MODULUS_LIMBS.last().unwrap() }
-            // ⋯ 2²⁹ 2⋅A₈+C₇⁺ C₇⁻ M₈
             OP_ADD
-            OP_ROT
-            // ⋯ 2⋅A₈+C₇⁺ C₇⁻+M₈ 2²⁹
-            limb_sub_borrow
+            OP_SWAP
+            OP_2SWAP
+            OP_ROT OP_ROT
+            OP_DUP
+            OP_ADD
+            OP_ADD
+            OP_DUP
             OP_TOALTSTACK
+            OP_ROT
+            OP_SUB
+            OP_DUP
+            0
+            OP_LESSTHAN
+            OP_TUCK
+            OP_IF
+                2 OP_PICK OP_ADD
+            OP_ENDIF
+            OP_TOALTSTACK
+
+
             // ⋯ 2²⁹ C₈⁻ | (2⋅A₈+C₇⁺)-(C₇⁻+M₈)
             OP_NIP
             OP_DUP


### PR DESCRIPTION
This PR optimizes the U254 (add1, add, sub, double, mul) and Fq (add, sub, neg, double) by replacing inefficient 'limb_add_carry' and 'limb_sub_borrow' functions with new 'limb_add_create_carry' and 'limb_sub_create_borrow' functions. It also optimizes the U254 (add, sub, double) operations by rolling limbs when needed instead of zipping, which can also be applied to Fq operations. Since these operations are basic, various other scripts are also slightly optimized.

This contribution is from Citrea Team, thanks to my teammates @Hakkush-07, @ekrembal.
We plan to open-source one more important step in upcoming days, mainly related to splitting the verifier script into 4mb pieces. This PR helps us with that improvement.

```
U254::add1      130 -> 114
U254::add       190 -> 140
U254::sub       197 -> 156
U254::double    171 -> 132
U254::mul    116218 -> 93651

Fq::add         428 -> 393
Fq::sub         444 -> 418
Fq::neg         194 -> 171
Fq::double      389 -> 349
```