### PR TITLE
Optimize Fq2 mul (hinted) to use 2 lc2 instead of 3 lc1 tmuls & Fix Fq neg

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1596,7 +1596,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_hinted_add = {} bytes", script.len());
-            run(script);
+            assert!(execute_script(script).success);
         }
     }
     

--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -266,51 +266,54 @@ pub trait Fp254Impl {
         script! {
             // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀ ⋯
             { Self::roll(a) }
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀
-            { Self::MODULUS_LIMBS[0] } OP_SWAP { 0x20000000 }
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁻ | M₀-A₀ ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₀⁻+A₁
-            { Self::MODULUS_LIMBS[1] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁻ | M₁-(C₀⁻+A₁) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₁⁻+A₂
-            { Self::MODULUS_LIMBS[2] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₂⁻ | M₂-(C₁⁻+A₂) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₂⁻+A₃
-            { Self::MODULUS_LIMBS[3] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₃⁻ | M₃-(C₂⁻+A₃) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₃⁻+A₄
-            { Self::MODULUS_LIMBS[4] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₄⁻ | M₄-(C₃⁻+A₄) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ A₆ 2²⁹ C₄⁻+A₅
-            { Self::MODULUS_LIMBS[5] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ A₆ 2²⁹ C₅⁻ | M₅-(C₄⁻+A₅) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ A₇ 2²⁹ C₅⁻+A₆
-            { Self::MODULUS_LIMBS[6] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ A₇ 2²⁹ C₆⁻ | M₆-(C₅⁻+A₆) ⋯
-            OP_ROT OP_ADD
-            // ⋯ A₈ 2²⁹ C₆⁻+A₇
-            { Self::MODULUS_LIMBS[7] } OP_SWAP OP_ROT
-            limb_sub_borrow OP_TOALTSTACK
-            // ⋯ A₈ 2²⁹ C₇⁻ | M₇-(C₆⁻+A₇) ⋯
-            OP_NIP OP_ADD
-            // ⋯ C₇⁻+A₈
-            { Self::MODULUS_LIMBS[8] } OP_SWAP OP_SUB
-            // ⋯ M₈-(C₇⁻+A₈)
-            OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
-            OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+            { Self::is_zero_keep_element(0) }
+            OP_NOTIF
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ A₀
+                { Self::MODULUS_LIMBS[0] } OP_SWAP { 0x20000000 }
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ A₁ 2²⁹ C₀⁻ | M₀-A₀ ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₀⁻+A₁
+                { Self::MODULUS_LIMBS[1] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ A₂ 2²⁹ C₁⁻ | M₁-(C₀⁻+A₁) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₁⁻+A₂
+                { Self::MODULUS_LIMBS[2] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ A₄ A₃ 2²⁹ C₂⁻ | M₂-(C₁⁻+A₂) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₂⁻+A₃
+                { Self::MODULUS_LIMBS[3] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ A₄ 2²⁹ C₃⁻ | M₃-(C₂⁻+A₃) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₃⁻+A₄
+                { Self::MODULUS_LIMBS[4] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ A₅ 2²⁹ C₄⁻ | M₄-(C₃⁻+A₄) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ A₆ 2²⁹ C₄⁻+A₅
+                { Self::MODULUS_LIMBS[5] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ A₆ 2²⁹ C₅⁻ | M₅-(C₄⁻+A₅) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ A₇ 2²⁹ C₅⁻+A₆
+                { Self::MODULUS_LIMBS[6] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ A₇ 2²⁹ C₆⁻ | M₆-(C₅⁻+A₆) ⋯
+                OP_ROT OP_ADD
+                // ⋯ A₈ 2²⁹ C₆⁻+A₇
+                { Self::MODULUS_LIMBS[7] } OP_SWAP OP_ROT
+                limb_sub_borrow OP_TOALTSTACK
+                // ⋯ A₈ 2²⁹ C₇⁻ | M₇-(C₆⁻+A₇) ⋯
+                OP_NIP OP_ADD
+                // ⋯ C₇⁻+A₈
+                { Self::MODULUS_LIMBS[8] } OP_SWAP OP_SUB
+                // ⋯ M₈-(C₇⁻+A₈)
+                OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+                OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
+            OP_ENDIF
         }
     }
 
@@ -625,7 +628,7 @@ pub trait Fp254Impl {
             { Fq::roll(d_depth + 4) }
             { Fq::tmul_lc2() }
         };
-        hints.push(Hint::BigIntegerTmulLC1(q));
+        hints.push(Hint::BigIntegerTmulLC2(q));
 
         (script, hints)
     }
@@ -655,7 +658,7 @@ pub trait Fp254Impl {
             { Fq::copy(d_depth + 4) }
             { Fq::tmul_lc2() }
         };
-        hints.push(Hint::BigIntegerTmulLC1(q));
+        hints.push(Hint::BigIntegerTmulLC2(q));
 
         (script, hints)
     }

--- a/src/bn254/fp254impl.rs
+++ b/src/bn254/fp254impl.rs
@@ -546,7 +546,7 @@ pub trait Fp254Impl {
             { Fq::roll(b_depth + 1) }
             { Fq::tmul() }
         };
-        hints.push(Hint::Fq(ark_bn254::Fq::from_str(&q.to_string()).unwrap()));
+        hints.push(Hint::BigIntegerTmulLC1(q));
 
         (script, hints)
     }
@@ -568,7 +568,7 @@ pub trait Fp254Impl {
             { fq_push_not_montgomery(*constant) }
             { Fq::tmul() }
         };
-        hints.push(Hint::Fq(ark_bn254::Fq::from_str(&q.to_string()).unwrap()));
+        hints.push(Hint::BigIntegerTmulLC1(q));
 
         (script, hints)
     }
@@ -595,7 +595,67 @@ pub trait Fp254Impl {
             { Fq::copy(b_depth + 2) }
             { Fq::tmul() }
         };
-        hints.push(Hint::Fq(ark_bn254::Fq::from_str(&q.to_string()).unwrap()));
+        hints.push(Hint::BigIntegerTmulLC1(q));
+
+        (script, hints)
+    }
+
+    fn hinted_mul_lc2(a_depth: u32, a: ark_bn254::Fq, b_depth: u32, b: ark_bn254::Fq, c_depth: u32, c: ark_bn254::Fq, d_depth: u32, d: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+        assert!(a_depth > b_depth && b_depth > c_depth && c_depth > d_depth);
+
+        let mut hints = Vec::new();
+
+        let modulus = &Fq::modulus_as_bigint();
+
+        let x = BigInt::from_str(&a.to_string()).unwrap();
+        let y = BigInt::from_str(&b.to_string()).unwrap();
+        let z = BigInt::from_str(&c.to_string()).unwrap();
+        let w = BigInt::from_str(&d.to_string()).unwrap();
+        
+        let q = (x * z + y * w) / modulus;
+
+        let script = script!{
+            for _ in 0..Self::N_LIMBS { 
+                OP_DEPTH OP_1SUB OP_ROLL // hints
+            }
+            // { fq_push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
+            { Fq::roll(a_depth + 1) }
+            { Fq::roll(b_depth + 2) }
+            { Fq::roll(c_depth + 3) }
+            { Fq::roll(d_depth + 4) }
+            { Fq::tmul_lc2() }
+        };
+        hints.push(Hint::BigIntegerTmulLC1(q));
+
+        (script, hints)
+    }
+
+    fn hinted_mul_lc2_keep_elements(a_depth: u32, a: ark_bn254::Fq, b_depth: u32, b: ark_bn254::Fq, c_depth: u32, c: ark_bn254::Fq, d_depth: u32, d: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+        assert!(a_depth > b_depth && b_depth > c_depth && c_depth > d_depth);
+
+        let mut hints = Vec::new();
+
+        let modulus = &Fq::modulus_as_bigint();
+
+        let x = BigInt::from_str(&a.to_string()).unwrap();
+        let y = BigInt::from_str(&b.to_string()).unwrap();
+        let z = BigInt::from_str(&c.to_string()).unwrap();
+        let w = BigInt::from_str(&d.to_string()).unwrap();
+        
+        let q = (x * z + y * w) / modulus;
+
+        let script = script!{
+            for _ in 0..Self::N_LIMBS { 
+                OP_DEPTH OP_1SUB OP_ROLL // hints
+            }
+            // { fq_push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
+            { Fq::copy(a_depth + 1) }
+            { Fq::copy(b_depth + 2) }
+            { Fq::copy(c_depth + 3) }
+            { Fq::copy(d_depth + 4) }
+            { Fq::tmul_lc2() }
+        };
+        hints.push(Hint::BigIntegerTmulLC1(q));
 
         (script, hints)
     }
@@ -1052,7 +1112,8 @@ pub trait Fp254Impl {
             { Fq::copy(0) }
             { Fq::tmul() }
         };
-        hints.push(Hint::Fq(ark_bn254::Fq::from_str(&q.to_string()).unwrap()));
+        hints.push(Hint::BigIntegerTmulLC1(q));
+
         (script, hints)
     }
 
@@ -1094,7 +1155,8 @@ pub trait Fp254Impl {
             { Fq::equalverify(1, 0) }
         };
         hints.push(Hint::Fq(ark_bn254::Fq::from_str(&y.to_string()).unwrap()));
-        hints.push(Hint::Fq(ark_bn254::Fq::from_str(&q.to_string()).unwrap()));
+        hints.push(Hint::BigIntegerTmulLC1(q));
+
         (script, hints)
     }
 

--- a/src/bn254/fq.rs
+++ b/src/bn254/fq.rs
@@ -402,7 +402,7 @@ fp_lc_mul!(Mul2LC, 3, 3, [true, true]);
 #[cfg(test)]
 mod test {
     use crate::bn254::utils::fq_push_not_montgomery;
-   use crate::bn254::fq::Fq;
+    use crate::bn254::fq::Fq;
     use crate::bn254::fp254impl::Fp254Impl;
     use crate::bigint::U254;
     use crate::treepp::*;

--- a/src/bn254/fq12.rs
+++ b/src/bn254/fq12.rs
@@ -900,7 +900,7 @@ mod test {
             assert!(res.success);
 
             max_stack = max_stack.max(res.stats.max_nb_stack_items);
-            println!("Fq6::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
+            println!("Fq12::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
         }
 
     }

--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -487,7 +487,7 @@ mod test {
             assert!(res.success);
 
             max_stack = max_stack.max(res.stats.max_nb_stack_items);
-            println!("Fq2::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
+            println!("Fq2::hinted_mul: {} @ {} stack", hinted_mul.len(), max_stack);
         }
 
     }
@@ -519,7 +519,7 @@ mod test {
             assert!(res.success);
 
             max_stack = max_stack.max(res.stats.max_nb_stack_items);
-            println!("Fq2::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
+            println!("Fq2::hinted_mul_by_constant: {} @ {} stack", hinted_mul.len(), max_stack);
         }
 
     }

--- a/src/bn254/fq6.rs
+++ b/src/bn254/fq6.rs
@@ -323,8 +323,8 @@ impl Fq6 {
         let mut script = script! {};
         let script_lines = [
             // compute ad = P(0)
-            Fq2::copy(b_depth + 4),
-            Fq2::copy(a_depth + 6),
+            Fq2::copy(a_depth + 4),
+            Fq2::copy(b_depth + 6),
             hinted_script1,
 
             // compute a+c
@@ -389,8 +389,8 @@ impl Fq6 {
             hinted_script4,
 
             // compute cf = P(inf)
-            Fq2::roll(b_depth + 8),
             Fq2::roll(a_depth + 4),
+            Fq2::roll(b_depth + 10),
             hinted_script5,
 
             // // at this point, we have v_0, v_1, v_2, v_3, v_4
@@ -554,8 +554,8 @@ impl Fq6 {
 
         let (hinted_script1, hint1) = Fq2::hinted_mul(2, p.c0, 0, c0);
         let (hinted_script2, hint2) = Fq2::hinted_mul(2, p.c1, 0, c1);
-        let (hinted_script3, hint3) = Fq2::hinted_mul(2, c1, 0, p.c1+p.c2);
-        let (hinted_script4, hint4) = Fq2::hinted_mul(2, c0+c1, 0, p.c0+p.c1);
+        let (hinted_script3, hint3) = Fq2::hinted_mul(2, p.c1+p.c2, 0, c1);
+        let (hinted_script4, hint4) = Fq2::hinted_mul(2, p.c0+p.c1, 0, c0+c1);
         let (hinted_script5, hint5) = Fq2::hinted_mul(10, c0, 0, p.c0+p.c2);
 
         let mut script = script! {};
@@ -1129,7 +1129,7 @@ mod test {
             assert!(res.success);
 
             max_stack = max_stack.max(res.stats.max_nb_stack_items);
-            println!("Fq6::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
+            println!("Fq6::hinted_mul: {} @ {} stack", hinted_mul.len(), max_stack);
         }
 
     }
@@ -1165,7 +1165,7 @@ mod test {
             assert!(res.success);
 
             max_stack = max_stack.max(res.stats.max_nb_stack_items);
-            println!("Fq6::window_mul: {} @ {} stack", hinted_mul.len(), max_stack);
+            println!("Fq6::hinted_mul_by_01: {} @ {} stack", hinted_mul.len(), max_stack);
         }
 
     }

--- a/src/bn254/utils.rs
+++ b/src/bn254/utils.rs
@@ -1546,7 +1546,7 @@ mod test {
             OP_TRUE
             // [OP_TRUE]
         };
-        run(script);
+        assert!(execute_script(script).success);
     }
 
     #[test]

--- a/src/bn254/utils.rs
+++ b/src/bn254/utils.rs
@@ -1,6 +1,8 @@
+use crate::bigint::BigIntImpl;
 // utils for push fields into stack
 use crate::bn254::ell_coeffs::EllCoeff;
 use crate::bn254::ell_coeffs::G2Prepared;
+use crate::bn254::fq::bigint_to_u32_limbs;
 use crate::bn254::fr::Fr;
 use crate::bn254::{fq12::Fq12, fq2::Fq2};
 use ark_ec::{bn::BnConfig, AffineRepr};
@@ -99,13 +101,25 @@ pub fn g1_affine_push_not_montgomery(point: ark_bn254::G1Affine) -> Script {
 
 pub enum Hint {
     Fq(ark_bn254::Fq),
+    BigIntegerTmulLC1(num_bigint::BigInt),
+    BigIntegerTmulLC2(num_bigint::BigInt),
 }
 
 impl Hint {
     pub fn push(&self) -> Script {
+        const K1: (u32, u32) = Fq::bigint_tmul_lc_1();
+        const K2: (u32, u32) = Fq::bigint_tmul_lc_2();
+        pub type T1 = BigIntImpl<{K1.0}, {K1.1}>;
+        pub type T2 = BigIntImpl<{K2.0}, {K2.1}>;
         match self {
             Hint::Fq(fq) => script! {
                 { fq_push_not_montgomery(*fq) }
+            },
+            Hint::BigIntegerTmulLC1(a) => script! {
+                { T1::push_u32_le(&bigint_to_u32_limbs(a.clone(), T1::N_BITS)) }
+            },
+            Hint::BigIntegerTmulLC2(a) => script! {
+                { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T2::N_BITS)) }
             },
         }
     }

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -172,7 +172,7 @@ impl Verifier {
         let p_lst = vec![p1, p2, p3, p4];
 
         let (hinted_script1, hint1) = Fq::hinted_inv(p1.y);
-        let (hinted_script2, hint2) = Fq::hinted_mul(1, p1.x.neg(), 0, p1.y.inverse().unwrap());
+        let (hinted_script2, hint2) = Fq::hinted_mul(1, p1.y.inverse().unwrap(), 0, p1.x.neg());
         let (hinted_script3, hint3) = hinted_from_eval_point(p2);
         let (hinted_script4, hint4) = hinted_from_eval_point(p3);
         let (hinted_script5, hint5) = hinted_from_eval_point(p4);


### PR DESCRIPTION
This PR optimizes Fq2::hinted_mul from 205.715 bytes to 190.871 bytes by using 2 lc2 tmuls instead of 3 lc1 tmuls. This reduces hinted groth16 verifier from 1.33GB to 1.26GB. Also, stack usage is improved, for example Fq12::hinted_mul now uses less than 1000 stack elements (882, was 1080 before).

Also, Fq::neg function was thinking negative of zero to be prime modulus. Now, it correctly gives zero.

Closes #111 