### PR TITLE
fix G2 element subgroup membership check

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1,5 +1,6 @@
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{AdditiveGroup, BigInteger, Field, PrimeField};
+use bitcoin::opcodes::all::{OP_BOOLAND, OP_FROMALTSTACK, OP_TOALTSTACK};
 use num_bigint::BigUint;
 
 use crate::bigint::U254;
@@ -1622,8 +1623,7 @@ impl G2Affine {
             { Fq2::add(2, 0) }
             { Fq2::roll(2) }
             { Fq2::square() }
-            { Fq2::equalverify()}
-            OP_TRUE
+            { Fq2::equal() }
         }
     }
 }
@@ -1634,6 +1634,7 @@ mod test {
 
     use crate::bn254::curves::{G1Affine, G2Affine, G1Projective};
     use crate::bn254::fq::Fq;
+    use crate::bn254::fq2::Fq2;
     use crate::bn254::utils::{
         fq2_push, fr_push, fr_push_not_montgomery, g1_affine_push, g1_affine_push_not_montgomery
     };
@@ -2415,6 +2416,16 @@ mod test {
                 { fq2_push(point.x) }
                 { fq2_push(point.y) }
                 { affine_is_on_curve.clone()}
+            };
+            println!("curves::test_affine_is_on_curve = {} bytes", script.len());
+            run(script);
+
+            let script = script! {
+                { fq2_push(point.x) }
+                { fq2_push(point.y) }
+                { Fq2::double(0) }
+                { affine_is_on_curve.clone()}
+                OP_NOT
             };
             println!("curves::test_affine_is_on_curve = {} bytes", script.len());
             run(script);

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -5,6 +5,7 @@ use num_bigint::BigUint;
 use crate::bigint::U254;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
+use crate::bn254::fq2::Fq2;
 use crate::bn254::fr::Fr;
 use crate::bn254::utils::fq_push;
 use crate::treepp::{script, Script};
@@ -1605,13 +1606,36 @@ impl G1Affine {
     }
 }
 
+pub struct G2Affine;
+
+//B = Fq2(19485874751759354771024239261021720505790618469301721065564631296452457478373,
+//266929791119991161246907387137283842545076965332900288569378510910307636690)
+impl G2Affine {
+    pub fn is_on_curve() -> Script {
+        script! {
+            { Fq2::copy(2) }
+            { Fq2::square() }
+            { Fq2::roll(4) }
+            { Fq2::mul(2,0) }
+            { Fq::push_dec("19485874751759354771024239261021720505790618469301721065564631296452457478373") }
+            { Fq::push_dec("266929791119991161246907387137283842545076965332900288569378510910307636690") }
+            { Fq2::add(2, 0) }
+            { Fq2::roll(2) }
+            { Fq2::square() }
+            { Fq2::equalverify()}
+            OP_TRUE
+        }
+    }
+}
+
+
 #[cfg(test)]
 mod test {
 
-    use crate::bn254::curves::{G1Affine, G1Projective};
+    use crate::bn254::curves::{G1Affine, G2Affine, G1Projective};
     use crate::bn254::fq::Fq;
     use crate::bn254::utils::{
-        fr_push, fr_push_not_montgomery, g1_affine_push, g1_affine_push_not_montgomery,
+        fq2_push, fr_push, fr_push_not_montgomery, g1_affine_push, g1_affine_push_not_montgomery
     };
     use crate::{
         execute_script, execute_script_as_chunks, execute_script_without_stack_limit, run,
@@ -2370,6 +2394,27 @@ mod test {
                 { Fq::double(0) }
                 { affine_is_on_curve.clone() }
                 OP_NOT
+            };
+            println!("curves::test_affine_is_on_curve = {} bytes", script.len());
+            run(script);
+        }
+    }
+
+    #[test]
+    fn test_g2_affine_is_on_curve() {
+        let affine_is_on_curve = G2Affine::is_on_curve();
+
+        println!("G2.affine_is_on_curve: {} bytes", affine_is_on_curve.len());
+
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+        for _ in 0..3 {
+            let point = ark_bn254::G2Affine::rand(&mut prng);
+
+            let script = script! {
+                { fq2_push(point.x) }
+                { fq2_push(point.y) }
+                { affine_is_on_curve.clone()}
             };
             println!("curves::test_affine_is_on_curve = {} bytes", script.len());
             run(script);

--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -107,6 +107,15 @@ impl Fq2 {
         }
     }
 
+    pub fn equal() -> Script {
+        script! {
+            { Fq::equal(3, 1) }
+            OP_TOALTSTACK
+            { Fq::equal(1, 0) }
+            OP_FROMALTSTACK
+            OP_BOOLAND
+        }
+    }
     pub fn roll(a: u32) -> Script {
         script! {
             { Fq::roll(a + 1) }


### PR DESCRIPTION
Hi, I fix the bug mentioned by BitVM /issues/109, support G2 element subgroup membership check and the script len is about 990983 bytes.
Thanks for the backend of [Bitlayer Labs](https://github.com/bitlayer-org).