### PR TITLE
Hint msm affine

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1529,7 +1529,7 @@ impl G1Affine {
         step_p: Vec<ark_bn254::G1Affine>,
         trace: Vec<ark_bn254::G1Affine>,
     ) -> (Script, Vec<Hint>) {
-        let hints = vec![];
+        let mut hints = vec![];
         let mut coeff_iter = coeff.iter();
         let mut step_p_iter = step_p.iter();
         let mut trace_iter = trace.iter();
@@ -1545,7 +1545,7 @@ impl G1Affine {
             p_mul.push((p_mul.last().unwrap().clone() + p.clone()).into_affine());
         }
 
-        let mut c = ark_bn254::G1Affine::zero();
+        let mut c: ark_bn254::G1Affine = ark_bn254::G1Affine::zero();
 
         let scalar_bigint = scalar.into_bigint();
 
@@ -1562,8 +1562,8 @@ impl G1Affine {
 
                 loop_scripts.push(double_loop_script.clone());
                 hints.extend(doulbe_hints);
-                c = c + *step.into();
-            }
+                c = ark_bn254::G1Affine::from(c + *step);
+            } 
             // if i == i_step * 2 {
             //     break;
             // }
@@ -1601,7 +1601,7 @@ impl G1Affine {
             loop_scripts.push(add_loop.clone());
             if mask != 0 {
                 hints.extend(add_hints);
-                c = c + p_mul[mask as usize];
+                c = ark_bn254::G1Affine::from(c + p_mul[mask as usize]);
             }
             // if i == i_step * 21 {
             //     break;

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -216,6 +216,64 @@ pub fn msm_with_constant_bases_affine(
     }
 }
 
+pub fn hinted_msm_with_constant_bases_affine(
+    bases: &[ark_bn254::G1Affine],
+    scalars: &[ark_bn254::Fr],
+) -> (Script, Vec<Hint>) {
+    assert_eq!(bases.len(), scalars.len());
+    let len = bases.len();
+    let i_step = 12_u32;
+    let (inner_coeffs, outer_coeffs) = prepare_msm_input(bases, scalars, i_step);
+
+    let mut hints = Vec::new();
+    let mut hinted_scripts = Vec::new();
+
+    // 1. init the sum=0;
+    let mut p = ark_bn254::G1Affine::zero();
+    for i in 0..len {
+        let mut c = bases[i];
+        if scalars[i] != ark_bn254::Fr::ONE {
+            let (hinted_script, hint) = G1Affine::hinted_scalar_mul_by_constant_g1(scalars[i], &mut c, inner_coeffs[i].0.clone(), inner_coeffs[i].1.clone(), inner_coeffs[i].2.clone());
+            
+            hinted_scripts.push(hinted_script);
+            hints.extend(hint);
+        }
+        // check coeffs before using
+        if i > 0 {
+            let (hinted_script, hint) = G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0, outer_coeffs[i - 1].1);
+            hinted_scripts.push(hinted_script);
+            hints.extend(hint);
+        }
+    }
+
+        let mut hinted_scripts_iter = hinted_scripts.into_iter();
+        let mut script_lines = Vec::new();
+    
+        // 1. init the sum=0;
+        script_lines.push(G1Affine::push_zero());
+        for i in 0..len {
+            // 2. scalar mul
+            if scalars[i] != ark_bn254::Fr::ONE {
+                script_lines.push(fr_push_not_montgomery(scalars[i]));
+                script_lines.push(hinted_scripts_iter.next().unwrap());
+            } else {
+                script_lines.push(G1Affine::push(bases[i]));
+            }
+            // 3. sum the base
+            script_lines.push(hinted_scripts_iter.next().unwrap());
+        }
+        // convert into Affine
+        script_lines.push(hinted_scripts_iter.next().unwrap());
+    
+        let mut script = script! {};
+        for script_line in script_lines {
+            script = script.push_script(script_line.compile());
+        }
+
+        (script, hints)
+    // into_affine involving extreem expensive field inversion, X/Z^2 and Y/Z^3, fortunately there's no need to do into_affine any more here
+}
+
 // Will compute msm assuming bases are constant and return the affine point
 // Output Stack: [x,y]
 pub fn msm_with_constant_bases(bases: &[ark_bn254::G1Affine], scalars: &[ark_bn254::Fr]) -> Script {

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -230,15 +230,15 @@ pub fn hinted_msm_with_constant_bases_affine(
     let mut hinted_scripts = Vec::new();
 
     // 1. init the sum=0;
-    let mut p = bases[0];
+    // let mut p = ark_bn254::G1Affine::zero();
+    let mut p = (bases[0] * scalars[0]).into_affine();
     for i in 0..len {
         let mut c = bases[i];
         if scalars[i] != ark_bn254::Fr::ONE {
             let (hinted_script, hint) = G1Affine::hinted_scalar_mul_by_constant_g1(scalars[i], &mut c, inner_coeffs[i].0.clone(), inner_coeffs[i].1.clone(), inner_coeffs[i].2.clone());
-            
             hinted_scripts.push(hinted_script);
             hints.extend(hint);
-        }
+        } 
         // check coeffs before using
         if i > 0 {
             let (hinted_script, hint) = G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0, outer_coeffs[i - 1].1);
@@ -251,8 +251,8 @@ pub fn hinted_msm_with_constant_bases_affine(
         let mut hinted_scripts_iter = hinted_scripts.into_iter();
         let mut script_lines = Vec::new();
     
-        // 1. init the sum = base[0];
-        script_lines.push(G1Affine::push_not_montgomery(bases[0]));
+        // 1. init the sum = base[0] * scalars[0];
+        // script_lines.push(G1Affine::push_not_montgomery((bases[0] * scalars[0]).into_affine()));
         for i in 0..len {
             // 2. scalar mul
             if scalars[i] != ark_bn254::Fr::ONE {

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -220,6 +220,7 @@ pub fn hinted_msm_with_constant_bases_affine(
     bases: &[ark_bn254::G1Affine],
     scalars: &[ark_bn254::Fr],
 ) -> (Script, Vec<Hint>) {
+    println!("use hinted_msm_with_constant_bases_affine");
     assert_eq!(bases.len(), scalars.len());
     let len = bases.len();
     let i_step = 12_u32;
@@ -243,7 +244,8 @@ pub fn hinted_msm_with_constant_bases_affine(
             let (hinted_script, hint) = G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0, outer_coeffs[i - 1].1);
             hinted_scripts.push(hinted_script);
             hints.extend(hint);
-        }
+            p = ark_bn254::G1Affine::from(p + c);
+        } 
     }
 
         let mut hinted_scripts_iter = hinted_scripts.into_iter();
@@ -260,10 +262,10 @@ pub fn hinted_msm_with_constant_bases_affine(
                 script_lines.push(G1Affine::push(bases[i]));
             }
             // 3. sum the base
-            script_lines.push(hinted_scripts_iter.next().unwrap());
+            if i > 0 {
+                script_lines.push(hinted_scripts_iter.next().unwrap());
+            }
         }
-        // convert into Affine
-        script_lines.push(hinted_scripts_iter.next().unwrap());
     
         let mut script = script! {};
         for script_line in script_lines {

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -3,7 +3,7 @@ use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fq12::Fq12;
 use crate::bn254::msm::{
-    hinted_msm_with_constant_bases, msm_with_constant_bases, msm_with_constant_bases_affine,
+    hinted_msm_with_constant_bases, hinted_msm_with_constant_bases_affine, msm_with_constant_bases, msm_with_constant_bases_affine
 };
 use crate::bn254::pairing::Pairing;
 use crate::bn254::utils::{
@@ -141,7 +141,8 @@ impl Verifier {
         .concat();
         let msm_g1 =
             G1Projective::msm(&vk.gamma_abc_g1, &scalars).expect("failed to calculate msm");
-        let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases(&vk.gamma_abc_g1, &scalars);
+        // let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases(&vk.gamma_abc_g1, &scalars);
+        let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases_affine(&vk.gamma_abc_g1, &scalars);
         hints.extend(hint_msm);
 
         let (exp, sign) = if LAMBDA.gt(&P_POW3) {

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -141,7 +141,7 @@ impl Verifier {
         .concat();
         let msm_g1 =
             G1Projective::msm(&vk.gamma_abc_g1, &scalars).expect("failed to calculate msm");
-        // let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases(&vk.gamma_abc_g1, &scalars);
+        //let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases(&vk.gamma_abc_g1, &scalars);
         let (hinted_msm, hint_msm) = hinted_msm_with_constant_bases_affine(&vk.gamma_abc_g1, &scalars);
         hints.extend(hint_msm);
 


### PR DESCRIPTION
hi, I supported the hinted_msm_affine_version groth16 verifier based on https://github.com/BitVM/BitVM/pull/114  and https://github.com/BitVM/BitVM/pull/93, and the hinted_groth16_verifier script len is 1127900767bytes (about 1.05G). This reduces hinted groth16 verifier from 1.26GB to 1.05GB. Thanks @PayneJoe , @wz14, @cyl19970726 for your help and the support from bitlayer labs.