### PR TITLE
feat: optimize winternitz

### DIFF
--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -55,7 +55,7 @@ pub fn public_key_for_digit(secret_key: &str, digit_index: u32) -> [u8; 20] {
     *hash.as_byte_array()
 }
 
-/// Generate a public key from a secret key 
+/// Generate a public key from a secret key
 pub fn generate_public_key(secret_key: &str) -> PublicKey {
     let mut public_key_array = [[0u8; 20]; N as usize];
     for i in 0..N {
@@ -109,8 +109,6 @@ pub fn to_digits<const DIGIT_COUNT: usize>(mut number: u32) -> [u8; DIGIT_COUNT]
     digits
 }
 
-
-
 /// Compute the signature for a given message
 pub fn sign_digits(secret_key: &str, message_digits: [u8; N0 as usize]) -> Script {
     // const message_digits = to_digits(message, n0)
@@ -135,15 +133,69 @@ pub fn sign(secret_key: &str, message_bytes: &[u8]) -> Script {
     sign_digits(secret_key, message_digits)
 }
 
-pub fn checksig_verify(public_key: &PublicKey) -> Script {
-    script! {
-        //
-        // Verify the hash chain for each digit
-        //
-
-        // Repeat this for every of the n many digits
-        for digit_index in 0..N {
+pub fn verify_digit(digit_pubkey: &[u8; 20]) -> Script {
+    if LOG_D == 4 {
+        // when using 4-bit digits, we apply an optimization. In the unoptimized version:
+        // - we push 16 hashes on the stack (OP_DUP + OP_HASH160)
+        // - use op_pick
+        // - do 8 OP_2DROPS to clear the stack
+        // In the optimized version, we save 8 OP_DUP and 4 OP_2DROPS, in exchange for 9 opcodes
+        // to implement to following logic (saving 3 bytes per digit):
+        // if the digit is less than 8:
+        //     we know that the hash that we're interested in is not in the first 8 hashes. So we
+        //     do the the first 8 hashes without storing intermediate results.
+        // else:
+        //     we know that the hash that we're interested in is not in the last 8 hashes. So we
+        //     just just reduce the op_pick input by 8
+        // Now we only need to do 8 iterations of [OP_DUP OP_HASH160], saving 8 OP_DUPS and 4 OP_2DROPS
+        script! {
             // Verify that the digit is in the range [0, d]
+            // See https://github.com/BitVM/BitVM/issues/35
+            { D }
+            OP_MIN
+
+            // Push a copy of the digit onto the altstack
+            OP_DUP
+            OP_TOALTSTACK
+            // push a copy of the digit on the stack
+            OP_DUP
+
+            OP_8
+            OP_LESSTHAN
+            OP_IF
+                // digit is less than 8: run 8 iterations of the hashing without storing intermediate results on stack
+                // The stack index to use will be equal to the digit.
+                OP_TOALTSTACK
+                for _ in 0..8 {
+                    OP_HASH160
+                }
+            OP_ELSE
+                // digit is 8 or more - we don't need to run the last 8 iterations of the hashing.
+                // Reduce the stack index by 8 to compensate
+                OP_8
+                OP_SUB
+                OP_TOALTSTACK
+            OP_ENDIF
+
+            // Hash the input hash d-8 times and put every result on the stack
+            for _ in 0..D-8 {
+                OP_DUP OP_HASH160
+            }
+
+            // Verify the signature for this digit
+            OP_FROMALTSTACK
+            OP_PICK
+            { digit_pubkey.to_vec() }
+            OP_EQUALVERIFY
+
+            // Drop the d+1 stack items
+            for _ in 0..(D+1)/2/2 {
+                OP_2DROP
+            }
+        }
+    } else {
+        script! {
+             // Verify that the digit is in the range [0, d]
             // See https://github.com/BitVM/BitVM/issues/35
             { D }
             OP_MIN
@@ -161,13 +213,26 @@ pub fn checksig_verify(public_key: &PublicKey) -> Script {
             // Verify the signature for this digit
             OP_FROMALTSTACK
             OP_PICK
-            { public_key[N as usize - 1 - digit_index as usize].to_vec() }
+            { digit_pubkey.to_vec() }
             OP_EQUALVERIFY
 
             // Drop the d+1 stack items
             for _ in 0..(D+1)/2 {
                 OP_2DROP
             }
+        }
+    }
+}
+
+pub fn checksig_verify(public_key: &PublicKey) -> Script {
+    script! {
+        //
+        // Verify the hash chain for each digit
+        //
+
+        // Repeat this for every of the n many digits
+        for digit_index in 0..N {
+            { verify_digit(&public_key[N as usize - 1 - digit_index as usize]) }
         }
 
         //
@@ -217,14 +282,12 @@ pub fn checksig_verify(public_key: &PublicKey) -> Script {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     // The secret key
     const MY_SECKEY: &str = "b138982ce17ac813d505b5b40b665d404e9528e7";
-
 
     #[test]
     fn test_winternitz() {
@@ -249,7 +312,7 @@ mod test {
             script.len() as f64 / (N0 * 4) as f64
         );
 
-        run(script! {
+        let result = execute_script(script! {
             { sign_digits(MY_SECKEY, MESSAGE) }
             { checksig_verify(&public_key) }
 
@@ -275,6 +338,8 @@ mod test {
             0x77 OP_EQUALVERIFY
             0x77 OP_EQUAL
         });
+
+        assert!(result.success);
     }
 
     // TODO: test the error cases: negative digits, digits > D, ...


### PR DESCRIPTION
Using 160-bit messages, this reduces the script size from 26.9375 bytes / bit to 26.1125 bytes / bit. (saves 3 ops per digit)

The optimization only works for 4-bit digits and up. For now it's implemented only for 4-bit digits. See the comments for details

(also changed `run` to `execute_script` since `run` doesn't work even in `main`)