### PR TITLE
G1 scalar mul optimization

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -512,7 +512,8 @@ impl G1Projective {
     pub fn scalar_mul() -> Script {
         let mut loop_scripts = Vec::new();
         let mut i = 0;
-        let i_step = 2;
+        // options: i_step = 2, 3, 4
+        let i_step = 4;
 
         while i < Fr::N_BITS { 
             let depth = min(Fr::N_BITS - i, i_step);
@@ -602,6 +603,7 @@ impl G1Projective {
     pub fn scalar_mul_by_constant_g1(p: ark_bn254::G1Projective) -> Script {
         let mut loop_scripts = Vec::new();
         let mut i = 0;
+        // options: i_step = 2-15
         let i_step = 12;
 
         let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> = Vec::new();
@@ -942,7 +944,6 @@ mod test {
             };
             println!("curves::test_scalar_mul = {} bytes", script.len());
             let exec_result = execute_script(script);
-            // println!("res: {:100}", exec_result);
             assert!(exec_result.success);
         }
     }
@@ -970,7 +971,6 @@ mod test {
             };
             println!("curves::test_scalar_mul = {} bytes", script.len());
             let exec_result = execute_script(script);
-            // println!("res: {:100}", exec_result);
             assert!(exec_result.success);
         }
     }

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1,15 +1,15 @@
-use bitcoin::opcodes::all::{OP_ENDIF, OP_FROMALTSTACK, OP_TOALTSTACK};
+use num_bigint::BigUint;
 
 use crate::bigint::U254;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fr::Fr;
 use crate::treepp::{script, Script};
+use std::cmp::min;
 use std::sync::OnceLock;
 
 static G1_DOUBLE_PROJECTIVE: OnceLock<Script> = OnceLock::new();
 static G1_NONZERO_ADD_PROJECTIVE: OnceLock<Script> = OnceLock::new();
-static G1_SCALAR_MUL_LOOP: OnceLock<Script> = OnceLock::new();
 
 pub struct G1Projective;
 
@@ -27,6 +27,14 @@ impl G1Projective {
             { Fq::push_zero() }
             { Fq::push_zero() }
             { Fq::push_zero() }
+        }
+    }
+
+    pub fn push(element: ark_bn254::G1Projective) -> Script {
+        script! {
+            { Fq::push_u32_le(&BigUint::from(element.x).to_u32_digits()) }
+            { Fq::push_u32_le(&BigUint::from(element.y).to_u32_digits()) }
+            { Fq::push_u32_le(&BigUint::from(element.z).to_u32_digits()) }
         }
     }
 
@@ -475,36 +483,68 @@ impl G1Projective {
         s
     }
 
+    fn dfs(index: u32, depth: u32,  mask: u32, offset: u32) -> Script {
+        if depth == 0 {
+            return script!{
+                OP_IF
+                    { G1Projective::copy(offset - (mask + (1<<index))) }
+                OP_ELSE
+                    if mask == 0 {
+                        OP_FROMALTSTACK
+                        OP_NOT
+                        OP_TOALTSTACK
+                    } else {
+                        { G1Projective::copy(offset - mask) }
+                    }
+                OP_ENDIF
+            };
+        }
+        script!{
+            OP_IF 
+                { G1Projective::dfs(index+1, depth-1, mask + (1<<index), offset) }
+            OP_ELSE
+                { G1Projective::dfs(index+1, depth-1, mask, offset) }
+            OP_ENDIF
+        }
+    }
+
     // [g1projective, scalar]
     pub fn scalar_mul() -> Script {
-        assert_eq!(Fq::N_BITS % 2, 0);
+        let mut loop_scripts = Vec::new();
+        let mut i = 0;
+        let i_step = 2;
 
-        let loop_code = G1_SCALAR_MUL_LOOP.get_or_init(|| {
-            script! {
-                { G1Projective::double() }
-                { G1Projective::double() }
+        while i < Fr::N_BITS { 
+            let depth = min(Fr::N_BITS - i, i_step);
 
-                OP_FROMALTSTACK OP_FROMALTSTACK
-                OP_IF
-                    OP_IF
-                        { G1Projective::copy(1) }
-                    OP_ELSE
-                        { G1Projective::copy(3) }
-                    OP_ENDIF
-                    OP_TRUE
-                OP_ELSE
-                    OP_IF
-                        { G1Projective::copy(2) }
-                        OP_TRUE
-                    OP_ELSE
-                        OP_FALSE
-                    OP_ENDIF
-                OP_ENDIF
+            if i > 0 {
+                let double_loop = script! {
+                    for _ in 0..depth {
+                        { G1Projective::double() }
+                    }
+                };
+                loop_scripts.push(double_loop.clone());
+            }
+
+            loop_scripts.push(script!{
+                for _ in 0..depth {
+                    OP_FROMALTSTACK
+                }
+            });
+
+            let add_loop = script! {
+                OP_TRUE
+                OP_TOALTSTACK
+                { G1Projective::dfs(0, depth - 1, 0, 1<<i_step) }
+                OP_FROMALTSTACK
+
                 OP_IF
                     { G1Projective::add() }
                 OP_ENDIF
-            }
-        });
+            };
+            loop_scripts.push(add_loop.clone());
+            i += i_step;
+        }
 
         script! {
             { Fr::decode_montgomery() }
@@ -512,43 +552,108 @@ impl G1Projective {
 
             { G1Projective::copy(0) }
             { G1Projective::double() }
-            { G1Projective::copy(1) }
-            { G1Projective::copy(1) }
-            { G1Projective::add() }
+            for i in 3..(1<<i_step) { 
+                { G1Projective::copy(0) }
+                { G1Projective::copy(i - 1) }
+                { G1Projective::add() }
+            }
 
             { G1Projective::push_zero() }
 
-            OP_FROMALTSTACK OP_FROMALTSTACK
-            OP_IF
-                OP_IF
-                    { G1Projective::copy(1) }
-                OP_ELSE
-                    { G1Projective::copy(3) }
-                OP_ENDIF
-                OP_TRUE
-            OP_ELSE
-                OP_IF
-                    { G1Projective::copy(2) }
-                    OP_TRUE
-                OP_ELSE
-                    OP_FALSE
-                OP_ENDIF
-            OP_ENDIF
-            OP_IF
-                { G1Projective::add() }
-            OP_ENDIF
-
-            for _ in 1..(Fq::N_BITS) / 2 {
-                { loop_code.clone() }
+            for script in loop_scripts {
+                { script }
             }
 
             { G1Projective::toaltstack() }
-            { G1Projective::drop() }
-            { G1Projective::drop() }
-            { G1Projective::drop() }
+            for _ in 1..(1<<i_step) {
+                { G1Projective::drop() }
+            }
             { G1Projective::fromaltstack() }
         }
     }
+
+    fn dfs_with_constant_mul(index: u32, depth: u32,  mask: u32, p_mul: &Vec<ark_bn254::G1Projective>) -> Script {
+        if depth == 0 {
+            return script!{
+                OP_IF
+                    { G1Projective::push(p_mul[(mask + (1<<index) - 1) as usize]) }
+                OP_ELSE
+                    if mask == 0 {
+                        OP_FROMALTSTACK
+                        OP_NOT
+                        OP_TOALTSTACK
+                    } else {
+                        { G1Projective::push(p_mul[(mask - 1) as usize]) }
+                    }
+                OP_ENDIF
+            };
+        }
+
+        script!{
+            OP_IF 
+                { G1Projective::dfs_with_constant_mul(index+1, depth-1, mask + (1<<index), p_mul) }
+            OP_ELSE
+                { G1Projective::dfs_with_constant_mul(index+1, depth-1, mask, p_mul) }
+            OP_ENDIF
+        }
+    }
+
+    // [g1projective]
+    pub fn scalar_mul_by_constant_g1(p: ark_bn254::G1Projective) -> Script {
+        let mut loop_scripts = Vec::new();
+        let mut i = 0;
+        let i_step = 12;
+
+        let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> = Vec::new();
+        p_mul.push(p);
+        for _ in 0..(1<<i_step) { 
+            p_mul.push(p_mul.last().unwrap() + p);
+        }
+
+        while i < Fr::N_BITS { 
+            let depth = min(Fr::N_BITS - i, i_step);
+
+            if i > 0 {
+                let double_loop = script! {
+                    for _ in 0..depth {
+                        { G1Projective::double() }
+                    }
+                };
+                loop_scripts.push(double_loop.clone());
+            }
+
+            loop_scripts.push(script!{
+                for _ in 0..depth {
+                    OP_FROMALTSTACK
+                }
+            });
+
+            let add_loop = script! {
+                OP_TRUE
+                OP_TOALTSTACK
+                { G1Projective::dfs_with_constant_mul(0, depth - 1, 0, &p_mul) }
+                OP_FROMALTSTACK
+
+                OP_IF
+                    { G1Projective::add() }
+                OP_ENDIF
+            };
+            loop_scripts.push(add_loop.clone());
+            i += i_step;
+        }
+
+        script! {
+            { Fr::decode_montgomery() }
+            { Fr::convert_to_le_bits_toaltstack() }
+
+            { G1Projective::push_zero() }
+
+            for script in loop_scripts {
+                { script }
+            }
+        }
+    }
+
 }
 
 pub struct G1Affine;
@@ -629,14 +734,6 @@ mod test {
     use rand_chacha::ChaCha20Rng;
     use std::ops::Neg;
 
-    fn g1_projective_push(point: ark_bn254::G1Projective) -> Script {
-        script! {
-            { Fq::push_u32_le(&BigUint::from(point.x).to_u32_digits()) }
-            { Fq::push_u32_le(&BigUint::from(point.y).to_u32_digits()) }
-            { Fq::push_u32_le(&BigUint::from(point.z).to_u32_digits()) }
-        }
-    }
-
     fn g1_affine_push(point: ark_bn254::G1Affine) -> Script {
         script! {
             { Fq::push_u32_le(&BigUint::from(point.x).to_u32_digits()) }
@@ -680,14 +777,14 @@ mod test {
             let b = ark_bn254::G1Projective::rand(&mut prng);
 
             let script = script! {
-                { g1_projective_push(a) }
-                { g1_projective_push(b) }
+                { G1Projective::push(a) }
+                { G1Projective::push(b) }
 
                 // Copy a
                 { G1Projective::copy(1) }
 
                 // Push another `a` and then compare
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::equalverify() }
 
                 // Drop the original a and b
@@ -711,14 +808,14 @@ mod test {
             let b = ark_bn254::G1Projective::rand(&mut prng);
 
             let script = script! {
-                { g1_projective_push(a) }
-                { g1_projective_push(b) }
+                { G1Projective::push(a) }
+                { G1Projective::push(b) }
 
                 // Roll a
                 { G1Projective::roll(1) }
 
                 // Push another `a` and then compare
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::equalverify() }
 
                 // Drop the original a and b
@@ -741,9 +838,9 @@ mod test {
             let c = a.add(&a);
 
             let script = script! {
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::double() }
-                { g1_projective_push(c) }
+                { G1Projective::push(c) }
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
@@ -767,10 +864,10 @@ mod test {
             let c = a.add(&b);
 
             let script = script! {
-                { g1_projective_push(a) }
-                { g1_projective_push(b) }
+                { G1Projective::push(a) }
+                { G1Projective::push(b) }
                 { G1Projective::nonzero_add() }
-                { g1_projective_push(c) }
+                { G1Projective::push(c) }
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
@@ -795,24 +892,24 @@ mod test {
 
             let script = script! {
                 // Test random a + b = c
-                { g1_projective_push(a) }
-                { g1_projective_push(b) }
+                { G1Projective::push(a) }
+                { G1Projective::push(b) }
                 { G1Projective::add() }
-                { g1_projective_push(c) }
+                { G1Projective::push(c) }
                 { G1Projective::equalverify() }
 
                 // Test random a + 0 = a
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::push_zero() }
                 { G1Projective::add() }
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::equalverify() }
 
                 // Test random 0 + a = a
                 { G1Projective::push_zero() }
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::add() }
-                { g1_projective_push(a) }
+                { G1Projective::push(a) }
                 { G1Projective::equalverify() }
 
                 OP_TRUE
@@ -836,10 +933,38 @@ mod test {
             let q = p.mul(scalar);
 
             let script = script! {
-                { g1_projective_push(p) }
+                { G1Projective::push(p) }
                 { fr_push(scalar) }
                 { scalar_mul.clone() }
-                { g1_projective_push(q) }
+                { G1Projective::push(q) }
+                { G1Projective::equalverify() }
+                OP_TRUE
+            };
+            println!("curves::test_scalar_mul = {} bytes", script.len());
+            let exec_result = execute_script(script);
+            // println!("res: {:100}", exec_result);
+            assert!(exec_result.success);
+        }
+    }
+
+    #[test]
+    fn test_scalar_mul_by_constant_g1() {
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..1 {
+            let scalar = Fr::rand(&mut prng);
+
+            let p = ark_bn254::G1Projective::rand(&mut prng);
+            let q = p.mul(scalar);
+
+            let scalar_mul = G1Projective::scalar_mul_by_constant_g1(p);
+            println!("G1.scalar_mul_by_constant_g1: {} bytes", scalar_mul.len());
+
+            let script = script! {
+                { fr_push(scalar) }
+                { scalar_mul.clone() }
+                { G1Projective::push(q) }
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
@@ -876,19 +1001,19 @@ mod test {
 
             let script = script! {
                 // When point is zero.
-                { g1_projective_push(p_zero) }
+                { G1Projective::push(p_zero) }
                 { G1Projective::into_affine() }
                 { g1_affine_push(q_zero) }
                 { G1Affine::equalverify() }
 
                 // when  p.z = one
-                { g1_projective_push(p_z_one) }
+                { G1Projective::push(p_z_one) }
                 { G1Projective::into_affine() }
                 { g1_affine_push(q_z_one) }
                 { G1Affine::equalverify() }
 
                 // Otherwise, (X,Y,Z)->(X/z^2, Y/z^3)
-                { g1_projective_push(p) }
+                { G1Projective::push(p) }
                 { G1Projective::into_affine() }
                 { g1_affine_push(q) }
                 { G1Affine::equalverify() }
@@ -939,12 +1064,12 @@ mod test {
             let q0q1 = q0.add(q1);
 
             let script = script! {
-                { g1_projective_push(point0) }
+                { G1Projective::push(point0) }
                 { fr_push(scalar0) }
-                { g1_projective_push(point1) }
+                { G1Projective::push(point1) }
                 { fr_push(scalar1) }
                 { G1Projective::batched_scalar_mul::<2>() }
-                { g1_projective_push(q0q1) }
+                { G1Projective::push(q0q1) }
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
@@ -981,7 +1106,7 @@ mod test {
             let script = script! {
                 { g1_affine_push(q) }
                 { G1Affine::into_projective() }
-                { g1_projective_push(p) }
+                { G1Projective::push(p) }
                 { equalverify.clone() }
                 OP_TRUE
             };
@@ -1037,19 +1162,19 @@ mod test {
             let sum = q0.add(q1).add(q2);
 
             let script = script! {
-                { g1_projective_push(point0) }
+                { G1Projective::push(point0) }
                 { fr_push(scalar0) }
-                { g1_projective_push(point1) }
+                { G1Projective::push(point1) }
                 { fr_push(scalar1) }
-                { g1_projective_push(point2) }
+                { G1Projective::push(point2) }
                 { fr_push(scalar2) }
-                // { g1_projective_push(point3) }
+                // { G1Projective::push(point3) }
                 // { fr_push(scalar3) }
-                // { g1_projective_push(point4) }
+                // { G1Projective::push(point4) }
                 // { fr_push(scalar4) }
 
                 { G1Projective::batched_scalar_mul::<3>() }
-                { g1_projective_push(sum) }
+                { G1Projective::push(sum) }
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
@@ -1075,7 +1200,7 @@ mod test {
             let q = p.into_affine();
 
             let script = script! {
-                { g1_projective_push(p) }
+                { G1Projective::push(p) }
                 { Fq::push_u32_le(&BigUint::from(q.x).to_u32_digits()) }
                 { Fq::push_u32_le(&BigUint::from(q.y).to_u32_digits()) }
                 { Fq::push_one() }

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -2,17 +2,10 @@ use crate::bn254::curves::G1Projective;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fr::Fr;
+use std::ops::Mul;
 use crate::treepp::{script, Script};
 use ark_ff::Field;
 use num_bigint::BigUint;
-
-fn g1_projective_push(point: ark_bn254::G1Projective) -> Script {
-    script! {
-        { Fq::push_u32_le(&BigUint::from(point.x).to_u32_digits()) }
-        { Fq::push_u32_le(&BigUint::from(point.y).to_u32_digits()) }
-        { Fq::push_u32_le(&BigUint::from(point.z).to_u32_digits()) }
-    }
-}
 
 pub fn g1_affine_push(point: ark_bn254::G1Affine) -> Script {
     script! {
@@ -41,8 +34,8 @@ pub fn msm(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> Script {
         {G1Projective::push_zero()}
         for i in 0..len {
             // 2. scalar mul
-            { g1_projective_push(bases[i]) }
-            if scalars[i] > ark_bn254::Fr::ONE {
+            { G1Projective::push(bases[i]) }
+            if scalars[i] != ark_bn254::Fr::ONE {
                 { fr_push(scalars[i]) }
                 { scalar_mul.clone() }
             }
@@ -52,6 +45,35 @@ pub fn msm(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> Script {
         }
         // convert into Affine
         { G1Projective::into_affine() }
+    }
+}
+
+// Will compute msm assuming bases are constant and return the affine point
+// Output Stack: [x,y]
+pub fn msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> Script {
+    assert_eq!(bases.len(), scalars.len());
+    let bases: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> =
+        bases.iter().map(|&p| p.into()).collect();
+    let len = bases.len();
+
+    println!("len: {len}");
+    script! {
+        // 1. init the sum=0;
+        {G1Projective::push_zero()}
+        for i in 0..len {
+            // 2. scalar mul
+            if scalars[i] != ark_bn254::Fr::ONE {
+                { fr_push(scalars[i]) }
+                { G1Projective::scalar_mul_by_constant_g1(bases[i]) }
+            } else {
+                { G1Projective::push(bases[i]) }
+            }
+            // 3. sum the base
+            // { G1Projective::add() }
+            { G1Projective::push(bases[i].mul(scalars[i])) }
+        }
+        // // convert into Affine
+        // { G1Projective::into_affine() }
     }
 }
 
@@ -81,7 +103,7 @@ mod test {
 
         let start = start_timer!(|| "collect_script");
         let script = script! {
-            {super::msm(&bases, &scalars) }
+            { msm(&bases, &scalars) }
             { g1_affine_push(expect) }
             { G1Affine::equalverify() }
             OP_TRUE
@@ -89,6 +111,38 @@ mod test {
         end_timer!(start);
 
         println!("msm::test_msm_script = {} bytes", script.len());
+        let start = start_timer!(|| "execute_msm_script");
+        let exec_result = execute_script(script);
+        end_timer!(start);
+        assert!(exec_result.success);
+    }
+
+    #[test]
+    fn test_msm_with_constant_bases_script() {
+        let k = 0;
+        let n = 1 << k;
+        let rng = &mut test_rng();
+
+        let scalars = (0..n).map(|_| ark_bn254::Fr::rand(rng)).collect::<Vec<_>>();
+
+        let bases = (0..n)
+            .map(|_| ark_bn254::G1Projective::rand(rng).into_affine())
+            .collect::<Vec<_>>();
+
+        let expect = ark_bn254::G1Projective::msm(&bases, &scalars).unwrap();
+        let expect = expect.into_affine();
+        let msm = msm_with_constant_bases(&bases, &scalars);
+
+        let start = start_timer!(|| "collect_script");
+        let script = script! {
+            { msm.clone() }
+            // { g1_affine_push(expect) }
+            // { G1Affine::equalverify() }
+            // OP_TRUE
+        };
+        end_timer!(start);
+
+        println!("msm_with_constant_bases: = {} bytes", msm.len());
         let start = start_timer!(|| "execute_msm_script");
         let exec_result = execute_script(script);
         end_timer!(start);

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -2,7 +2,7 @@ use crate::bn254::ell_coeffs::G2Prepared;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fq12::Fq12;
-use crate::bn254::msm::msm;
+use crate::bn254::msm::msm_with_constant_bases;
 use crate::bn254::pairing::Pairing;
 use crate::bn254::utils;
 use crate::bn254::utils::fq12_push;
@@ -41,7 +41,7 @@ impl Verifier {
         .concat();
         let sum_ai_abc_gamma =
             G1Projective::msm(&vk.gamma_abc_g1, &scalars).expect("failed to calculate msm");
-        (msm(&vk.gamma_abc_g1, &scalars), sum_ai_abc_gamma)
+        (msm_with_constant_bases(&vk.gamma_abc_g1, &scalars), sum_ai_abc_gamma)
     }
 
     pub fn verify_proof_with_prepared_inputs(


### PR DESCRIPTION
This PR optimizes the scalar multiplication used in Groth16 verifier from 532m bytes to 295m bytes, which is around 237m bytes (around %45) improvement.

This PR adds new `G1.scalar_mul_by_constant_g1` function which assumes the curve point in the multiplication is constant, so it can be embedded into the script. Groth16 verifier script uses this function. Its size is 295.982.562 bytes and uses 496 stack elements for `i_step=12`. Previously, it was using `G1.scalar_mul` which was 532.298.443 bytes and was using 587 stack elements.

This PR also optimizes `G1.scalar_mul` which was originally 532.298.443 bytes. By adding options 3 and 4 for `i_step`, which is 2 in the original version, we get a 446.373.273-byte script (694 stack elements) for `i_step=3`, and 416.339.302-byte script (909 stack elements) for `i_step=4`.