### PR TITLE
Affine versioned MSM 

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1387,12 +1387,7 @@ impl G1Affine {
                 let double_loop = script! {
                     // check before usage
                     { G1Affine::push(*step) }
-                    { Fq::copy(3) }
-                    { Fq::roll(3) }
-                    { Fq::copy(3) }
-                    { Fq::roll(3) }
-                    { G1Affine::check_chord_line(double_coeff.0, double_coeff.1)}
-                    { G1Affine::add(double_coeff.0, double_coeff.1) }
+                    { G1Affine::check_add(double_coeff.0, double_coeff.1) }
                     // FOR DEBUG
                     // { G1Affine::push(point_after_double.clone()) }
                     // { G1Affine::equalverify() }
@@ -1423,12 +1418,7 @@ impl G1Affine {
                 { G1Affine::dfs_with_constant_mul(0, depth - 1, 0, &p_mul) }
                 // check before usage
                 if i > 0 {
-                    { Fq::copy(3) }
-                    { Fq::roll(3) }
-                    { Fq::copy(3) }
-                    { Fq::roll(3) }
-                    { G1Affine::check_chord_line(add_coeff.0, add_coeff.1) }
-                    { G1Affine::add(add_coeff.0, add_coeff.1) }
+                    { G1Affine::check_add(add_coeff.0, add_coeff.1) }
                 }
                 // FOR DEBUG
                 // { G1Affine::push(point_after_add.clone()) }
@@ -1452,6 +1442,17 @@ impl G1Affine {
             for script in loop_scripts {
                 { script }
             }
+        }
+    }
+
+    pub fn check_add(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
+        script! {
+            { Fq::copy(3) }
+            { Fq::roll(3) }
+            { Fq::copy(3) }
+            { Fq::roll(3) }
+            { G1Affine::check_chord_line(c3, c4) }
+            { G1Affine::add(c3, c4) }
         }
     }
 

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -6,6 +6,7 @@ use crate::bigint::U254;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fr::Fr;
+use crate::bn254::utils::fq_push;
 use crate::treepp::{script, Script};
 use std::cmp::min;
 use std::sync::OnceLock;
@@ -114,7 +115,7 @@ impl G1Projective {
         let (hinted_script6, hint6) = Fq::hinted_mul(1, twelve_xy2 - nine_x4, 0, three_x2);
         let (hinted_script7, hint7) = Fq::hinted_mul(1, a.y, 0, a.z);
 
-        let script_lines = vec! [
+        let script_lines = vec![
             // x, y, z
             Fq::copy(2),
             // x, y, z, x
@@ -182,7 +183,7 @@ impl G1Projective {
             Fq::double(0),
             // 9x^4-8xy^2, 3x^2(12xy^2-9x^4)-8y^4, 2yz
         ];
-        let mut script = script!{};
+        let mut script = script! {};
         for script_line in script_lines {
             script = script.push_script(script_line.compile());
         }
@@ -226,14 +227,14 @@ impl G1Projective {
         let mut hints = Vec::new();
         let (hinted_nonzero_double, hint1) = G1Projective::hinted_nonzero_double(a);
 
-        let script_lines = vec! [
+        let script_lines = vec![
             // Check if the first point is zero
             G1Projective::is_zero_keep_element(0),
-            script!{OP_NOTIF},
-                hinted_nonzero_double,
-            script!{OP_ENDIF}
+            script! {OP_NOTIF},
+            hinted_nonzero_double,
+            script! {OP_ENDIF},
         ];
-        let mut script = script!{};
+        let mut script = script! {};
         for script_line in script_lines {
             script = script.push_script(script_line.compile());
         }
@@ -310,23 +311,26 @@ impl G1Projective {
             .clone()
     }
 
-    pub fn hinted_nonzero_add(a: ark_bn254::G1Projective, b: ark_bn254::G1Projective) -> (Script, Vec<Hint>) {
+    pub fn hinted_nonzero_add(
+        a: ark_bn254::G1Projective,
+        b: ark_bn254::G1Projective,
+    ) -> (Script, Vec<Hint>) {
         let mut hints = Vec::new();
         let var1 = a.z.square();
         let var2 = b.z.square();
         let var3 = a.x * var2;
         let var4 = b.x * var1;
-        let var5= a.y * var2;
+        let var5 = a.y * var2;
         let var6 = b.y * var1;
         let var7 = b.z * var5;
         let var8 = a.z * var6;
         let var9 = var4 - var3;
         let var10 = (var9 + var9).square();
         let var11 = var10 * var9;
-        let var12 =  var8-var7 + var8-var7;
+        let var12 = var8 - var7 + var8 - var7;
         let var13 = var10 * var3;
         let var14 = var12.square();
-        let var15 = var13+var13+var13-var14+var11;
+        let var15 = var13 + var13 + var13 - var14 + var11;
         // let var16 = var15 * var12;
         // let var17 = var7 * var11;
 
@@ -345,9 +349,10 @@ impl G1Projective {
         let (hinted_script13, hint13) = Fq::hinted_mul(1, var15, 0, var12);
         let (hinted_script14, hint14) = Fq::hinted_mul(1, var7, 0, var11);
         let (hinted_script15, hint15) = Fq::hinted_square(a.z + b.z);
-        let (hinted_script16, hint16) = Fq::hinted_mul(1, (a.z+b.z).square()-var1-var2, 0, var9);
+        let (hinted_script16, hint16) =
+            Fq::hinted_mul(1, (a.z + b.z).square() - var1 - var2, 0, var9);
 
-        let script_lines = vec! [
+        let script_lines = vec![
             // ax ay az bx by bz
             Fq::copy(3),
             hinted_script1,
@@ -369,7 +374,7 @@ impl G1Projective {
             // az by bz var1 var2 var3 var4 var5
             Fq::copy(5),
             hinted_script6,
-            // az by bz var1 var2 var3 var4 var7 
+            // az by bz var1 var2 var3 var4 var7
             Fq::copy(4),
             Fq::roll(7),
             hinted_script7,
@@ -395,9 +400,9 @@ impl G1Projective {
             // var1 var2 var3 var7 var8 az+bz var9 var10 var11
             Fq::copy(5),
             Fq::sub(5, 0),
-            // var1 var2 var3 var7 az+bz var9 var10 var11 var8-var7 
+            // var1 var2 var3 var7 az+bz var9 var10 var11 var8-var7
             Fq::double(0),
-            // var1 var2 var3 var7 az+bz var9 var10 var11 var12 
+            // var1 var2 var3 var7 az+bz var9 var10 var11 var12
             Fq::roll(6),
             // var1 var2 var7 az+bz var9 var10 var11 var12 var3
             Fq::roll(3),
@@ -448,7 +453,7 @@ impl G1Projective {
             hinted_script16,
             // var14-var11-2*var13 var16-2*var17 ((az+bz)^2-var1-var2)*var9
         ];
-        let mut script = script!{};
+        let mut script = script! {};
         for script_line in script_lines {
             script = script.push_script(script_line.compile());
         }
@@ -519,29 +524,32 @@ impl G1Projective {
         }
     }
 
-    pub fn hinted_add(a: ark_bn254::G1Projective, b: ark_bn254::G1Projective) -> (Script, Vec<Hint>) {
+    pub fn hinted_add(
+        a: ark_bn254::G1Projective,
+        b: ark_bn254::G1Projective,
+    ) -> (Script, Vec<Hint>) {
         let mut hints = Vec::new();
         let (hinted_script1, hint1) = G1Projective::hinted_nonzero_add(a, b);
 
-        let script_lines = vec! [
+        let script_lines = vec![
             // Check if the first point is zero
             G1Projective::is_zero_keep_element(0),
-            script!{OP_IF},
-                // First point is zero
-                G1Projective::drop(),
-            script!{OP_ELSE},
-                // Check if the second point is zero
-                G1Projective::is_zero_keep_element(1),
-                script!{OP_IF},
-                    // Second point is zero
-                    G1Projective::roll(1),
-                    G1Projective::drop(),
-                script!{OP_ELSE},
-                    hinted_script1,
-                script!{OP_ENDIF},
-            script!{OP_ENDIF},
+            script! {OP_IF},
+            // First point is zero
+            G1Projective::drop(),
+            script! {OP_ELSE},
+            // Check if the second point is zero
+            G1Projective::is_zero_keep_element(1),
+            script! {OP_IF},
+            // Second point is zero
+            G1Projective::roll(1),
+            G1Projective::drop(),
+            script! {OP_ELSE},
+            hinted_script1,
+            script! {OP_ENDIF},
+            script! {OP_ENDIF},
         ];
-        let mut script = script!{};
+        let mut script = script! {};
         for script_line in script_lines {
             script = script.push_script(script_line.compile());
         }
@@ -609,7 +617,10 @@ impl G1Projective {
         }
     }
 
-    pub fn hinted_equalverify(a: ark_bn254::G1Projective, b: ark_bn254::G1Projective) -> (Script, Vec<Hint>) {
+    pub fn hinted_equalverify(
+        a: ark_bn254::G1Projective,
+        b: ark_bn254::G1Projective,
+    ) -> (Script, Vec<Hint>) {
         let mut hints = Vec::new();
 
         let (hinted_script1, hint1) = Fq::hinted_square(a.z);
@@ -618,22 +629,20 @@ impl G1Projective {
         let (hinted_script4, hint4) = Fq::hinted_mul(1, b.z, 0, b.z.square());
         let (hinted_script5, hint5) = Fq::hinted_mul(1, a.x, 0, b.z.square());
         let (hinted_script6, hint6) = Fq::hinted_mul(1, b.x, 0, a.z.square());
-        let (hinted_script7, hint7) = Fq::hinted_mul(1, a.y, 0, b.z.square()*b.z);
-        let (hinted_script8, hint8) = Fq::hinted_mul(1, b.y, 0, a.z.square()*a.z);
-        
-        let script_lines = vec! [
+        let (hinted_script7, hint7) = Fq::hinted_mul(1, a.y, 0, b.z.square() * b.z);
+        let (hinted_script8, hint8) = Fq::hinted_mul(1, b.y, 0, a.z.square() * a.z);
+
+        let script_lines = vec![
             Fq::copy(3),
             hinted_script1,
             Fq::roll(4),
             Fq::copy(1),
             hinted_script2,
-
             Fq::copy(2),
             hinted_script3,
             Fq::roll(3),
             Fq::copy(1),
             hinted_script4,
-
             Fq::roll(7),
             Fq::roll(2),
             hinted_script5,
@@ -641,7 +650,6 @@ impl G1Projective {
             Fq::roll(4),
             hinted_script6,
             Fq::equalverify(1, 0),
-
             Fq::roll(3),
             Fq::roll(1),
             hinted_script7,
@@ -650,7 +658,7 @@ impl G1Projective {
             hinted_script8,
             Fq::equalverify(1, 0),
         ];
-        let mut script = script!{};
+        let mut script = script! {};
         for script_line in script_lines {
             script = script.push_script(script_line.compile());
         }
@@ -770,7 +778,7 @@ impl G1Projective {
     // Output Stack: [x/z^2, y/z^3]
     pub fn hinted_into_affine(a: ark_bn254::G1Projective) -> (Script, Vec<Hint>) {
         let mut hints = Vec::new();
-        
+
         let (
             (hinted_script1, hint1),
             (hinted_script2, hint2),
@@ -791,8 +799,7 @@ impl G1Projective {
                 (hinted_script4, hint4),
                 (hinted_script5, hint5),
             )
-        }
-        else {
+        } else {
             let (hinted_script1, hint1) = (script! {}, vec![]);
             let (hinted_script2, hint2) = (script! {}, vec![]);
             let (hinted_script3, hint3) = (script! {}, vec![]);
@@ -817,44 +824,39 @@ impl G1Projective {
 
             // 1. Check if the first point is zero
             G1Projective::is_zero_keep_element(0),
-
             script! {OP_IF},
-                // Z is zero so drop the point and return the affine::identity
-                Fq::drop(),
-                Fq::drop(),
-                Fq::drop(),
-                G1Affine::identity(),
+            // Z is zero so drop the point and return the affine::identity
+            Fq::drop(),
+            Fq::drop(),
+            Fq::drop(),
+            G1Affine::identity(),
             script! {OP_ELSE},
-                Fq::is_one_keep_element_not_montgomery(0),
-                script! {OP_IF},
-                    Fq::drop(),
-                script! {OP_ELSE},
-                    // 2.2 Otherwise, Z is non-one, so it must have an inverse in a field.
-                    // conpute Z^-1
-                    hinted_script1,
+            Fq::is_one_keep_element_not_montgomery(0),
+            script! {OP_IF},
+            Fq::drop(),
+            script! {OP_ELSE},
+            // 2.2 Otherwise, Z is non-one, so it must have an inverse in a field.
+            // conpute Z^-1
+            hinted_script1,
+            // compute Z^-2
+            Fq::copy(0),
+            hinted_script2,
+            // compute Z^-3 = Z^-2 * z^-1
+            Fq::copy(0),
+            Fq::roll(2),
+            hinted_script3,
+            // For now, stack: [x, y, z^-2, z^-3]
 
-                    // compute Z^-2
-                    Fq::copy(0),
-                    hinted_script2,
-                    // compute Z^-3 = Z^-2 * z^-1
-                    Fq::copy(0),
-                    Fq::roll(2),
-                    hinted_script3,
-
-                    // For now, stack: [x, y, z^-2, z^-3]
-
-                    // compute Y/Z^3 = Y * Z^-3
-                    Fq::roll(2),
-                    hinted_script4,
-
-                    // compute X/Z^2 = X * Z^-2
-                    Fq::roll(1),
-                    Fq::roll(2),
-                    hinted_script5,
-
-                    // Return (x,y)
-                    Fq::roll(1),
-                script! {OP_ENDIF},
+            // compute Y/Z^3 = Y * Z^-3
+            Fq::roll(2),
+            hinted_script4,
+            // compute X/Z^2 = X * Z^-2
+            Fq::roll(1),
+            Fq::roll(2),
+            hinted_script5,
+            // Return (x,y)
+            Fq::roll(1),
+            script! {OP_ENDIF},
             script! {OP_ENDIF},
         ];
 
@@ -869,7 +871,7 @@ impl G1Projective {
             hints.extend(hint4);
             hints.extend(hint5);
         }
-        
+
         (script, hints)
     }
 
@@ -958,7 +960,7 @@ impl G1Projective {
                 { script!{ OP_PICK }.add_stack_hint(-((27 * 2^TERMS + 26) as i32), 0) }
                 for _ in 0..26 {
                     OP_FROMALTSTACK
-                    { script!{ OP_PICK }.add_stack_hint(-((27 * 2^TERMS + 26) as i32), 0)} 
+                    { script!{ OP_PICK }.add_stack_hint(-((27 * 2^TERMS + 26) as i32), 0)}
                 }
 
                 { G1Projective::add() }
@@ -979,9 +981,9 @@ impl G1Projective {
         script
     }
 
-    fn dfs(index: u32, depth: u32,  mask: u32, offset: u32) -> Script {
+    fn dfs(index: u32, depth: u32, mask: u32, offset: u32) -> Script {
         if depth == 0 {
-            return script!{
+            return script! {
                 OP_IF
                     { G1Projective::copy(offset - (mask + (1<<index))) }
                 OP_ELSE
@@ -993,8 +995,8 @@ impl G1Projective {
                 OP_ENDIF
             };
         }
-        script!{
-            OP_IF 
+        script! {
+            OP_IF
                 { G1Projective::dfs(index+1, depth-1, mask + (1<<index), offset) }
             OP_ELSE
                 { G1Projective::dfs(index+1, depth-1, mask, offset) }
@@ -1009,7 +1011,7 @@ impl G1Projective {
         // options: i_step = 2, 3, 4
         let i_step = 4;
 
-        while i < Fr::N_BITS { 
+        while i < Fr::N_BITS {
             let depth = min(Fr::N_BITS - i, i_step);
 
             if i > 0 {
@@ -1021,7 +1023,7 @@ impl G1Projective {
                 loop_scripts.push(double_loop.clone());
             }
 
-            loop_scripts.push(script!{
+            loop_scripts.push(script! {
                 for _ in 0..depth {
                     OP_FROMALTSTACK
                 }
@@ -1041,7 +1043,7 @@ impl G1Projective {
 
             { G1Projective::copy(0) }
             { G1Projective::double() }
-            for i in 3..(1<<i_step) { 
+            for i in 3..(1<<i_step) {
                 { G1Projective::copy(0) }
                 { G1Projective::copy(i - 1) }
                 { G1Projective::add() }
@@ -1061,9 +1063,14 @@ impl G1Projective {
         }
     }
 
-    fn dfs_with_constant_mul(index: u32, depth: u32,  mask: u32, p_mul: &Vec<ark_bn254::G1Projective>) -> Script {
+    fn dfs_with_constant_mul(
+        index: u32,
+        depth: u32,
+        mask: u32,
+        p_mul: &Vec<ark_bn254::G1Projective>,
+    ) -> Script {
         if depth == 0 {
-            return script!{
+            return script! {
                 OP_IF
                     { G1Projective::push(p_mul[(mask + (1<<index)) as usize]) }
                 OP_ELSE
@@ -1076,8 +1083,8 @@ impl G1Projective {
             };
         }
 
-        script!{
-            OP_IF 
+        script! {
+            OP_IF
                 { G1Projective::dfs_with_constant_mul(index+1, depth-1, mask + (1<<index), p_mul) }
             OP_ELSE
                 { G1Projective::dfs_with_constant_mul(index+1, depth-1, mask, p_mul) }
@@ -1085,9 +1092,14 @@ impl G1Projective {
         }
     }
 
-    fn dfs_with_constant_mul_not_montgomery(index: u32, depth: u32,  mask: u32, p_mul: &Vec<ark_bn254::G1Projective>) -> Script {
+    fn dfs_with_constant_mul_not_montgomery(
+        index: u32,
+        depth: u32,
+        mask: u32,
+        p_mul: &Vec<ark_bn254::G1Projective>,
+    ) -> Script {
         if depth == 0 {
-            return script!{
+            return script! {
                 OP_IF
                     { G1Projective::push_not_montgomery(p_mul[(mask + (1<<index)) as usize]) }
                 OP_ELSE
@@ -1100,8 +1112,8 @@ impl G1Projective {
             };
         }
 
-        script!{
-            OP_IF 
+        script! {
+            OP_IF
                 { G1Projective::dfs_with_constant_mul_not_montgomery(index+1, depth-1, mask + (1<<index), p_mul) }
             OP_ELSE
                 { G1Projective::dfs_with_constant_mul_not_montgomery(index+1, depth-1, mask, p_mul) }
@@ -1116,14 +1128,15 @@ impl G1Projective {
         // options: i_step = 2-15
         let i_step = 12;
 
-        let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> = Vec::new();
+        let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> =
+            Vec::new();
         p_mul.push(ark_bn254::G1Projective::ZERO);
-        p_mul.push(p);
-        for _ in 0..(1<<i_step) { 
+        // p_mul.push(p);
+        for _ in 1..(1 << i_step) {
             p_mul.push(p_mul.last().unwrap() + p);
         }
 
-        while i < Fr::N_BITS { 
+        while i < Fr::N_BITS {
             let depth = min(Fr::N_BITS - i, i_step);
 
             if i > 0 {
@@ -1135,7 +1148,7 @@ impl G1Projective {
                 loop_scripts.push(double_loop.clone());
             }
 
-            loop_scripts.push(script!{
+            loop_scripts.push(script! {
                 for _ in 0..depth {
                     OP_FROMALTSTACK
                 }
@@ -1162,22 +1175,26 @@ impl G1Projective {
         }
     }
 
-     // [g1projective]
-     pub fn hinted_scalar_mul_by_constant_g1(scalar: ark_bn254::Fr,p: &mut ark_bn254::G1Projective) -> (Script, Vec<Hint>) {
+    // [g1projective]
+    pub fn hinted_scalar_mul_by_constant_g1(
+        scalar: ark_bn254::Fr,
+        p: &mut ark_bn254::G1Projective,
+    ) -> (Script, Vec<Hint>) {
         let (mut loop_scripts, mut hints) = (Vec::new(), Vec::new());
         let mut i = 0;
         // options: i_step = 2-15
         let i_step = 12;
 
-        let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> = Vec::new();
+        let mut p_mul: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> =
+            Vec::new();
         p_mul.push(ark_bn254::G1Projective::ZERO);
-        for _ in 0..(1<<i_step) { 
+        for _ in 0..(1 << i_step) {
             p_mul.push(p_mul.last().unwrap() + p.clone());
         }
 
-        let mut c: ark_bn254::G1Projective = ark_bn254::G1Projective::ZERO; 
+        let mut c: ark_bn254::G1Projective = ark_bn254::G1Projective::ZERO;
         let scalar_bigint = scalar.into_bigint();
-        while i < Fr::N_BITS { 
+        while i < Fr::N_BITS {
             let depth = min(Fr::N_BITS - i, i_step);
 
             if i > 0 {
@@ -1189,14 +1206,14 @@ impl G1Projective {
                 }
             }
 
-            loop_scripts.push(script!{
+            loop_scripts.push(script! {
                 for _ in 0..depth {
                     OP_FROMALTSTACK
                 }
             });
 
             let mut mask = 0;
-            
+
             for j in 0..depth {
                 mask *= 2;
                 mask += scalar_bigint.get_bit((Fr::N_BITS - i - j - 1) as usize) as u32;
@@ -1209,9 +1226,9 @@ impl G1Projective {
             loop_scripts.push(add_loop.clone());
             if mask != 0 {
                 hints.extend(add_hints);
-                    c = c + p_mul[mask as usize];
+                c = c + p_mul[mask as usize];
             }
-            i += i_step;            
+            i += i_step;
         }
         *p = c;
         let mut script = script! {
@@ -1226,12 +1243,301 @@ impl G1Projective {
 
         (script, hints)
     }
-
 }
 
 pub struct G1Affine;
 
 impl G1Affine {
+    /// check line through one point, that is:
+    ///     y - alpha * x - bias = 0
+    ///
+    /// input on stack:
+    ///     x (1 elements)
+    ///     y (1 elements)
+    ///
+    /// input of parameters:
+    ///     c3: alpha
+    ///     c4: -bias
+    ///
+    /// output:
+    ///     true or false (consumed on stack)
+    pub fn check_line_through_point(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
+        script! {
+            // [x, y]
+            { Fq::roll(1) }
+            // [y, x]
+            { Fq::mul_by_constant(&c3) }
+            // [y, alpha * x]
+            { Fq::neg(0) }
+            // [y, -alpha * x]
+            { Fq::add(1, 0) }
+            // [y - alpha * x]
+
+            { fq_push(c4) }
+            // [y - alpha * x, -bias]
+            { Fq::add(1, 0) }
+            // [y - alpha * x - bias]
+
+            { Fq::push_zero() }
+            // [y - alpha * x - bias, 0]
+            { Fq::equalverify(1, 0) }
+        }
+    }
+
+    /// check whether a tuple coefficient (alpha, -bias) of a chord line is satisfied with expected points T and Q (both are affine cooordinates)
+    /// two aspects:
+    ///     1. T.y - alpha * T.x - bias = 0
+    ///     2. Q.y - alpha * Q.x - bias = 0, make sure the alpha/-bias are the right ONEs
+    ///
+    /// input on stack:
+    ///     T.x (1 elements)
+    ///     T.y (1 elements)
+    ///     Q.x (1 elements)
+    ///     Q.y (1 elements)
+    ///
+    /// input of parameters:
+    ///     c3: alpha
+    ///     c4: -bias
+    /// output:
+    ///     true or false (consumed on stack)
+    pub fn check_chord_line(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
+        script! {
+            // check: Q.y - alpha * Q.x - bias = 0
+            { G1Affine::check_line_through_point(c3, c4) }
+            // [T.x, T.y]
+            // check: T.y - alpha * T.x - bias = 0
+            { G1Affine::check_line_through_point(c3, c4) }
+            // []
+        }
+    }
+
+    pub fn push_zero() -> Script {
+        script! {
+            { Fq::push_zero() }
+            { Fq::push_zero() }
+        }
+    }
+
+    pub fn push(element: ark_bn254::G1Affine) -> Script {
+        script! {
+            { Fq::push_u32_le(&BigUint::from(element.x).to_u32_digits()) }
+            { Fq::push_u32_le(&BigUint::from(element.y).to_u32_digits()) }
+        }
+    }
+
+    fn dfs_with_constant_mul(
+        index: u32,
+        depth: u32,
+        mask: u32,
+        p_mul: &Vec<ark_bn254::G1Affine>,
+    ) -> Script {
+        if depth == 0 {
+            return script! {
+                OP_IF
+                    { G1Affine::push(p_mul[(mask + (1 << index)) as usize]) }
+                OP_ELSE
+                    if mask == 0 {
+                        { G1Affine::push_zero() }
+                    } else {
+                        { G1Affine::push(p_mul[mask as usize]) }
+                    }
+                OP_ENDIF
+            };
+        }
+
+        script! {
+            OP_IF
+                { G1Affine::dfs_with_constant_mul(index + 1, depth - 1, mask + (1 << index), p_mul) }
+            OP_ELSE
+                { G1Affine::dfs_with_constant_mul(index + 1, depth - 1, mask, p_mul) }
+            OP_ENDIF
+        }
+    }
+
+    // scalar already in stack, base point as input parameter
+    pub fn scalar_mul_by_constant_g1(
+        p: ark_bn254::G1Affine,
+        coeff: Vec<(ark_bn254::Fq, ark_bn254::Fq)>,
+        step_p: Vec<ark_bn254::G1Affine>,
+        trace: Vec<ark_bn254::G1Affine>,
+    ) -> Script {
+        let mut coeff_iter = coeff.iter();
+        let mut step_p_iter = step_p.iter();
+        let mut trace_iter = trace.iter();
+        let mut loop_scripts = Vec::new();
+        let mut i = 0;
+        // options: i_step = 2-15
+        let i_step = 12;
+
+        // precomputed lookup table (affine)
+        let mut p_mul: Vec<ark_bn254::G1Affine> = Vec::new();
+        p_mul.push(ark_bn254::G1Affine::zero());
+        for _ in 1..(1 << i_step) {
+            p_mul.push((p_mul.last().unwrap().clone() + p.clone()).into_affine());
+        }
+
+        while i < Fr::N_BITS {
+            let depth = min(Fr::N_BITS - i, i_step);
+
+            // double(step-size) point
+            if i > 0 {
+                let double_coeff = coeff_iter.next().unwrap();
+                let step = step_p_iter.next().unwrap();
+                let point_after_double = trace_iter.next().unwrap();
+                let double_loop = script! {
+                    // check before usage
+                    { G1Affine::push(*step) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { G1Affine::check_chord_line(double_coeff.0, double_coeff.1)}
+                    { G1Affine::add(double_coeff.0, double_coeff.1) }
+                    // FOR DEBUG
+                    // { G1Affine::push(point_after_double.clone()) }
+                    // { G1Affine::equalverify() }
+                    // { G1Affine::push(point_after_double.clone()) }
+                };
+                loop_scripts.push(double_loop.clone());
+            }
+            // if i == i_step * 2 {
+            //     break;
+            // }
+
+            // squeeze a bucket scalar
+            loop_scripts.push(script! {
+                for _ in 0..depth {
+                    OP_FROMALTSTACK
+                }
+            });
+
+            // add point
+            let add_coeff = if i > 0 {
+                *coeff_iter.next().unwrap()
+            } else {
+                (ark_bn254::Fq::ZERO, ark_bn254::Fq::ZERO)
+            };
+            let point_after_add = trace_iter.next().unwrap();
+            let add_loop = script! {
+                // query bucket point through lookup table
+                { G1Affine::dfs_with_constant_mul(0, depth - 1, 0, &p_mul) }
+                // check before usage
+                if i > 0 {
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { G1Affine::check_chord_line(add_coeff.0, add_coeff.1) }
+                    { G1Affine::add(add_coeff.0, add_coeff.1) }
+                }
+                // FOR DEBUG
+                // { G1Affine::push(point_after_add.clone()) }
+                // { G1Affine::equalverify() }
+                // { G1Affine::push(point_after_add.clone()) }
+            };
+            loop_scripts.push(add_loop.clone());
+            // if i == i_step * 21 {
+            //     break;
+            // }
+            i += i_step;
+        }
+        assert!(coeff_iter.next() == None);
+        assert!(step_p_iter.next() == None);
+        assert!(trace_iter.next() == None);
+
+        script! {
+            { Fr::decode_montgomery() }
+            { Fr::convert_to_le_bits_toaltstack() }
+
+            for script in loop_scripts {
+                { script }
+            }
+        }
+    }
+
+    /// add two points T and Q
+    ///     x' = alpha^2 - T.x - Q.x
+    ///     y' = -bias - alpha * x'
+    ///
+    /// input on stack:
+    ///     T.x (1 elements)
+    ///     Q.x (1 elements)
+    ///
+    /// input of parameters:
+    ///     c3: alpha - line slope
+    ///     c4: -bias - line intercept
+    ///
+    /// output on stack:
+    ///     T'.x (1 elements)
+    ///     T'.y (1 elements)
+    pub fn add(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
+        script! {
+            // [T.x, Q.x]
+            { Fq::neg(0) }
+            // [T.x, -Q.x]
+            { Fq::roll(1) }
+            // [-Q.x, T.x]
+            { Fq::neg(0) }
+            // [-T.x - Q.x]
+            { Fq::add(1, 0) }
+            // [-T.x - Q.x]
+            { fq_push(c3) }
+            // [-T.x - Q.x, alpha]
+            { Fq::copy(0) }
+            // [-T.x - Q.x, alpha, alpha]
+            { Fq::square() }
+            // [-T.x - Q.x, alpha, alpha^2]
+            // calculate x' = alpha^2 - T.x - Q.x
+            { Fq::add(2, 0) }
+            // [alpha, x']
+            { Fq::copy(0) }
+            // [alpha, x', x']
+            { Fq::roll(2) }
+            { Fq::mul() }
+            // [x', alpha * x']
+            { Fq::neg(0) }
+            // [x', -alpha * x']
+            { fq_push(c4) }
+            // [x', -alpha * x', -bias]
+            // compute y' = -bias - alpha * x'
+            { Fq::add(1, 0) }
+            // [x', y']
+        }
+    }
+
+    /// double a point T:
+    ///     x' = alpha^2 - 2 * T.x
+    ///     y' = -bias - alpha* x'
+    ///
+    /// input on stack:
+    ///     T.x (1 elements)
+    ///
+    /// output on stack:
+    ///     T'.x (1 elements)
+    ///     T'.y (1 elements)
+    pub fn double(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
+        script! {
+            { Fq::double(0) }
+            { Fq::neg(0) }
+            // [- 2 * T.x]
+            { fq_push(c3) }
+            { Fq::copy(0) }
+            { Fq::square() }
+            // [- 2 * T.x, alpha, alpha^2]
+            { Fq::add(2, 0) }
+            { Fq::copy(0) }
+            // [alpha, x', x']
+            { Fq::roll(2) }
+            { Fq::mul() }
+            { Fq::neg(0) }
+            // [x', -alpha * x']
+
+            { fq_push(c4) }
+            { Fq::add(1, 0) }
+            // [x', y']
+        }
+    }
+
     pub fn identity() -> Script {
         script! {
             { Fq::push_zero() }
@@ -1284,7 +1590,7 @@ impl G1Affine {
     // Output Stack: [x,y,z] (z=1)
     //pub fn into_projective() -> Script { script!({ Fq::push_one() }) }
     pub fn into_projective() -> Script {
-        script!{
+        script! {
             { Fq::is_zero_keep_element(0) }
             OP_TOALTSTACK
             { Fq::is_zero_keep_element(1) }
@@ -1303,9 +1609,13 @@ mod test {
 
     use crate::bn254::curves::{G1Affine, G1Projective};
     use crate::bn254::fq::Fq;
-    use crate::bn254::utils::{fr_push, fr_push_not_montgomery, g1_affine_push, g1_affine_push_not_montgomery};
+    use crate::bn254::utils::{
+        fr_push, fr_push_not_montgomery, g1_affine_push, g1_affine_push_not_montgomery,
+    };
+    use crate::{
+        execute_script, execute_script_as_chunks, execute_script_without_stack_limit, run,
+    };
     use crate::{run_as_chunks, treepp::*};
-    use crate::{execute_script, execute_script_as_chunks, execute_script_without_stack_limit, run};
 
     use crate::bn254::fp254impl::Fp254Impl;
     use ark_bn254::Fr;
@@ -1429,12 +1739,12 @@ mod test {
             let c = a.add(&a);
 
             let (hinted_double, mut hints) = G1Projective::hinted_double(a);
-            let (hinted_equal_verify1, hints1) = G1Projective::hinted_equalverify(a+a, c);
+            let (hinted_equal_verify1, hints1) = G1Projective::hinted_equalverify(a + a, c);
             hints.extend(hints1);
             println!("G1.hinted_double: {} bytes", hinted_double.len());
 
             let script = script! {
-                for hint in hints { 
+                for hint in hints {
                     { hint.push() }
                 }
                 { G1Projective::push_not_montgomery(a) }
@@ -1487,12 +1797,12 @@ mod test {
             let c = a.add(&b);
 
             let (hinted_nonzero_add, mut hints) = G1Projective::hinted_nonzero_add(a, b);
-            let (hinted_equal_verify1, hints1) = G1Projective::hinted_equalverify(a+b, c);
+            let (hinted_equal_verify1, hints1) = G1Projective::hinted_equalverify(a + b, c);
             println!("G1.hinted_nonzero_add: {} bytes", hinted_nonzero_add.len());
             hints.extend(hints1);
 
             let script = script! {
-                for hint in hints { 
+                for hint in hints {
                     { hint.push() }
                 }
                 { G1Projective::push_not_montgomery(a) }
@@ -1557,11 +1867,15 @@ mod test {
             let c = a.add(&b);
             let mut hints = Vec::new();
             let (hinted_add1, hints1) = G1Projective::hinted_add(a, b);
-            let (hinted_equal_verify1, hints2) = G1Projective::hinted_equalverify(a+b, c);
-            let (hinted_add2, hints3) = G1Projective::hinted_add(a, ark_bn254::G1Projective::zero());
-            let (hinted_equal_verify2, hints4) = G1Projective::hinted_equalverify(a+ark_bn254::G1Projective::zero(), a);
-            let (hinted_add3, hints5) = G1Projective::hinted_add(ark_bn254::G1Projective::zero(), a);
-            let (hinted_equal_verify3, hints6) = G1Projective::hinted_equalverify(ark_bn254::G1Projective::zero()+a, a);
+            let (hinted_equal_verify1, hints2) = G1Projective::hinted_equalverify(a + b, c);
+            let (hinted_add2, hints3) =
+                G1Projective::hinted_add(a, ark_bn254::G1Projective::zero());
+            let (hinted_equal_verify2, hints4) =
+                G1Projective::hinted_equalverify(a + ark_bn254::G1Projective::zero(), a);
+            let (hinted_add3, hints5) =
+                G1Projective::hinted_add(ark_bn254::G1Projective::zero(), a);
+            let (hinted_equal_verify3, hints6) =
+                G1Projective::hinted_equalverify(ark_bn254::G1Projective::zero() + a, a);
             hints.extend(hints1);
             hints.extend(hints2);
             hints.extend(hints3);
@@ -1569,7 +1883,7 @@ mod test {
             hints.extend(hints5);
             hints.extend(hints6);
             let script = script! {
-                for hint in hints { 
+                for hint in hints {
                     { hint.push() }
                 }
                 // Test random a + b = c
@@ -1599,7 +1913,7 @@ mod test {
             run(script);
         }
     }
-    
+
     #[test]
     fn test_scalar_mul() {
         let scalar_mul = G1Projective::scalar_mul();
@@ -1661,14 +1975,18 @@ mod test {
             let mut p = ark_bn254::G1Projective::rand(&mut prng);
             let q = p.mul(scalar);
 
-            let (hinted_scalar_mul, mut hints) = G1Projective::hinted_scalar_mul_by_constant_g1(scalar, &mut p);
+            let (hinted_scalar_mul, mut hints) =
+                G1Projective::hinted_scalar_mul_by_constant_g1(scalar, &mut p);
             assert_eq!(p, q);
-            println!("G1.scalar_mul_by_constant_g1: {} bytes", hinted_scalar_mul.len());
+            println!(
+                "G1.scalar_mul_by_constant_g1: {} bytes",
+                hinted_scalar_mul.len()
+            );
             let (hinted_equal_verify, hint1) = G1Projective::hinted_equalverify(p, q);
             hints.extend(hint1);
 
             let script = script! {
-                for hint in hints { 
+                for hint in hints {
                     { hint.push() }
                 }
                 { fr_push_not_montgomery(scalar) }
@@ -1802,7 +2120,7 @@ mod test {
                 { hinted_into_affine }
                 { g1_affine_push_not_montgomery(q) }
                 { G1Affine::equalverify() }
-                
+
                 OP_TRUE
             };
             end_timer!(start);
@@ -1980,10 +2298,10 @@ mod test {
     #[test]
     fn test_hinted_projective_equalverify() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
-        
+
         for _ in 0..1 {
             let scalar = Fr::rand(&mut prng);
-            
+
             let p = ark_bn254::G1Projective::rand(&mut prng).mul(scalar);
             let q = p.into_affine();
             let (equalverify, hints) = G1Projective::hinted_equalverify(p, q.into_group());

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -1,9 +1,148 @@
-use crate::bn254::utils::fr_push_not_montgomery;
-use crate::bn254::{curves::G1Projective, utils::fr_push};
-use crate::treepp::*;
-use ark_ff::Field;
-use ark_ec::AdditiveGroup;
+use std::cmp::min;
+
 use super::utils::Hint;
+use crate::bn254::fp254impl::Fp254Impl;
+use crate::bn254::utils::fr_push_not_montgomery;
+use crate::bn254::{curves::G1Affine, curves::G1Projective, utils::fr_push};
+use crate::treepp::*;
+use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup, PrimeGroup};
+use ark_ff::{BigInteger, Field, PrimeField};
+
+pub fn affine_double_line_coeff(
+    t: &mut ark_bn254::G1Affine,
+    i_step: u32,
+) -> ((ark_bn254::Fq, ark_bn254::Fq), ark_bn254::G1Affine) {
+    let step_p = t.mul_bigint([(1 << i_step) - 1]).into_affine();
+    (affine_add_line_coeff(t, step_p), step_p)
+}
+
+pub fn affine_add_line_coeff(
+    t: &mut ark_bn254::G1Affine,
+    p: ark_bn254::G1Affine,
+) -> (ark_bn254::Fq, ark_bn254::Fq) {
+    // alpha = (t.y - q.y) / (t.x - q.x)
+    // bias = t.y - alpha * t.x
+    let alpha = (t.y - p.y) / (t.x - p.x);
+    let bias = t.y - alpha * t.x;
+
+    // update T
+    // T.x = alpha^2 - t.x - q.x
+    // T.y = -bias - alpha * T.x
+    let tx = alpha.square() - t.x - p.x;
+    t.y = -bias - alpha * tx;
+    t.x = tx;
+
+    (alpha, -bias)
+}
+
+pub fn collect_scalar_mul_coeff(
+    base: ark_bn254::G1Affine,
+    scalar: ark_bn254::Fr,
+    i_step: u32,
+) -> (
+    Vec<(ark_bn254::Fq, ark_bn254::Fq)>,
+    Vec<ark_bn254::G1Affine>,
+    Vec<ark_bn254::G1Affine>,
+) {
+    if scalar == ark_bn254::Fr::ONE {
+        (vec![], vec![], vec![])
+    } else {
+        // precomputed lookup table (affine)
+        let mut p_mul: Vec<ark_bn254::G1Affine> = Vec::new();
+        p_mul.push(ark_bn254::G1Affine::zero());
+        for _ in 1..(1 << i_step) {
+            p_mul.push((p_mul.last().unwrap().clone() + base.clone()).into_affine());
+        }
+
+        // split into chunks
+        let chunks = scalar
+            .into_bigint()
+            .to_bits_be()
+            .iter()
+            .map(|b| if *b { 1_u8 } else { 0_u8 })
+            .skip(256 - crate::bn254::fr::Fr::N_BITS as usize)
+            .collect::<Vec<_>>()
+            .chunks(i_step as usize)
+            .map(|slice| slice.into_iter().fold(0, |acc, &b| (acc << 1) + b as u32))
+            .collect::<Vec<u32>>();
+        assert!(chunks.len() > 0);
+
+        // query lookup table, then double/add based on that
+        let mut line_coeff = vec![];
+        let mut step_points = vec![];
+        let mut trace = vec![];
+        let mut t = p_mul[chunks[0] as usize];
+        // for check variables
+        let mut acc = ark_bn254::G1Projective::from(p_mul[chunks[0] as usize]);
+        let mut s = ark_ff::BigInt::<4>::from(chunks[0]);
+        trace.push(p_mul[chunks[0] as usize]);
+        chunks.iter().skip(1).enumerate().for_each(|(idx, query)| {
+            let depth = if (idx == chunks.len() - 2)
+                && (crate::bn254::fr::Fr::N_BITS as u32 % i_step != 0)
+            {
+                crate::bn254::fr::Fr::N_BITS as u32 % i_step
+            } else {
+                i_step
+            };
+            let tmp = t.clone();
+            let (double_coeff, step_p) = affine_double_line_coeff(&mut t, depth);
+            line_coeff.push(double_coeff);
+            step_points.push(step_p);
+            assert_eq!(tmp + step_p, tmp.mul_bigint([1 << depth]));
+            assert_eq!(
+                step_p.y().unwrap() - double_coeff.0 * step_p.x().unwrap() + double_coeff.1,
+                ark_bn254::Fq::ZERO
+            );
+            assert_eq!(
+                tmp.y().unwrap() - double_coeff.0 * tmp.x().unwrap() + double_coeff.1,
+                ark_bn254::Fq::ZERO
+            );
+
+            // FOR DEBUG
+            s <<= depth;
+            for _ in 0..depth {
+                acc.double_in_place();
+            }
+            trace.push(acc.into_affine());
+
+            line_coeff.push(affine_add_line_coeff(&mut t, p_mul[*query as usize]));
+            // FOR DEBUG
+            acc += ark_bn254::G1Projective::from(p_mul[*query as usize]);
+            trace.push(acc.into_affine());
+            // TODO: zero point can be ignored
+            // if p_mul[*query as usize] != ark_bn254::G1Projective::ZERO {
+            //     line_coeff.push(affine_add_line_coeff(&mut t, p_mul[*query as usize]));
+            //     // FOR DEBUG
+            //     acc += ark_bn254::G1Projective::from(p_mul[*query as usize]);
+            // }
+
+            // FOR DEBUG
+            s.add_with_carry(&ark_ff::BigInt::<4>::from(*query));
+        });
+        assert_eq!(s, scalar.into_bigint());
+        assert_eq!(acc.into_affine(), (base * scalar).into_affine());
+
+        // return line coefficients of single scalar mul
+        (line_coeff, step_points, trace)
+    }
+}
+
+// line coefficients, denoted as tuple (alpha, bias), for the purpose of affine mode of MSM
+pub fn collect_msm_coeff(
+    bases: &[ark_bn254::G1Affine],
+    scalars: &[ark_bn254::Fr],
+    i_step: u32,
+) -> Vec<(
+    Vec<(ark_bn254::Fq, ark_bn254::Fq)>,
+    Vec<ark_bn254::G1Affine>,
+    Vec<ark_bn254::G1Affine>,
+)> {
+    bases
+        .iter()
+        .zip(scalars.iter())
+        .map(|(base, scalar)| collect_scalar_mul_coeff(*base, *scalar, i_step))
+        .collect()
+}
 
 // Will compute msm and return the affine point
 // Output Stack: [x,y]
@@ -25,6 +164,33 @@ pub fn msm(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> Script {
                 { scalar_mul.clone() }
             }
 
+            // 3. sum the base
+            { G1Projective::add() }
+        }
+        // convert into Affine
+        { G1Projective::into_affine() }
+    }
+}
+
+pub fn msm_with_constant_bases_affine(
+    bases: &[ark_bn254::G1Affine],
+    scalars: &[ark_bn254::Fr],
+) -> Script {
+    assert_eq!(bases.len(), scalars.len());
+    let len = bases.len();
+    let i_step = 12_u32;
+    let msm_coeffs = collect_msm_coeff(bases, scalars, i_step);
+    script! {
+        // 1. init the sum=0;
+        {G1Projective::push_zero()}
+        for i in 0..len {
+            // 2. scalar mul
+            if scalars[i] != ark_bn254::Fr::ONE {
+                { fr_push(scalars[i]) }
+                // { G1Projective::scalar_mul_by_constant_g1(bases[i]) }
+            } else {
+                // { G1Projective::push(bases[i]) }
+            }
             // 3. sum the base
             { G1Projective::add() }
         }
@@ -61,7 +227,10 @@ pub fn msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn2
     }
 }
 
-pub fn hinted_msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> (Script, Vec<Hint>) {
+pub fn hinted_msm_with_constant_bases(
+    bases: &[ark_bn254::G1Affine],
+    scalars: &[ark_bn254::Fr],
+) -> (Script, Vec<Hint>) {
     assert_eq!(bases.len(), scalars.len());
     let bases: Vec<ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>> =
         bases.iter().map(|&p| p.into()).collect();
@@ -76,12 +245,13 @@ pub fn hinted_msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[
         // 2. scalar mul
         let mut c = bases[i];
         if scalars[i] != ark_bn254::Fr::ONE {
-            let (hinted_script, hint) = G1Projective::hinted_scalar_mul_by_constant_g1(scalars[i], &mut c);
+            let (hinted_script, hint) =
+                G1Projective::hinted_scalar_mul_by_constant_g1(scalars[i], &mut c);
             hinted_scripts.push(hinted_script);
             hints.extend(hint);
         }
         // 3. sum the base
-        let (hinted_script, hint) = G1Projective::hinted_add(p,  c);
+        let (hinted_script, hint) = G1Projective::hinted_add(p, c);
         hinted_scripts.push(hinted_script);
         hints.extend(hint);
         p += c;
@@ -110,14 +280,13 @@ pub fn hinted_msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[
     // convert into Affine
     script_lines.push(hinted_scripts_iter.next().unwrap());
 
-    let mut script = script!{};
+    let mut script = script! {};
     for script_line in script_lines {
         script = script.push_script(script_line.compile());
     }
 
     (script, hints)
 }
-
 
 #[cfg(test)]
 mod test {
@@ -191,6 +360,76 @@ mod test {
     }
 
     #[test]
+    fn test_scalar_mul_projective() {
+        let k = 0;
+        let n = 1 << k;
+        let rng = &mut test_rng();
+
+        let scalars = (0..n).map(|_| ark_bn254::Fr::rand(rng)).collect::<Vec<_>>();
+
+        let bases = (0..n)
+            .map(|_| ark_bn254::G1Projective::rand(rng))
+            .collect::<Vec<_>>();
+
+        let scalar_mul_projective_script =
+            crate::bn254::curves::G1Projective::scalar_mul_by_constant_g1(bases[0]);
+
+        let script = script! {
+            { fr_push(scalars[0]) }
+            { scalar_mul_projective_script.clone() }
+            { crate::bn254::curves::G1Projective::into_affine() }
+            { crate::bn254::curves::G1Affine::push((bases[0] * scalars[0]).into_affine()) }
+            { crate::bn254::curves::G1Affine::equalverify() }
+            OP_TRUE
+        };
+        let exec_result = execute_script_without_stack_limit(script);
+        println!("{}", exec_result.final_stack);
+        assert!(exec_result.success);
+
+        println!(
+            "script size of scalar_mul_projective: {}",
+            scalar_mul_projective_script.len()
+        );
+    }
+
+    #[test]
+    fn test_scalar_mul_affine() {
+        let k = 0;
+        let n = 1 << k;
+        let rng = &mut test_rng();
+
+        let scalars = (0..n).map(|_| ark_bn254::Fr::rand(rng)).collect::<Vec<_>>();
+
+        let bases = (0..n)
+            .map(|_| ark_bn254::G1Projective::rand(rng).into_affine())
+            .collect::<Vec<_>>();
+
+        let msm_coeffs = collect_msm_coeff(&bases, &scalars, 12);
+        let scalar_mul_affine_script = crate::bn254::curves::G1Affine::scalar_mul_by_constant_g1(
+            bases[0],
+            msm_coeffs[0].0.clone(),
+            msm_coeffs[0].1.clone(),
+            msm_coeffs[0].2.clone(),
+        );
+
+        let script = script! {
+            { fr_push(scalars[0]) }
+            { scalar_mul_affine_script.clone() }
+            { crate::bn254::curves::G1Affine::push((bases[0] * scalars[0]).into_affine()) }
+            { crate::bn254::curves::G1Affine::equalverify() }
+            OP_TRUE
+        };
+        let exec_result = execute_script_without_stack_limit(script);
+        println!("{}", exec_result.final_stack);
+        assert!(exec_result.success);
+
+        println!(
+            "script size of scalar_mul_affine: {}",
+            scalar_mul_affine_script.len()
+        );
+    }
+
+    #[test]
     fn test_hinted_msm_with_constant_bases_script() {
         let k = 2;
         let n = 1 << k;
@@ -224,5 +463,21 @@ mod test {
         let exec_result = execute_script_without_stack_limit(script);
         end_timer!(start);
         assert!(exec_result.success);
+    }
+
+    #[test]
+    fn test_demo() {
+        use crate::bn254::fp254impl::Fp254Impl;
+
+        // let script = script! {
+        //     { crate::bn254::fr::Fr::push_dec("7") }
+        //     { crate::bn254::fr::Fr::decode_montgomery() }
+        //     { crate::bn254::fr::Fr::convert_to_le_bits() }
+        //     // { crate::bn254::fr::Fr::convert_to_le_bits_toaltstack() }
+        // };
+        // let exec_result = execute_script_without_stack_limit(script);
+        // println!("{:?}", exec_result.final_stack);
+        // let a = ark_ff::BigInt::<4>::from([3_u32, 5_u32, 7_u32, 9_u32]);
+        // println!("{:?}", a.to_bits_le());
     }
 }

--- a/src/groth16/test.rs
+++ b/src/groth16/test.rs
@@ -1,9 +1,9 @@
-use crate::{execute_script_as_chunks, execute_script_without_stack_limit};
 use crate::groth16::verifier::Verifier;
+use crate::{execute_script_as_chunks, execute_script_without_stack_limit};
 use ark_bn254::Bn254;
 use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_ec::pairing::Pairing;
-use ark_ff::PrimeField;
+use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::Groth16;
 use ark_relations::lc;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
@@ -70,6 +70,8 @@ fn test_groth16_verifier() {
 
     let c = circuit.a.unwrap() * circuit.b.unwrap();
 
+    println!("c = {:?}", c.into_bigint().to_bits_le());
+
     let proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
 
     let start = start_timer!(|| "collect_script");
@@ -104,7 +106,10 @@ fn test_hinted_groth16_verifier() {
 
     let (hinted_groth16_verifier, hints) = Verifier::hinted_verify(&vec![c], &proof, &vk);
 
-    println!("hinted_groth16_verifier: {:?} bytes", hinted_groth16_verifier.len());
+    println!(
+        "hinted_groth16_verifier: {:?} bytes",
+        hinted_groth16_verifier.len()
+    );
 
     let start = start_timer!(|| "collect_script");
     let script = script! {
@@ -148,7 +153,13 @@ fn test_groth16_verifier_as_chunks() {
     println!("groth16::test_verify_proof = {} bytes", script.len());
 
     let interval = script.max_op_if_interval();
-    println!("Max if interval: {:?} difference: {}, debug info: {}, {}", interval, interval.1 - interval.0, script.debug_info(interval.0), script.debug_info(interval.1));
+    println!(
+        "Max if interval: {:?} difference: {}, debug info: {}, {}",
+        interval,
+        interval.1 - interval.0,
+        script.debug_info(interval.0),
+        script.debug_info(interval.1)
+    );
     let start = start_timer!(|| "execute_script");
     let exec_result = execute_script_as_chunks(script, 3_000_000, 1000);
     end_timer!(start);

--- a/src/groth16/test.rs
+++ b/src/groth16/test.rs
@@ -56,7 +56,7 @@ impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
 }
 
 #[test]
-fn test_groth16_verifier() {
+fn test_groth16_verifier_native() {
     type E = Bn254;
     let k = 6;
     let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
@@ -69,8 +69,6 @@ fn test_groth16_verifier() {
     let (pk, vk) = Groth16::<E>::setup(circuit, &mut rng).unwrap();
 
     let c = circuit.a.unwrap() * circuit.b.unwrap();
-
-    println!("c = {:?}", c.into_bigint().to_bits_le());
 
     let proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
 


### PR DESCRIPTION
Hi, I replaced MSM with projective coordinate with affine one upon my last PR [#83](https://github.com/BitVM/BitVM/pull/83) , I think I had much underestimated affine's impact on MSM, the result's still beautiful:
- single scalar_mul, script size is reduced by 267328930 bytes
- groth16 verifier with one public input, script size is reduced by 277271131 bytes, from 2652277658 bytes to 2375006527 bytes

Give credit to the authors of [On Proving Pairings](https://eprint.iacr.org/2024/640.pdf), thanks for the backend of [Bitlayer Labs]( https://github.com/bitlayer-org), and thanks for Lukas's pointing out https://github.com/BitVM/BitVM/issues/110.