### PR TITLE
Schnorr signature verification

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -711,7 +711,20 @@ impl G1Affine {
     }
     // Input Stack: [x,y]
     // Output Stack: [x,y,z] (z=1)
-    pub fn into_projective() -> Script { script!({ Fq::push_one() }) }
+    //pub fn into_projective() -> Script { script!({ Fq::push_one() }) }
+    pub fn into_projective() -> Script {
+        script!{
+            { Fq::is_zero_keep_element(0) }
+            OP_TOALTSTACK
+            { Fq::is_zero_keep_element(1) }
+            OP_FROMALTSTACK OP_BOOLAND
+            OP_IF // if x == 0 and y == 0, then z = 0
+                { Fq::push_zero() }
+            OP_ELSE // else z = 1
+                { Fq::push_one() }
+            OP_ENDIF
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod pseudo;
 pub mod signatures;
 pub mod u32;
 pub mod u4;
+pub mod schnorr_bn254;
 
 /// A wrapper for the stack types to print them better.
 pub struct FmtStack(Stack);

--- a/src/schnorr_bn254/g1projective_equal.rs
+++ b/src/schnorr_bn254/g1projective_equal.rs
@@ -1,0 +1,40 @@
+use crate::treepp::{script, Script};
+
+use crate::bn254::fq::Fq;
+use crate::bn254::fp254impl::Fp254Impl;
+
+pub fn G1Projective_equal() -> Script {
+    script! {
+        OP_1 OP_TOALTSTACK // initialize result stack
+
+        { Fq::copy(3) }
+        { Fq::square() }
+        { Fq::roll(4) }
+        { Fq::copy(1) }
+        { Fq::mul() }
+
+        { Fq::copy(2) }
+        { Fq::square() }
+        { Fq::roll(3) }
+        { Fq::copy(1) }
+        { Fq::mul() }
+
+        { Fq::roll(7) }
+        { Fq::roll(2) }
+        { Fq::mul() }
+        { Fq::roll(5) }
+        { Fq::roll(4) }
+        { Fq::mul() }
+        { Fq::equal(1, 0) }
+        OP_FROMALTSTACK OP_BOOLAND OP_TOALTSTACK // and the output of equal with the result
+
+        { Fq::roll(3) }
+        { Fq::roll(1) }
+        { Fq::mul() }
+        { Fq::roll(2) }
+        { Fq::roll(2) }
+        { Fq::mul() }
+        { Fq::equal(1, 0) }
+        OP_FROMALTSTACK OP_BOOLAND // and the output of equal with the result, and leave result on the stack
+    }
+}

--- a/src/schnorr_bn254/mod.rs
+++ b/src/schnorr_bn254/mod.rs
@@ -1,0 +1,1 @@
+pub mod utility;

--- a/src/schnorr_bn254/mod.rs
+++ b/src/schnorr_bn254/mod.rs
@@ -1,1 +1,4 @@
 pub mod utility;
+pub mod g1projective_equal;
+
+pub mod schnorr_ss;

--- a/src/schnorr_bn254/mod.rs
+++ b/src/schnorr_bn254/mod.rs
@@ -2,3 +2,5 @@ pub mod utility;
 pub mod g1projective_equal;
 
 pub mod schnorr_ss;
+pub mod schnorr_ps;
+pub mod schnorr_ps_scripts;

--- a/src/schnorr_bn254/schnorr_ps.rs
+++ b/src/schnorr_bn254/schnorr_ps.rs
@@ -13,17 +13,29 @@ use ark_ff::{PrimeField, UniformRand};
 use crate::schnorr_bn254::schnorr_ps_scripts::*;
 use crate::schnorr_bn254::utility::*;
 
+/*
+    schnorr_ps refers to partitioned schnorr signature verification script
+    using the schnorr_pr_verify_scripts::new(),
+    we create a list of scripts and their intermediate inputs and outputs,
+    these scripts succeed, only if the corresponding signature verification intermediate operation is incorrect
+    (realize the not equal connotation at the end of all scripts of schnorr_ps_scripts.rs)
+    i.e. you only need to run one of these scripts on chain to prove that the calculation was incorrect.
+
+    exec_context is a simple struct defined just to encapsulate the input and the script
+ */
 pub struct exec_context {
     pub input : Vec<u8>,
     pub script : Rc<Script>,
 }
 
 pub struct schnorr_ps_verify_scripts {
+    // instances of scripts of all possible computation that we clone from
     verify_e_script : Rc<Script>,
     verify_bit_product_script : Rc<Script>,
     verify_double_script : Rc<Script>,
     verify_result_script : Rc<Script>,
 
+    // actual exec_context-s to be executed/committed on chain
     pub exec_contexts : Vec<exec_context>,
 }
 
@@ -194,7 +206,7 @@ mod test {
                         {(*x)}
                     }
                     { (*(ec.script)).clone() }
-                    OP_NOT
+                    OP_NOT // for the tests to pass we want all scripts to return 0
                 }
             );
         }

--- a/src/schnorr_bn254/schnorr_ps.rs
+++ b/src/schnorr_bn254/schnorr_ps.rs
@@ -1,0 +1,159 @@
+use crate::treepp::{script, Script};
+use std::rc::Rc;
+
+use ark_ff::BigInteger;
+use num_bigint::BigUint;
+use num_traits::Zero;
+use std::ops::{Add, Mul, Shl, Rem, Neg};
+
+use ark_bn254::{Fr, Fq, G1Affine, G1Projective};
+use ark_ec::{AffineRepr,PrimeGroup};
+use ark_ff::{PrimeField, UniformRand};
+
+use crate::schnorr_bn254::schnorr_ps_scripts::*;
+use crate::schnorr_bn254::utility::*;
+
+pub struct exec_context {
+    pub input : Vec<u8>,
+    pub script : Rc<Script>,
+}
+
+pub struct schnorr_ps_verify_scripts {
+    pub verify_e_script : Rc<Script>,
+    pub verify_bit_product_script : Rc<Script>,
+    pub verify_double_script : Rc<Script>,
+    pub verify_result_script : Rc<Script>,
+
+    pub exec_contexts : Vec<exec_context>,
+}
+
+impl schnorr_ps_verify_scripts {
+    pub fn new(data : &[u8], public_key : &G1Affine, R : &G1Affine, s : &Fr) -> (bool, schnorr_ps_verify_scripts) {
+        let mut result = schnorr_ps_verify_scripts {
+            verify_e_script : Rc::new(verify_e(data.len())),
+            verify_bit_product_script : Rc::new(verify_bit_product()),
+            verify_double_script : Rc::new(verify_double()),
+            verify_result_script : Rc::new(verify_result()),
+
+            exec_contexts : vec![],
+        };
+
+        // construct e = h(Rx || M) -> using script verify_e
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&serialize_bn254_element(&BigUint::from(R.x), true));
+        hasher.update(&data);
+        let data_hash = hasher.finalize();
+        let data_hash = data_hash.as_bytes();
+        let e : Fr = Fr::from_le_bytes_mod_order(data_hash);
+
+        // push a script for calculation of e
+        {
+            let mut input = vec![];
+            input.extend_from_slice(&serialize_bn254_element(&BigUint::from(R.x), true));
+            input.extend_from_slice(data);
+            input.extend_from_slice(&serialize_fr(&e));
+            result.exec_contexts.push(exec_context{
+                input : input,
+                script : result.verify_e_script.clone(),
+            });
+        }
+
+        // construct eP = e * P
+        let mut eP = G1Projective::zero();
+        {
+            let mut power_i = G1Projective::from(*public_key);
+            for i in 0..254 {
+                let mut eP_next = eP.clone();
+                if(e.into_bigint().get_bit(i) == true) {
+                    eP_next = eP + power_i;
+                }
+                let power_i_next = power_i + power_i;
+
+                // script for eP_next
+                {
+                    let mut input = vec![];
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(eP_next)));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i)));
+                    input.push(i as u8);
+                    input.extend_from_slice(&serialize_fr(&e));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(eP)));
+                    result.exec_contexts.push(exec_context{
+                        input : input,
+                        script : result.verify_bit_product_script.clone(),
+                    });
+                }
+
+                // script for power_i_next
+                {
+                    let mut input = vec![];
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i_next)));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i)));
+                    result.exec_contexts.push(exec_context{
+                        input : input,
+                        script : result.verify_double_script.clone(),
+                    });
+                }
+
+                eP = eP_next;
+                power_i = power_i_next;
+            }
+        }
+        assert!((eP == (G1Projective::from(*public_key) * e)), "wrong eP");
+
+        // construct Rv = s * G
+        let mut Rv = G1Projective::zero();
+        {
+            let mut power_i = G1Projective::generator();
+            for i in 0..254 {
+                let mut Rv_next = Rv.clone();
+                if(s.into_bigint().get_bit(i) == true) {
+                    Rv_next = Rv + power_i;
+                }
+                let power_i_next = power_i + power_i;
+
+                // script for Rv_next
+                {
+                    let mut input = vec![];
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(Rv_next)));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i)));
+                    input.push(i as u8);
+                    input.extend_from_slice(&serialize_fr(s));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(Rv)));
+                    result.exec_contexts.push(exec_context{
+                        input : input,
+                        script : result.verify_bit_product_script.clone(),
+                    });
+                }
+
+                // script for power_i_next
+                {
+                    let mut input = vec![];
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i_next)));
+                    input.extend_from_slice(&serialize_g1affine(&G1Affine::from(power_i)));
+                    result.exec_contexts.push(exec_context{
+                        input : input,
+                        script : result.verify_double_script.clone(),
+                    });
+                }
+
+                Rv = Rv_next;
+                power_i = power_i_next;
+            }
+        }
+        assert!((Rv == G1Projective::generator().mul(s)), "wrong Rv");
+
+        // build script for R - Rv == eP
+        {
+            let mut input = vec![];
+            input.extend_from_slice(&serialize_g1affine(R));
+            input.extend_from_slice(&serialize_g1affine(&G1Affine::from(Rv)));
+            input.extend_from_slice(&serialize_g1affine(&G1Affine::from(eP)));
+            result.exec_contexts.push(exec_context{
+                input : input,
+                script : result.verify_result_script.clone(),
+            });
+        }
+
+        return ((G1Projective::from(*R).add(Rv.neg()) == eP) , result);
+    }
+}

--- a/src/schnorr_bn254/schnorr_ps.rs
+++ b/src/schnorr_bn254/schnorr_ps.rs
@@ -162,7 +162,6 @@ impl schnorr_ps_verify_scripts {
 mod test {
     use super::*;
     use crate::{run};
-    use crate::schnorr_bn254::{schnorr_ss::*, utility::*};
 
     #[test]
     fn test_schnorr_ps() {

--- a/src/schnorr_bn254/schnorr_ps.rs
+++ b/src/schnorr_bn254/schnorr_ps.rs
@@ -162,12 +162,16 @@ impl schnorr_ps_verify_scripts {
 mod test {
     use super::*;
     use crate::{run};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
 
     #[test]
     fn test_schnorr_ps() {
         #[rustfmt::skip]
 
-        let (private_key, public_key) = generate_key_pair(0);
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let (private_key, public_key) = generate_key_pair(&mut prng);
 
         // generate some deterministic data
         const data_size : usize = 64;
@@ -177,7 +181,7 @@ mod test {
         }
 
         // sign the data promducing (R,s)
-        let (R, s) = sign(&data, &private_key, 1);
+        let (R, s) = sign(&data, &private_key, &mut prng);
         assert!(verify(&data, &public_key, &R, &s), "test failed signature logic (signing or verification) incorrect");
 
         let (verified, scripts) = schnorr_ps_verify_scripts::new(&data, &public_key, &R, &s);

--- a/src/schnorr_bn254/schnorr_ps_scripts.rs
+++ b/src/schnorr_bn254/schnorr_ps_scripts.rs
@@ -1,0 +1,150 @@
+use crate::schnorr_bn254::g1projective_equal::G1Projective_equal;
+use crate::schnorr_bn254::utility::{serialize_fr, serialize_g1affine};
+use crate::treepp::{script, Script};
+
+use crate::hash::blake3::blake3_var_length;
+
+use crate::bn254::curves::{G1Affine, G1Projective};
+use crate::bn254::fq::Fq;
+use crate::bn254::fr::Fr;
+use crate::bn254::fp254impl::Fp254Impl;
+use crate::bigint::U254;
+
+// inputs are e, data, R.x <- top of the stack
+// alll the fields with their 0th byte closest to the top of the stack
+pub fn verify_e(data_size : usize) -> Script {
+    script! {
+        { blake3_var_length(data_size + 36) } // hash (Rx || data)
+
+        // the below Fr::from_hash call requires us to reverse the output of the blake3_var_length
+        for i in 0..32 {
+            {i} OP_ROLL
+        }
+        { Fr::from_hash() }
+
+        { Fr::toaltstack() } // push generated e to the stack
+
+        { U254::from_bytes() } // convert input e to its Fr form
+
+        { Fr::fromaltstack() } // now both the e (generated and the input) are on the stack
+
+        { Fr::equal(1, 0) } // compare them both
+
+        OP_NOT
+    }
+}
+
+const input_point_size_on_stack : usize = 36 * 2;
+fn convert_to_G1Projective_from_top_bytes() -> Script {
+    script! {
+        { U254::from_bytes() }
+        { Fq::toaltstack() }
+        { U254::from_bytes() }
+        { Fq::fromaltstack() }
+        { G1Affine::into_projective() }
+    }
+}
+
+// inputs are serialized form of (Ri, Pi, i, s, Ri-1)
+// Ri being at the top of the stack
+// evaulates (Ri != Ri-1 + s[i] * Pi)
+pub fn verify_bit_product() -> Script {
+    script! {
+        // Ri to its G1Projective form and push it to alt stack
+        { convert_to_G1Projective_from_top_bytes() }
+        { G1Projective::toaltstack() }
+
+        // Pi to its G1Projective form and push it to alt stack
+        { convert_to_G1Projective_from_top_bytes() }
+        { G1Projective::toaltstack() }
+
+        // now the top of the stack are i and then s and then Ri-1
+        OP_TOALTSTACK
+        { U254::from_bytes() }
+        { Fr::decode_montgomery() } // need to decode montgomery for the scalar, for scalar multiplication
+        { Fr::convert_to_le_bits() }
+        OP_FROMALTSTACK
+        OP_ROLL // fetch the ith bit
+        // drop the rest of the 253 bits
+        OP_TOALTSTACK
+        for _ in 0..253 {
+            OP_DROP
+        }
+
+        // now the top of the alt stack is s[i]
+        // and top of the stack is Ri-1 in bytes
+
+        // convert Ri-1 into its projective from
+        { convert_to_G1Projective_from_top_bytes() }
+
+        OP_FROMALTSTACK // bring s[i] to the stack
+        OP_IF
+            { G1Projective::fromaltstack() }
+            { G1Projective::add() }
+        OP_ELSE
+            { G1Projective::fromaltstack() }
+            { G1Projective::drop() }
+        OP_ENDIF
+
+        // bring Ri from its affine from, from the altstack
+        { G1Projective::fromaltstack() }
+
+        // compare
+        { G1Projective_equal() }
+        OP_NOT
+    }
+}
+
+// inputs are serialized form of (Pi+1, Pi)
+// Pi+1 being at the top of the stack
+// evaulates (Pi+1 != 2 * Pi)
+pub fn verify_double() -> Script {
+    script!{
+        // Pi+1 into its G1Projective form and push it to alt stack
+        { convert_to_G1Projective_from_top_bytes() }
+        { G1Projective::toaltstack() }
+
+        // Pi into its G1Projective form
+        { convert_to_G1Projective_from_top_bytes() }
+
+        // double Pi
+        { G1Projective::double() }
+
+        // bring Pi+1 to the stack
+        { G1Projective::fromaltstack() }
+
+        // compare both Pi+1 and Pi * 2
+        { G1Projective_equal() }
+        OP_NOT
+    }
+}
+
+// inputs are serialized form of (R, s*G, e*P)
+// R at the top of the stack
+// evauates R - s * G != e * P
+pub fn verify_result() -> Script {
+    script!{
+        // convert R into into its G1Projective from, and push it to altstack
+        { convert_to_G1Projective_from_top_bytes() }
+        { G1Projective::toaltstack() }
+
+        // convert s * G into its G1Projective form, and then negate it
+        { convert_to_G1Projective_from_top_bytes() }
+        { G1Projective::neg() }
+
+        // add the R + (-s*G)
+        { G1Projective::fromaltstack() }
+        { G1Projective::add() }
+        { G1Projective::toaltstack() }
+
+        // convert e*P into its G1Projective form
+        { convert_to_G1Projective_from_top_bytes() }
+
+        // now move the addition result to the stack and compare it
+        { G1Projective::fromaltstack() }
+
+        // compare them
+        { G1Projective_equal() }
+        OP_NOT
+    }
+}

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -29,7 +29,7 @@ pub fn verify_schnorr_ss(data_size : usize) -> Script {
         for _ in (0..36) {// copy Rx to the top of ths stack giving us Rx || tx on the top of the stack
             {data_size + 36 + 35} OP_PICK
         }
-        { blake3_var_length(data_size + 36) } // hash (Rx || tx-without the signature attributes)
+        { blake3_var_length(data_size + 36) } // hash (Rx || data)
 
         // the below Fr::from_hash call requires us to reverse the output of the blake3_var_length, only due to its byte ordering requirements
         for i in 0..32 {

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -1,0 +1,118 @@
+use crate::schnorr_bn254::g1projective_equal::G1Projective_equal;
+use crate::treepp::{script, Script};
+
+use crate::hash::blake3::blake3_var_length;
+
+use crate::bn254::curves::{G1Affine, G1Projective};
+use crate::bn254::fq::Fq;
+use crate::bn254::fr::Fr;
+use crate::bn254::fp254impl::Fp254Impl;
+use crate::bigint::U254;
+
+// stack contents == s, R, data, public_key <- top of the stack
+// here public_key, R and s are represented similar to the output of the functions serialize_G1Affine and serialize_Fr,
+// with their 0th bytes closest to the top of the stack
+// data should be in the byte order with 0th byte closest to the top of the stack
+// refer to the testcase for more understanding
+pub fn verify_schnorr_ss(data_size : usize) -> Script {
+    script! {
+        // generate P
+        // public_key, convert it to G1Affine, then to G1Projective and then push it to the alt stack, as is
+        { U254::from_bytes() } // for y
+        { Fq::toaltstack() } // push y to alt stack
+        { U254::from_bytes() } // for x
+        { Fq::fromaltstack() } // pop y from alt stack, now we have G1Affine form of P on the stack
+        { G1Affine::into_projective() } // convert G1Affine P to G1Projective P
+        { G1Projective::toaltstack() } // push P back to alt stack
+        
+        // generate e = h(Rx || M)
+        for _ in (0..36) {// copy Rx to the top of ths stack giving us Rx || tx on the top of the stack
+            {data_size + 35} OP_PICK
+        }
+        { blake3_var_length(data_size) } // hash (Rx || tx-without the signature attributes)
+
+        // the below Fr::from_hash call requires us to reverse the output of the blake3_var_length, only due to its byte ordering requirements
+        for i in 0..32 {
+            {i} OP_ROLL
+        }
+        { Fr::from_hash() }
+
+        // now e is at the top if the stack
+        { G1Projective::fromaltstack() } // pop G1Projective P to the top of the stack
+        { Fr::roll(3) } // bring e to the top of the stack, and P right under it
+        { G1Projective::scalar_mul() } // generate eP = e * P
+        { G1Projective::toaltstack() } // push eP to alt stack
+
+        // now the top of the stack is signature component R, we will convert it to G1Projective R
+        { U254::from_bytes() } // for y
+        { Fq::toaltstack() } // push y to alt stack
+        { U254::from_bytes() } // for x
+        { Fq::fromaltstack() } // pop y from alt stack, now we have G1Affine form of R on the stack
+        { G1Affine::into_projective() } // convert G1Affine R to G1Projective R
+        { G1Projective::toaltstack() } // push R back to alt stack
+
+        // now the top of the stack is signature s
+        { U254::from_bytes() } // s into its Fr form
+        { Fr::toaltstack() } // push s to alt stack
+
+        // push generator on the stack G
+        { G1Projective::push_generator() }
+        { Fr::fromaltstack() } // bring s back to the stack
+
+        // produce Rv = s * G
+        { G1Projective::scalar_mul() }
+
+        // produce R - Rv
+        { G1Projective::neg() } // top of the stack is Rv, so first negate it
+        { G1Projective::fromaltstack() } // now the stack contains :: -Rv Rv <- top
+        { G1Projective::add() } // add them
+
+        // move eP to the stack
+        { G1Projective::fromaltstack() }
+
+        // compare top 2 elements of the stack
+        { G1Projective_equal() }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::run;
+    use crate::schnorr_bn254::{schnorr_ss::*, utility::*};
+
+    #[test]
+    fn test_schnorr_ss() {
+        #[rustfmt::skip]
+
+        let (private_key, public_key) = generate_key_pair(0);
+
+        // generate some deterministic data
+        const data_size : usize = 64;
+        let mut data : [u8; data_size] = [0; data_size];
+        for i in 0..data_size {
+            data[i] = ((i * 13) as u8);
+        }
+
+        // sign the data promducing (R,s)
+        let (R, s) = sign(&data, &private_key, 1);        
+        assert!(verify(&data, &public_key, &R, &s), "test failed signature logic (signing or verification) incorrect");
+
+        run(script! {
+            for x in serialize_fr(&s).iter().rev() {
+                {(*x)}
+            }
+            for x in serialize_g1affine(&R).iter().rev() {
+                {(*x)}
+            }
+            for x in (&data).iter().rev() {
+                {(*x)}
+            }
+            for x in serialize_g1affine(&public_key).iter().rev() {
+                {(*x)}
+            }
+
+            { verify_schnorr_ss(data_size) }
+        });
+    }
+}

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -29,7 +29,7 @@ pub fn verify_schnorr_ss(data_size : usize) -> Script {
         for _ in (0..36) {// copy Rx to the top of ths stack giving us Rx || tx on the top of the stack
             {data_size + 35} OP_PICK
         }
-        { blake3_var_length(data_size) } // hash (Rx || tx-without the signature attributes)
+        { blake3_var_length(data_size + 36) } // hash (Rx || tx-without the signature attributes)
 
         // the below Fr::from_hash call requires us to reverse the output of the blake3_var_length, only due to its byte ordering requirements
         for i in 0..32 {

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -27,7 +27,7 @@ pub fn verify_schnorr_ss(data_size : usize) -> Script {
         
         // generate e = h(Rx || M)
         for _ in (0..36) {// copy Rx to the top of ths stack giving us Rx || tx on the top of the stack
-            {data_size + 35} OP_PICK
+            {data_size + 36 + 35} OP_PICK
         }
         { blake3_var_length(data_size + 36) } // hash (Rx || tx-without the signature attributes)
 
@@ -99,7 +99,7 @@ mod test {
         assert!(verify(&data, &public_key, &R, &s), "test failed signature logic (signing or verification) incorrect");
 
         let ss = verify_schnorr_ss(data_size);
-        println!("script size for schnorr_ss = {}, hence advised to to switch to using schnorr_ps", ss.len());
+        println!("script size for schnorr_ss = {}, hence advised to, switch to using schnorr_ps", ss.len());
 
         let exec_result = execute_script_without_stack_limit(script! {
             for x in serialize_fr(&s).iter().rev() {

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -9,6 +9,16 @@ use crate::bn254::fr::Fr;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bigint::U254;
 
+/*
+    schnorr_ss refers to single script schnorr signature verification script
+    here we have built a script to perform the exact computation for schnorr signature verification in a single script
+    this script succeeds only if the signature verification passes, unlike schnorr_ps.rs where atleast one of which succeeds on failure
+
+    this script is unusable due to high final script size (830+ MBs) and over utilization of stack
+    hence, it is advised to use schnorr_ps.rs instead
+    this script was developed as a initial step to implement the final signature verification
+ */
+
 // stack contents == s, R, data, public_key <- top of the stack
 // here public_key, R and s are represented similar to the output of the functions serialize_G1Affine and serialize_Fr,
 // with their 0th bytes closest to the top of the stack

--- a/src/schnorr_bn254/schnorr_ss.rs
+++ b/src/schnorr_bn254/schnorr_ss.rs
@@ -78,14 +78,18 @@ pub fn verify_schnorr_ss(data_size : usize) -> Script {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
     use crate::{execute_script, execute_script_without_stack_limit, run};
-    use crate::schnorr_bn254::{schnorr_ss::*, utility::*};
+    use crate::schnorr_bn254::{utility::*};
 
     #[test]
     fn test_schnorr_ss() {
         #[rustfmt::skip]
 
-        let (private_key, public_key) = generate_key_pair(0);
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        let (private_key, public_key) = generate_key_pair(&mut prng);
 
         // generate some deterministic data
         const data_size : usize = 64;
@@ -95,7 +99,7 @@ mod test {
         }
 
         // sign the data promducing (R,s)
-        let (R, s) = sign(&data, &private_key, 1);        
+        let (R, s) = sign(&data, &private_key, &mut prng);        
         assert!(verify(&data, &public_key, &R, &s), "test failed signature logic (signing or verification) incorrect");
 
         let ss = verify_schnorr_ss(data_size);

--- a/src/schnorr_bn254/utility.rs
+++ b/src/schnorr_bn254/utility.rs
@@ -152,9 +152,11 @@ pub fn verify(data : &[u8], public_key : &G1Affine, R : &G1Affine, s : &Fr) -> b
     let data_hash = hasher.finalize();
     let data_hash = data_hash.as_bytes();
     let e : Fr = Fr::from_le_bytes_mod_order(data_hash);
+    println!("e = {:x?}", serialize_fr(&e));
 
     // Rv = s * G
     let Rv : G1Projective = G1Projective::generator() * s;
+    println!("R-Rv = {:x?}", serialize_g1affine(&G1Affine::from(G1Projective::from(*R) + Rv.neg())));
 
     // R - Rv == e * P
     return (G1Projective::from(*R) + Rv.neg()) == (G1Projective::from(*public_key) * e);

--- a/src/schnorr_bn254/utility.rs
+++ b/src/schnorr_bn254/utility.rs
@@ -152,11 +152,9 @@ pub fn verify(data : &[u8], public_key : &G1Affine, R : &G1Affine, s : &Fr) -> b
     let data_hash = hasher.finalize();
     let data_hash = data_hash.as_bytes();
     let e : Fr = Fr::from_le_bytes_mod_order(data_hash);
-    println!("e = {:x?}", serialize_fr(&e));
 
     // Rv = s * G
     let Rv : G1Projective = G1Projective::generator() * s;
-    println!("R-Rv = {:x?}", serialize_g1affine(&G1Affine::from(G1Projective::from(*R) + Rv.neg())));
 
     // R - Rv == e * P
     return (G1Projective::from(*R) + Rv.neg()) == (G1Projective::from(*public_key) * e);

--- a/src/schnorr_bn254/utility.rs
+++ b/src/schnorr_bn254/utility.rs
@@ -1,0 +1,154 @@
+use ark_bn254::{Fr, Fq, G1Affine, G1Projective};
+use ark_ec::{AffineRepr,PrimeGroup};
+use ark_ff::{PrimeField, UniformRand};
+use num_bigint::BigUint;
+use num_traits::Num;
+use std::ops::{Add, Mul, Shl, Rem, Neg};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+fn serialize_254bit_element(s : &BigUint) -> [u8; 36] {
+    let mut result : [u8; 36] = [0; 36];
+    let mut bits_consumed : usize = 0;
+    let mut bytes_produced : usize = 0;
+    while(bits_consumed < 254) {
+        for _ in 0..3 {
+            for i in 0..8 {
+                result[bytes_produced] |= ((s.bit(bits_consumed as u64) as u8) << i);
+                bits_consumed+=1;
+            }
+            bytes_produced+=1;
+        }
+        for i in 0..5 {
+            result[bytes_produced] |= ((s.bit(bits_consumed as u64) as u8) << i);
+            bits_consumed+=1;
+        }
+        bytes_produced+=1;
+    }
+    return result;
+}
+
+fn deserialize_254bit_element(d : &[u8]) -> BigUint {
+    let mut result : BigUint = BigUint::ZERO;
+    let mut bytes_consumed : usize = 0;
+    let mut bits_produced : usize = 0;
+    while(bits_produced < 254) {
+        for _ in 0..3 {
+            for i in 0..8 {
+                result.set_bit(bits_produced as u64, ((d[bytes_consumed] >> i) & 0x01) == 0x01);
+                bits_produced+=1;
+            }
+            bytes_consumed+=1;
+        }
+        for i in 0..5 {
+            result.set_bit(bits_produced as u64, ((d[bytes_consumed] >> i) & 0x01) == 0x01);
+            bits_produced+=1;
+        }
+        bytes_consumed+=1;
+    }
+
+    return result;
+}
+
+pub fn serialize_bn254_element(_s : &BigUint, is_Fq : bool) -> [u8; 36] {
+    let mut N : BigUint = BigUint::ZERO;
+    if is_Fq {
+        N = BigUint::from_str_radix("30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47", 16).unwrap();
+    } else {
+        N = BigUint::from_str_radix("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001", 16).unwrap();
+    }
+    let mut R : BigUint = BigUint::ZERO;
+    if is_Fq {
+        R = BigUint::from_str_radix("dc83629563d44755301fa84819caa36fb90a6020ce148c34e8384eb157ccc21", 16).unwrap();
+    } else {
+        R = BigUint::from_str_radix("dc83629563d44755301fa84819caa8075bba827a494b01a2fd4e1568fffff57", 16).unwrap();
+    }
+
+    let s = _s.mul(&R).rem(&N);
+
+    return serialize_254bit_element(&s);
+}
+
+pub fn deserialize_bn254_element(d : &[u8], is_Fq : bool) -> BigUint {
+    let mut N : BigUint = BigUint::ZERO;
+    if is_Fq {
+        N = BigUint::from_str_radix("30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47", 16).unwrap();
+    } else {
+        N = BigUint::from_str_radix("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001", 16).unwrap();
+    }
+    let mut Rinv : BigUint = BigUint::ZERO;
+    if is_Fq {
+        Rinv = BigUint::from_str_radix("18223d71645e71455ce0bffc0a6ec602ae5dab0851091e61fb9b65ed0584ee8b", 16).unwrap();
+    } else {
+        Rinv = BigUint::from_str_radix("1be7cbeb2ac214c05dee57a5ce4e849f4ee5aa561380deb5f511f723626d88cb", 16).unwrap();
+    }
+
+    return deserialize_254bit_element(d).mul(&Rinv).rem(&N);
+}
+
+pub fn serialize_g1affine(p : &G1Affine) -> [u8; 72] {
+    let mut result : [u8; 72] = [0; 72];
+    if p.is_zero() {
+        return result;
+    }
+    result[0..36].copy_from_slice(&serialize_bn254_element(&BigUint::from(p.y), true));
+    result[36..72].copy_from_slice(&serialize_bn254_element(&BigUint::from(p.x), true));
+    return result;
+}
+
+pub fn serialize_fr(s : &Fr) -> [u8; 36] {
+    return serialize_bn254_element(&BigUint::from(s.clone()), false);
+}
+
+pub fn deserialize_g1affine(b : &[u8]) -> G1Affine {
+    if b.into_iter().all(|&b| b == 0) {
+        return G1Affine::zero();
+    }
+    return G1Affine::new_unchecked(
+        Fq::from(deserialize_bn254_element(&b[36..72], true)),
+        Fq::from(deserialize_bn254_element(&b[0..36], true))
+    );
+}
+
+pub fn deserialize_fr(b : &[u8]) -> Fr {
+    return Fr::from(deserialize_bn254_element(b, false));
+}
+
+pub fn sign(data : &[u8], private_key : &Fr, random_seed : u64) -> (G1Affine, Fr) {
+    // k = random scalar
+    let mut prng = ChaCha20Rng::seed_from_u64(random_seed);
+    let k : Fr = Fr::rand(&mut prng);
+
+    // R = kG
+    let R : G1Projective = G1Projective::generator() * k;
+
+    // e = h(Rx || M)
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&serialize_bn254_element(&BigUint::from(G1Affine::from(R).x), true));
+    hasher.update(data);
+    let data_hash = hasher.finalize();
+    let data_hash = data_hash.as_bytes();
+    let e : Fr = Fr::from_le_bytes_mod_order(data_hash);
+
+    // s = (k - de) mod N
+    let s : Fr = k - (*private_key) * e;
+
+    // R, s is the siganture
+    return (G1Affine::from(R), s);
+}
+
+pub fn verify(data : &[u8], public_key : &G1Affine, R : &G1Affine, s : &Fr) -> bool {
+    // e = h(Rx || M)
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&serialize_bn254_element(&BigUint::from(R.x), true));
+    hasher.update(data);
+    let data_hash = hasher.finalize();
+    let data_hash = data_hash.as_bytes();
+    let e : Fr = Fr::from_le_bytes_mod_order(data_hash);
+
+    // Rv = s * G
+    let Rv : G1Projective = G1Projective::generator() * s;
+
+    // R - Rv == e * P
+    return (G1Projective::from(*R) + Rv.neg()) == (G1Projective::from(*public_key) * e);
+}

--- a/src/schnorr_bn254/utility.rs
+++ b/src/schnorr_bn254/utility.rs
@@ -173,7 +173,7 @@ mod test {
         // generate some deterministic data
         const data_size : usize = 128;
         let mut data : [u8; data_size] = [0; data_size];
-        for i in (0..12) {
+        for i in 0..data_size {
             data[i] = ((i * 13) as u8);
         }
 


### PR DESCRIPTION
## Implemented

 * schnorr signature verification logic using BitVM's BN254 curve in Bitcoin scripts, and utilities for supportive off-chain signing and verification logic.
 * a small fix to allow G1Affine::into_projective() to also work with identity/zero points.

**to be squash merged.**