### PR TITLE
feat: allow to serialize and cache layout and chunks to speed up eval.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tmp
 
 # Bridge public and private files
 bridge_data/
+
+# Cache for any evaluation result
+.cache/** */
+!.cache/.gitkeep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ark-bn254 = { git = "https://github.com/Antalpha-Labs/algebra/", features = ["cu
 ark-ff = { git = "https://github.com/Antalpha-Labs/algebra/" }
 ark-ec = { git = "https://github.com/Antalpha-Labs/algebra/" }
 ark-groth16 = { git = "https://github.com/Antalpha-Labs/groth16" }
+ark-serialize = { version = "0.4", features = ["derive"] }
 sha2 = "0.10.8"
 tokio = { version = "1.37.0", features = ["full"] }
 esplora-client = { git = "https://github.com/BitVM/rust-esplora-client" }
@@ -41,6 +42,8 @@ suppaftp = { version = "6.0.1", features = ["async", "async-native-tls"] }
 openssh-sftp-client = { version = "0.14.6", features = ["openssh"] }
 openssh = { version = "0.10.4", features = ["native-mux"] }
 alloy = { version = "0.2.1", features = ["full"] }
+bincode = { version = "1.3.3" }
+rayon = { version = "1.10.0" }
 
 [dev-dependencies]
 num-bigint = { version = "0.4.4", features = ["rand"] }

--- a/src/layout/cache.rs
+++ b/src/layout/cache.rs
@@ -1,0 +1,304 @@
+use std::{
+    cell::RefCell,
+    env,
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+    rc::Rc,
+};
+
+use once_cell::sync::Lazy;
+
+use super::{
+    serialization::{ChunkWithoutInputOutput, SerializableChunk, SerializableLayout},
+    HashedInput, Layout,
+};
+
+use rayon::prelude::*;
+
+static CACHE_LAYOUT_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    let path = if let Ok(env_path) = env::var("CACHE_LAYOUT_PATH") {
+        PathBuf::from(env_path)
+    } else if cfg!(test) {
+        PathBuf::from(".cache/test-layout")
+    } else {
+        PathBuf::from(".cache/layout")
+    };
+
+    if !path.exists() {
+        eprintln!("Warning: Path {:?} does not exist. Creating it now.", path);
+
+        if let Err(e) = fs::create_dir_all(&path) {
+            eprintln!("Error: Failed to create directory {:?}: {:?}", path, e);
+        }
+    }
+
+    path
+});
+
+trait SerializableStack {
+    fn from_u8_vec(v: Vec<Vec<u8>>) -> Self;
+    fn as_v8_vec(&self) -> Vec<Vec<u8>>;
+
+    fn dump(&self, layout_name: &str, label: &str) -> Result<(), bincode::Error> {
+        let subfolder_name = format!("{}.bin", label);
+        let cache_path = CACHE_LAYOUT_PATH.join(layout_name).join(subfolder_name);
+        let mut file = File::create(&cache_path).expect(format!("Failed to create file: {:?}", cache_path).as_str());
+        let encoded = bincode::serialize(&self.as_v8_vec());
+        match encoded {
+            Ok(encoded) => file.write_all(&encoded).map_err(|e| e.into()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn load(layout_name: &str, label: &str) -> Result<Self, bincode::Error>
+    where
+        Self: Sized,
+    {
+        let subfolder_name = format!("{}.bin", label);
+        let cache_path = CACHE_LAYOUT_PATH.join(layout_name).join(subfolder_name);
+        let file = File::open(&cache_path).expect(format!("Failed to open file: {:?}", cache_path).as_str());
+        let decoded = bincode::deserialize_from(file);
+        match decoded {
+            Ok(decoded) => Ok(Self::from_u8_vec(decoded)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl SerializableChunk {
+    fn dump(&self, layout_name: &str, label: &str) -> Result<(), bincode::Error> {
+        let subfolder_name = format!("{}.bin", label);
+        let cache_path = CACHE_LAYOUT_PATH.join(layout_name).join(subfolder_name);
+        let mut file = File::create(&cache_path).expect(format!("Failed to create file: {:?}", cache_path).as_str());
+        let encoded = bincode::serialize(&self);
+        match encoded {
+            Ok(encoded) => file.write_all(&encoded).map_err(|e| e.into()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn load(layout_name: &str, label: &str) -> Result<Self, bincode::Error> {
+        let subfolder_name = format!("{}.bin", label);
+        let cache_path = CACHE_LAYOUT_PATH.join(layout_name).join(subfolder_name);
+        let file = File::open(&cache_path).expect(format!("Failed to open file: {:?}", cache_path).as_str());
+        bincode::deserialize_from(file)
+    }
+}
+
+impl SerializableLayout {
+    fn dump(&self) -> Result<(), bincode::Error> {
+        let layout_name = self.name.clone();
+        let cache_path = CACHE_LAYOUT_PATH
+            .join(layout_name)
+            .join(format!("layout-info.bin"));
+        let mut file = File::create(&cache_path).expect(format!("Failed to create file: {:?}", cache_path).as_str());
+        let encoded = bincode::serialize(&self);
+        match encoded {
+            Ok(encoded) => file.write_all(&encoded).map_err(|e| e.into()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn load(name: &str) -> Result<Self, bincode::Error> {
+        let layout_name = name;
+        let cache_path = CACHE_LAYOUT_PATH
+            .join(layout_name)
+            .join(format!("layout-info.bin"));
+        let file = File::open(&cache_path).expect(format!("Failed to open file: {:?}", cache_path).as_str());
+        bincode::deserialize_from(file)
+    }
+}
+
+impl Layout {
+    pub fn saved_chunk_name(i: usize, chunk_name: &str) -> String {
+        format!("chunk_{}_{}", i, chunk_name)
+    }
+
+    // Serialize the layout and write it to a file.
+    pub fn dump(&self) -> Result<(), bincode::Error> {
+        let layout_name = self.name.clone();
+        let cache_path = CACHE_LAYOUT_PATH
+            .join(&layout_name);
+        if !cache_path.exists() {
+            fs::create_dir_all(&cache_path).expect(format!("Failed to create directory: {:?}", cache_path).as_str());
+        }
+        let chunk_names: Vec<String> = self
+            .chunks
+            .iter()
+            .map(|c| c.as_ref().borrow().name.clone())
+            .collect();
+        let mut inputs: Vec<(usize, usize, usize)> = vec![];
+        for (index, c) in self.chunks.iter().enumerate() {
+            let chunk = c.as_ref().borrow();
+            let arc_indices: Vec<(usize, usize, usize)> = chunk
+                .inputs
+                .iter()
+                .filter_map(|input_index| {
+                    for (i, c) in self.chunks.iter().enumerate() {
+                        if Rc::ptr_eq(c, &input_index.outputting_chunk) {
+                            return Some((index, i, input_index.output_index));
+                        }
+                    }
+                    return None;
+                })
+                .collect();
+            inputs.extend(arc_indices);
+        }
+        let mut outputs: Vec<(usize, usize)> = vec![];
+        for (index, c) in self.chunks.iter().enumerate() {
+            let chunk = c.as_ref().borrow();
+            let arc_indices: Vec<(usize, usize)> = chunk
+                .outputs
+                .iter()
+                .map(|output_index| (index, *output_index))
+                .collect();
+            outputs.extend(arc_indices);
+        }
+        let serializable_layout = SerializableLayout {
+            chunk_names,
+            name: layout_name.clone(),
+            outputs,
+            inputs,
+        };
+        let chunk_withouts: Vec<ChunkWithoutInputOutput> = self
+            .chunks
+            .iter()
+            .map(|c| ChunkWithoutInputOutput::from_chunk(&c.as_ref().borrow()))
+            .collect();
+
+        let res = chunk_withouts
+            .par_iter()
+            .enumerate()
+            .try_for_each(|(i, c)| {
+                let cs = c.as_serializable();
+                cs.dump(
+                    &layout_name.clone(),
+                    Layout::saved_chunk_name(i, &cs.name).as_str(),
+                )
+            });
+
+        match res {
+            Ok(_) => {
+                let res = serializable_layout.dump();
+                match res {
+                    Ok(_) => Ok(()),
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn load(layout_name: &str) -> Self {
+        let serializable_layout = SerializableLayout::load(layout_name).unwrap();
+        let mut chunks = vec![];
+        for (i, chunk_name) in serializable_layout.chunk_names.iter().enumerate() {
+            let chunk =
+                SerializableChunk::load(layout_name, &Layout::saved_chunk_name(i, chunk_name))
+                    .unwrap();
+            let chunk_without = ChunkWithoutInputOutput::from_serializable(chunk);
+            let chunk = chunk_without.into_chunk();
+            chunks.push(Rc::new(RefCell::new(chunk)));
+        }
+        for (i, chunk) in chunks.iter().enumerate() {
+            let mut chunk = chunk.borrow_mut();
+            chunk.inputs = serializable_layout
+                .inputs
+                .iter()
+                .filter_map(|pair| {
+                    if pair.0 == i {
+                        Some(HashedInput::new(chunks[pair.1].clone(), pair.2))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            chunk.outputs = serializable_layout
+                .outputs
+                .iter()
+                .filter_map(|pair| if pair.0 == i { Some(pair.1) } else { None })
+                .collect();
+        }
+        let mut layout = Layout::new(layout_name);
+        layout.chunks = chunks;
+        layout
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+    use std::panic;
+    use std::path::PathBuf;
+    use std::rc::Rc;
+
+    use crate::layout::example::example_combine_layout;
+    use crate::layout::example::example_split_layout;
+    use crate::layout::Layout;
+
+    use super::CACHE_LAYOUT_PATH;
+
+    #[test]
+    fn test_dump_example_combine_layout() {
+        let path: &PathBuf = &*CACHE_LAYOUT_PATH;
+        fs::create_dir_all(path).expect("Failed to create cache directory");
+
+        let result = panic::catch_unwind(|| {
+            let layout_0 = example_combine_layout();
+            layout_0.dump().unwrap();
+            let layout_1 = Layout::load(layout_0.name.as_str());
+            for (c0, c1) in layout_0.chunks.iter().zip(layout_1.chunks.iter()) {
+                let c0 = c0.borrow();
+                let c1 = c1.borrow();
+                assert!(c0.name == c1.name);
+                assert!(c0.execution_script.len() == c1.execution_script.len());
+                assert!(c0.hints == c1.hints);
+                let c0_output_indexs: Vec<usize> =
+                    c0.inputs.iter().map(|i| i.output_index).collect();
+                let c1_output_indexs: Vec<usize> =
+                    c1.inputs.iter().map(|i| i.output_index).collect();
+                assert!(c0_output_indexs == c1_output_indexs);
+                assert!(c0.outputs == c1.outputs);
+            }
+        });
+
+        fs::remove_dir_all(path).unwrap();
+
+        if let Err(err) = result {
+            panic::resume_unwind(err);
+        }
+    }
+
+
+    #[test]
+    fn test_dump_example_split_layout() {
+        let path: &PathBuf = &*CACHE_LAYOUT_PATH;
+        fs::create_dir_all(path).expect("Failed to create cache directory");
+
+        let result = panic::catch_unwind(|| {
+            let layout_0 = example_split_layout();
+            layout_0.dump().unwrap();
+            let layout_1 = Layout::load(layout_0.name.as_str());
+            for (c0, c1) in layout_0.chunks.iter().zip(layout_1.chunks.iter()) {
+                let c0 = c0.borrow();
+                let c1 = c1.borrow();
+                assert!(c0.name == c1.name);
+                assert!(c0.execution_script.len() == c1.execution_script.len());
+                assert!(c0.hints == c1.hints);
+                let c0_output_indexs: Vec<usize> =
+                    c0.inputs.iter().map(|i| i.output_index).collect();
+                let c1_output_indexs: Vec<usize> =
+                    c1.inputs.iter().map(|i| i.output_index).collect();
+                assert!(c0_output_indexs == c1_output_indexs);
+                assert!(c0.outputs == c1.outputs);
+            }
+        });
+
+        fs::remove_dir_all(path).unwrap();
+
+        if let Err(err) = result {
+            panic::resume_unwind(err);
+        }
+    }
+}

--- a/src/layout/example.rs
+++ b/src/layout/example.rs
@@ -7,19 +7,19 @@ const G1P: usize = 27;
 
 // Splits input from one chunk to two other chunks
 pub fn example_split_layout() -> Layout {
-    let mut layout = Layout::new();
-    layout.push_serial_chunk(vec![G1P], vec![], G1Projective::push_zero());
-    layout.push_serial_chunk(vec![2 * G1P], vec![], G1Projective::push_zero());
-    layout.push_serial_chunk(vec![3 * G1P], vec![], G1Projective::push_zero());
+    let mut layout = Layout::new("example_split_layout");
+    layout.push_serial_chunk(vec![G1P], vec![], G1Projective::push_zero(), "chunk_a");
+    layout.push_serial_chunk(vec![2 * G1P], vec![], G1Projective::push_zero(), "chunk_b");
+    layout.push_serial_chunk(vec![3 * G1P], vec![], G1Projective::push_zero(), "chunk_c");
     // Split input into two outputs in the next chunk
     let last_push_zero_chunk =
-        layout.push_serial_chunk(vec![2 * G1P, 2 * G1P], vec![], G1Projective::push_zero());
+        layout.push_serial_chunk(vec![2 * G1P, 2 * G1P], vec![], G1Projective::push_zero(), "chunk_d");
 
-    let mut sub_layout_1 = Layout::new();
-    sub_layout_1.push_serial_chunk(vec![], vec![], G1Projective::equalverify());
+    let mut sub_layout_1 = Layout::new("example_split_layout_sub_layout_1");
+    sub_layout_1.push_serial_chunk(vec![], vec![], G1Projective::equalverify(), "chunk_e");
 
-    let mut sub_layout_2 = Layout::new();
-    sub_layout_2.push_serial_chunk(vec![], vec![], G1Projective::equalverify());
+    let mut sub_layout_2 = Layout::new("example_split_layout_sub_layout_2");
+    sub_layout_2.push_serial_chunk(vec![], vec![], G1Projective::equalverify(), "chunk_f");
 
     // Specify to which output each sub layout is linked and integrate them into the layout
     let _chunk_a = layout.push_partial_parallel_layout(sub_layout_1, vec![(last_push_zero_chunk.clone(), 0)]);
@@ -33,18 +33,20 @@ pub fn example_split_layout() -> Layout {
 
 // Combines outputs from two chunks into one chunk
 pub fn example_combine_layout() -> Layout {
-    let mut layout = Layout::new();
+    let mut layout = Layout::new("example_combine_layout");
     let chunk_a = layout.push(Chunk::new(
         vec![],
         vec![G1P],
         vec![],
         G1Projective::push_zero(),
+        "chunk_a",
     ));
     let chunk_b = layout.push(Chunk::new(
         vec![],
         vec![G1P],
         vec![],
         G1Projective::push_zero(),
+        "chunk_b",
     ));
 
     let combined_input_chunk = Chunk::new(
@@ -53,6 +55,7 @@ pub fn example_combine_layout() -> Layout {
         vec![],
         vec![],
         G1Projective::equalverify(),
+        "combined_input_chunk",
     );
     layout.push(combined_input_chunk);
     layout

--- a/src/layout/groth16.rs
+++ b/src/layout/groth16.rs
@@ -2,6 +2,6 @@ use super::{Chunk, Layout};
 
 
 pub fn groth16_layout() -> Layout {
-    let layout = Layout::new();
+    let layout = Layout::new("groth16_layout");
     layout
 }

--- a/src/layout/serialization.rs
+++ b/src/layout/serialization.rs
@@ -1,0 +1,131 @@
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+use bitcoin::ScriptBuf;
+use bitcoin_script::Script;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::treepp;
+
+use super::Chunk;
+use super::Hint;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializableHint {
+    pub label: String,
+    pub bytes: Vec<u8>,
+}
+
+impl Hint {
+    pub fn as_serializable(&self) -> SerializableHint {
+        match self {
+            Hint::Fr(fr) => SerializableHint {
+                label: "Fr".to_string(),
+                bytes: {
+                    let mut bytes = Vec::new();
+                    fr.serialize_uncompressed(&mut bytes).unwrap();
+                    bytes
+                },
+            },
+            Hint::Fq(fq) => SerializableHint {
+                label: "Fq".to_string(),
+                bytes: {
+                    let mut bytes = Vec::new();
+                    fq.serialize_uncompressed(&mut bytes).unwrap();
+                    bytes
+                },
+            },
+        }
+    }
+    pub fn from_serializable(v: &SerializableHint) -> Self {
+        match v.label.as_str() {
+            "Fr" => Hint::Fr(ark_bn254::Fr::deserialize_uncompressed(&v.bytes[..]).unwrap()),
+            "Fq" => Hint::Fq(ark_bn254::Fq::deserialize_uncompressed(&v.bytes[..]).unwrap()),
+            _ => panic!("Unknown hint type."),
+        }
+    }
+}
+
+impl Serialize for Hint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_serializable().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Hint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Hint::from_serializable(&SerializableHint::deserialize(
+            deserializer,
+        )?))
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializableChunk {
+    pub hints: Vec<SerializableHint>,
+    pub execution_script_buf: Vec<u8>,
+    pub name: String,
+}
+
+pub struct ChunkWithoutInputOutput {
+    hints: Vec<Hint>,
+    execution_script: Script,
+    name: String,
+}
+
+impl ChunkWithoutInputOutput {
+    pub fn as_serializable(&self) -> SerializableChunk {
+        SerializableChunk {
+            hints: self.hints.iter().map(|h| h.as_serializable()).collect(),
+            execution_script_buf: {
+                let script_buf = self.execution_script.clone().compile();
+                script_buf.into_bytes()
+            },
+            name: self.name.clone(),
+        }
+    }
+
+    pub fn from_serializable(v: SerializableChunk) -> Self {
+        let mut script = treepp::Script::new("deserialized_script");
+        script = script.push_script(ScriptBuf::from_bytes(v.execution_script_buf));
+        ChunkWithoutInputOutput {
+            hints: v.hints.iter().map(|h| Hint::from_serializable(h)).collect(),
+            execution_script: script,
+            name: v.name.clone(),
+        }
+    }
+
+    pub fn from_chunk(chunk: &Chunk) -> Self {
+        ChunkWithoutInputOutput {
+            hints: chunk.hints.clone(),
+            execution_script: chunk.execution_script.clone(),
+            name: chunk.name.clone(),
+        }
+    }
+
+    pub fn into_chunk(self) -> Chunk {
+        Chunk {
+            hints: self.hints,
+            execution_script: self.execution_script,
+            name: self.name,
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializableLayout {
+    pub chunk_names: Vec<String>,
+    pub name: String,
+    // (chunk_index, output_chunk)
+    pub outputs: Vec<(usize, usize)>,
+    // (chunk_index, input_chunk_index, input_chunk_output_index)
+    pub inputs: Vec<(usize, usize, usize)>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod treepp {
 use core::fmt;
 use std::{cmp::min, fs::File, io::Write};
 
-use bitcoin::{hashes::Hash, hex::DisplayHex, Opcode, ScriptBuf, TapLeafHash, Transaction};
+use bitcoin::{hashes::Hash, hex::DisplayHex, Opcode, TapLeafHash, Transaction};
 use bitcoin_scriptexec::{Exec, ExecCtx, ExecError, ExecStats, Options, Stack, TxTemplate};
 
 pub mod bigint;


### PR DESCRIPTION
Changelogs:

- Add a `name` field to identify different layouts.
- Support serialization and deserialization for Hint, Chunk, and Layout.
- Test the function correctness for Serialization, Dump, and Load.
- Format the file.

The compatibility is kept between commits.