### PR TITLE
~50% Optimization of Field Multiplication with Lookup Table

### DIFF
--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -3,13 +3,16 @@ use crate::bigint::bits::limb_to_be_bits;
 use crate::bigint::sub::limb_sub_borrow;
 use crate::bigint::U254;
 use crate::bigint::u29x9::{u29x9_mul_karazuba, u29x9_mul_karazuba_imm, u29x9_mulhi_karazuba_imm, u29x9_mullo_karazuba_imm, u29x9_square};
+use crate::bn254::fq::Fq;
+use crate::bn254::utils::fq_to_bits;
 use crate::pseudo::OP_256MUL;
 use crate::treepp::*;
-use ark_ff::{BigInteger, PrimeField};
+use ark_ff::{BigInt, BigInteger, PrimeField};
 use bitcoin_script::script;
 use num_bigint::BigUint;
 use num_traits::{Num, One};
 use std::ops::{Add, Div, Mul, Rem, Shl};
+use std::str::FromStr;
 use std::sync::OnceLock;
 
 pub trait Fp254Impl {
@@ -508,6 +511,315 @@ pub trait Fp254Impl {
             }
         })
         .clone()
+    }
+
+    // create table for top item on the stack
+    fn init_table(window: u32) -> Script {
+        assert!(
+            1 <= window && window <= 6,
+            "expected 1<=window<=6; got window={}",
+            window
+        );
+        script! {
+            for i in 2..=window {
+                for j in 1 << (i - 1)..1 << i {
+                    if j % 2 == 0 {
+                        { U254::copy(j/2 - 1) }
+                        { U254::double(0) }
+                    } else {
+                        { U254::copy(0) }
+                        { U254::copy(j - 1) }
+                        { U254::add(1, 0) }
+                    }
+                }
+            }
+        }
+    }
+
+    fn mul_bucket() -> Script {
+        let q_big = BigUint::from_str_radix(Fq::MODULUS, 16).unwrap();
+        let q_limbs = fq_to_bits(BigInt::<4>::from_str(&q_big.to_str_radix(10)).unwrap(), 4);
+
+        script! {
+                // stack: {a} {b} {p}
+                { U254::roll(1) } // {a} {p} {b}
+                { U254::toaltstack() }
+                { U254::toaltstack() }
+                { U254::toaltstack() }
+
+                // keep the window size is 16 = 1 << 4
+                { U254::push_zero() }
+                { U254::fromaltstack() }
+                { Self::init_table(4) }
+                // keep the window size is 16 = 1 << 4
+                { U254::push_zero() }
+                { U254::fromaltstack() }
+                { Self::init_table(4) }
+
+                { U254::fromaltstack() }
+                { Fq::convert_to_be_u4().clone() }
+
+                // {a_table} {q_table} {b} {q}
+                for i in 0..64 {
+
+                    { 16 }
+                    { q_limbs[63 - i]}
+                    OP_SUB
+                    // cal offset: index * 9 + 64
+                    OP_DUP
+                    OP_DUP
+                    OP_ADD // 2 * index
+                    OP_DUP
+                    OP_ADD // 4 * index
+                    OP_DUP
+                    OP_ADD // 8 * index
+                    OP_ADD // 9 * index
+                    { 63 - i}
+                    OP_ADD
+
+                    // TO ALTSTACK
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+
+                    // get target bucket
+                    OP_PICK
+
+                    for _ in 0..8 {
+                        OP_FROMALTSTACK
+                        OP_PICK
+                    }
+
+                    // push bucket element to element
+                    // | y_0 * x
+                    { U254::toaltstack() }
+
+                    // 32 - stack
+                    { 16 }
+                    OP_SWAP
+                    OP_SUB
+                    // cal offset: index * 9 + 64
+                    OP_DUP
+                    OP_DUP
+                    OP_ADD // 2 * index
+                    OP_DUP
+                    OP_ADD // 4 * index
+                    OP_DUP
+                    OP_ADD // 8 * index
+                    OP_ADD // 9 * index
+                    { 63 - i + 144 - 1 } // 16 * 9 = 144
+                    OP_ADD
+
+                    // TO ALTSTACK
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+
+                    // get target bucket
+                    OP_PICK
+
+                    for _ in 0..8 {
+                        OP_FROMALTSTACK
+                        OP_PICK
+                    }
+
+                    { U254::fromaltstack() }
+
+                    { U254::sub(1, 0) }
+
+                    if i == 0 {
+                        { U254::toaltstack() }
+                    } else {
+                        { U254::fromaltstack() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::add(1, 0)}
+                        { U254::toaltstack() }
+                    }
+                }
+                // {a_tablr} {q_table} | bi * a - p_i * q (i = 0~50)
+                // drop table
+                for _ in 0..16 {
+                    { U254::drop() }
+                }
+
+                for _ in 0..16 {
+                    { U254::drop() }
+                }
+                { U254::fromaltstack() }
+
+        }
+    }
+
+    fn mul_by_constant_bucket(constant: &Self::ConstantType) -> Script {
+        let q_big = BigUint::from_str_radix(Fq::MODULUS, 16).unwrap();
+        let q_limbs = fq_to_bits(BigInt::<4>::from_str(&q_big.to_str_radix(10)).unwrap(), 4);
+
+        let b = constant.to_string();
+        let b_big = BigUint::from_str_radix(&b, 10).unwrap();
+        let b_limbs = fq_to_bits(BigInt::<4>::from_str(&b_big.to_str_radix(10)).unwrap(), 4);
+        script! {
+                // stack: {a} {p}
+                { U254::toaltstack() }
+                { U254::toaltstack() }
+
+                // keep the window size is 16 = 1 << 4
+                { U254::push_zero() }
+                { U254::fromaltstack() }
+                { Self::init_table(4) }
+                // keep the window size is 16 = 1 << 4
+                { U254::push_zero() }
+                { U254::fromaltstack() }
+                { Self::init_table(4) }
+
+                // {a_table} {q_table}
+                for i in 0..64 {
+
+                    { 16 }
+                    { q_limbs[63 - i] }
+                    //OP_SWAP
+                    OP_SUB
+                    // cal offset: index * 9 + 64
+                    OP_DUP
+                    OP_DUP
+                    OP_ADD // 2 * index
+                    OP_DUP
+                    OP_ADD // 4 * index
+                    OP_DUP
+                    OP_ADD // 8 * index
+                    OP_ADD // 9 * index
+                    //{ 63 - i + 64 - i - 1}
+                    OP_1SUB
+
+                    // TO ALTSTACK
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+
+                    // get target bucket
+                    OP_PICK
+
+                    for _ in 0..8 {
+                        OP_FROMALTSTACK
+                        OP_PICK
+                    }
+
+                    // push bucket element to element
+                    // | y_0 * x
+                    { U254::toaltstack() }
+
+                    // 32 - stack
+                    { 16 }
+                    { b_limbs[63 - i] }
+                    OP_SUB
+                    // cal offset: index * 9 + 64
+                    OP_DUP
+                    OP_DUP
+                    OP_ADD // 2 * index
+                    OP_DUP
+                    OP_ADD // 4 * index
+                    OP_DUP
+                    OP_ADD // 8 * index
+                    OP_ADD // 9 * index
+                    //{ 63 - i + 63 - i + 144 - 1 } // 16 * 9 = 144
+                    { 144 - 1 }
+                    OP_ADD
+
+                    // TO ALTSTACK
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_DUP
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+                    OP_TOALTSTACK
+
+                    // get target bucket
+                    OP_PICK
+
+                    for _ in 0..8 {
+                        OP_FROMALTSTACK
+                        OP_PICK
+                    }
+
+                    { U254::fromaltstack() }
+
+                    { U254::sub(1, 0) }
+
+                    if i == 0 {
+                        { U254::toaltstack() }
+                    } else {
+                        { U254::fromaltstack() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::double_allow_overflow() }
+                        { U254::add(1, 0)}
+                        { U254::toaltstack() }
+                    }
+                }
+                // {a_tablr} {q_table} | bi * a - p_i * q (i = 0~50)
+                // drop table
+                for _ in 0..16 {
+                    { U254::drop() }
+                }
+
+                for _ in 0..16 {
+                    { U254::drop() }
+                }
+                { U254::fromaltstack() }
+
+        }
     }
 
     fn is_zero(a: u32) -> Script { U254::is_zero(a) }
@@ -1063,6 +1375,107 @@ pub trait Fp254Impl {
             { build_u8_from_be_bits(8) }
 
             for _ in 0..31 {
+                OP_FROMALTSTACK
+            }
+        }
+    }
+
+    fn convert_to_be_u4() -> Script {
+        let build_u8_from_be_bits = |i| {
+            script! {
+                for _ in 0..(i - 1) {
+                    OP_DUP OP_ADD OP_ADD
+                }
+            }
+        };
+
+        script! {
+            // { Self::decode_montgomery() }
+            // start with the top limb
+            // 22 bits => 2 + 5 u4
+            { Self::N_LIMBS - 1 } OP_ROLL
+            { limb_to_be_bits(22) }
+            { build_u8_from_be_bits(2) } OP_TOALTSTACK
+            for _ in 0..5 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+
+            // second limb, 29 bits => 7 u4 + 1 leftover bits
+            { Self::N_LIMBS - 2 } OP_ROLL
+            { limb_to_be_bits(29) }
+            for _ in 0..7 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(1) } OP_TOALTSTACK
+
+            // third limb, 29 bits = 3 bits borrow + 6 u4 + 2 leftover bits
+            { Self::N_LIMBS - 3 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            for _ in 0..6 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(2) } OP_TOALTSTACK
+
+            // fourth limb, 29 bits = 2 bits borrow + 6 u4 + 3 leftover bits
+            { Self::N_LIMBS - 4 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(3) } OP_TOALTSTACK
+            for _ in 0..6 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(3) } OP_TOALTSTACK
+
+            // fifth limb, 30 bits = 1 bits borrow + 7 u4
+            { Self::N_LIMBS - 5 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(2) } OP_TOALTSTACK
+            for _ in 0..7 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+
+            // sixth limb, 30 bits => 7 u4 + 1 leftover bits
+            { Self::N_LIMBS - 6 } OP_ROLL
+            { limb_to_be_bits(29) }
+            for _ in 0..7 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(1) } OP_TOALTSTACK
+
+            // seventh limb, 30 bits = 3 bits borrow + 6 u4 + 2 leftover bits
+            { Self::N_LIMBS - 7 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            for _ in 0..6 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(2) } OP_TOALTSTACK
+
+            // eighth limb, 30 bits = 2 bits borrow + 6 u4 + 3 leftover bits
+            { Self::N_LIMBS - 8 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(3) } OP_TOALTSTACK
+            for _ in 0..6 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(3) } OP_TOALTSTACK
+
+            // ninth limb, 29 bits = 1 bits borrow + 7 u4
+            { Self::N_LIMBS - 9 } OP_ROLL
+            { limb_to_be_bits(29) }
+            OP_FROMALTSTACK
+            { build_u8_from_be_bits(2) } OP_TOALTSTACK
+            for _ in 0..6 {
+                { build_u8_from_be_bits(4) } OP_TOALTSTACK
+            }
+            { build_u8_from_be_bits(4) }
+
+            for _ in 0..63 {
                 OP_FROMALTSTACK
             }
         }

--- a/src/bn254/fq.rs
+++ b/src/bn254/fq.rs
@@ -490,6 +490,68 @@ mod test {
     }
 
     #[test]
+    fn test_mul_bucket() {
+        println!("Fq.mul_bucket: {} bytes", Fq::mul_bucket().len());
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        for _ in 0..1 {
+            let a = ark_bn254::Fq::rand(&mut prng);
+            let b = ark_bn254::Fq::rand(&mut prng);
+            let r = a * b;
+
+            let q_big = BigUint::from_str_radix(Fq::MODULUS, 16).unwrap();
+            let p = ((BigUint::from(a.clone()) * BigUint::from(b.clone())) - BigUint::from(r))
+                / q_big.clone();
+            let p = ark_bn254::Fq::from(p);
+
+            let script = script! {
+                { U254::push_u32_le(&BigUint::from(a.clone()).to_u32_digits()) }
+                { U254::push_u32_le(&BigUint::from(b.clone()).to_u32_digits()) }
+                { U254::push_u32_le(&BigUint::from(p.clone()).to_u32_digits()) }
+                { Fq::mul_bucket() }
+                { U254::push_u32_le(&BigUint::from(r.clone()).to_u32_digits()) }
+                { U254::equalverify(1,0) }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script.clone());
+            assert!(exec_result.success);
+            dbg!(exec_result.stats.max_nb_stack_items);
+        }
+    }
+
+    #[test]
+    fn test_mul_by_constant_bucket() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        for _ in 0..1 {
+            let a = ark_bn254::Fq::rand(&mut prng);
+            let b = ark_bn254::Fq::rand(&mut prng);
+            let r = a * b;
+
+            println!(
+                "Fq.mul_by_constant_bucket: {} bytes",
+                Fq::mul_by_constant_bucket(&b).len()
+            );
+
+            let q_big = BigUint::from_str_radix(Fq::MODULUS, 16).unwrap();
+            let p = ((BigUint::from(a.clone()) * BigUint::from(b.clone())) - BigUint::from(r))
+                / q_big.clone();
+            let p = ark_bn254::Fq::from(p);
+
+            let script = script! {
+                { U254::push_u32_le(&BigUint::from(a.clone()).to_u32_digits()) }
+                { U254::push_u32_le(&BigUint::from(p.clone()).to_u32_digits()) }
+                { Fq::mul_by_constant_bucket(&b) }
+                { U254::push_u32_le(&BigUint::from(r.clone()).to_u32_digits()) }
+                { U254::equalverify(1,0) }
+                OP_TRUE
+            };
+            let exec_result = execute_script(script.clone());
+            assert!(exec_result.success);
+            dbg!(exec_result.stats.max_nb_stack_items);
+        }
+    }
+
+    #[test]
     fn test_square() {
         println!("Fq.square: {} bytes", Fq::square().len());
         let m = BigUint::from_str_radix(Fq::MODULUS, 16).unwrap();

--- a/src/bn254/utils.rs
+++ b/src/bn254/utils.rs
@@ -3,6 +3,7 @@ use crate::bn254::ell_coeffs::EllCoeff;
 use crate::bn254::ell_coeffs::G2Prepared;
 use crate::bn254::{fq12::Fq12, fq2::Fq2};
 use ark_ec::{bn::BnConfig, AffineRepr};
+use ark_ff::BigInt;
 use ark_ff::Field;
 use num_bigint::BigUint;
 
@@ -259,6 +260,23 @@ pub fn fq12_push(element: ark_bn254::Fq12) -> Script {
             { Fq::push_u32_le(&BigUint::from(elem).to_u32_digits()) }
        }
     }
+}
+
+pub fn fq_to_bits(fq: BigInt<4>, limb_size: usize) -> Vec<u32> {
+    let mut bits: Vec<bool> = ark_ff::BitIteratorBE::new(fq.as_ref()).skip(2).collect();
+    bits.reverse();
+
+    bits.chunks(limb_size)
+        .map(|chunk| {
+            let mut factor = 1;
+            let res = chunk.iter().fold(0, |acc, &x| {
+                let r = acc + if x { factor } else { 0 };
+                factor *= 2;
+                r
+            });
+            res
+        })
+        .collect()
 }
 
 /// add two points T and Q


### PR DESCRIPTION
We are excited to merge our new optimization on Field Multiplication operations into the BitVM repository, inspired by a paper from Alpen Labs. Key improvements include:

- Reducing Field Multiplication operations from ~140K to ~76K;
- Decreasing the script size for Groth16 by ~1.08GB and for Fflonk by ~0.7GB.

Please note, this new code is not compatible with the current version due to the need to precompute a hint. The changes to the script are as follows:

- Current script code: a, b, Fq_mul;
- New script code: a, b, q, Fq_mul_bucket;

This optimization is particularly suitable for fragmentation. Special thanks to Payne, Cyimon, Paul, and Alpen Labs for their contributions.
