### PR TITLE
change algebra dependency to the version with new ATE_LOOP_COUNT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"
 serde = { version = "1.0.197", features = ["derive"] }
 num-bigint = "0.4.4"
 num-traits = "0.2.18"
-ark-bn254 = { git = "https://github.com/Antalpha-Labs/algebra/", features = ["curve"], default-features = false }
-ark-ff = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-ec = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-groth16 = { git = "https://github.com/Antalpha-Labs/groth16" }
+ark-bn254 = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop", features = ["curve"], default-features = false }
+ark-ff = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-ec = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-groth16 = { git = "https://github.com/arkworks-rs/groth16" }
 sha2 = "0.10.8"
 tokio = { version = "1.37.0", features = ["full"] }
 esplora-client = { git = "https://github.com/BitVM/rust-esplora-client" }
@@ -45,8 +45,8 @@ alloy = { version = "0.2.1", features = ["full"] }
 [dev-dependencies]
 num-bigint = { version = "0.4.4", features = ["rand"] }
 ark-std = { version = "0.4.0", default-features = false, features = ["print-trace"] }
-ark-crypto-primitives = { git = "https://github.com/Antalpha-Labs/crypto-primitives", features = ["snark", "sponge"] }
-ark-relations = { git = "https://github.com/Antalpha-Labs/snark/" }
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", features = ["snark", "sponge"] }
+ark-relations = { git = "https://github.com/arkworks-rs/snark/" }
 
 [profile.dev]
 opt-level = 3
@@ -62,15 +62,15 @@ bitcoin-internals = { git = "https://github.com/rust-bitcoin/rust-bitcoin", bran
 bitcoin-io = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm"}
 bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm"}
 
-ark-ff = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-ec = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-poly = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-serialize = { git = "https://github.com/Antalpha-Labs/algebra/" }
-ark-bn254 = { git = "https://github.com/Antalpha-Labs/algebra/", features = ["curve"], default-features = false }
+ark-ff = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-ec = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-poly = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-serialize = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop" }
+ark-bn254 = { git = "https://github.com/chainwayxyz/algebra/", branch = "new-ate-loop", features = ["curve"], default-features = false }
 
-ark-r1cs-std = { git = "https://github.com/Antalpha-Labs/r1cs-std/" }
-ark-crypto-primitives = { git = "https://github.com/Antalpha-Labs/crypto-primitives/" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives/" }
 
-ark-relations = { git = "https://github.com/Antalpha-Labs/snark/" }
-ark-snark = { git = "https://github.com/Antalpha-Labs/snark/" }
-ark-groth16 = { git = "https://github.com/Antalpha-Labs/groth16" }
+ark-relations = { git = "https://github.com/arkworks-rs/snark/" }
+ark-snark = { git = "https://github.com/arkworks-rs/snark/" }
+ark-groth16 = { git = "https://github.com/arkworks-rs/groth16" }


### PR DESCRIPTION
This PR changes the algebra dependency to include the new ATE_LOOP_COUNT change, while keeping the work done by by Antalpha-Labs. With this change hinted Groth16 verifier becomes 1.002 GB instead of 1.05 GB.