### PR TITLE
Affine infinity fix

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1534,14 +1534,7 @@ impl G1Affine {
                     let point_after_double = trace_iter.next().unwrap();
                     let double_loop = script! {
                         // check before usage
-                        { G1Affine::is_zero_keep_element() }
-                        OP_NOTIF
-                            { G1Affine::check_double(double_coeff.0, double_coeff.1) }
-                            // FOR DEBUG
-                            // { G1Affine::push(point_after_double.clone()) }
-                            // { G1Affine::equalverify() }
-                            // { G1Affine::push(point_after_double.clone()) }
-                        OP_ENDIF
+                        { G1Affine::check_double(double_coeff.0, double_coeff.1) }
                     };
                     loop_scripts.push(double_loop.clone());
                 }
@@ -1569,18 +1562,7 @@ impl G1Affine {
                 { G1Affine::dfs_with_constant_mul(0, depth - 1, 0, &p_mul) }
                 // check before usage
                 if i > 0 {
-                    { G1Affine::is_zero_keep_element() }
-                    OP_IF
-                        { G1Affine::drop() }
-                    OP_ELSE
-                        { G1Affine::roll(1) }
-                        { G1Affine::is_zero_keep_element() }
-                        OP_IF
-                            { G1Affine::drop() }
-                        OP_ELSE
-                            { G1Affine::check_add(add_coeff.0, add_coeff.1) }
-                        OP_ENDIF
-                    OP_ENDIF
+                    { G1Affine::check_add(add_coeff.0, add_coeff.1) }
                 }
                 // FOR DEBUG
                 // { G1Affine::push(point_after_add.clone()) }
@@ -1709,12 +1691,23 @@ impl G1Affine {
 
     pub fn check_add(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
         script! {
-            { Fq::copy(3) }
-            { Fq::roll(3) }
-            { Fq::copy(3) }
-            { Fq::roll(3) }
-            { G1Affine::check_chord_line(c3, c4) }
-            { G1Affine::add(c3, c4) }
+            { Self::is_zero_keep_element() }
+            OP_IF
+                { Self::drop() }
+            OP_ELSE
+                { Self::roll(1) }
+                { Self::is_zero_keep_element() }
+                OP_IF
+                    { Self::drop() }
+                OP_ELSE
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { G1Affine::check_chord_line(c3, c4) }
+                    { G1Affine::add(c3, c4) }
+                OP_ENDIF
+            OP_ENDIF
         }
     }
 
@@ -1928,10 +1921,13 @@ impl G1Affine {
 
     pub fn check_double(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
         script! {
-            { Fq::copy(1) }
-            { Fq::roll(1) }
-            { G1Affine::check_tangent_line(c3, c4) }
-            { G1Affine::double(c3, c4) }
+            { Self::is_zero_keep_element() }
+            OP_NOTIF
+                { Fq::copy(1) }
+                { Fq::roll(1) }
+                { G1Affine::check_tangent_line(c3, c4) }
+                { G1Affine::double(c3, c4) }
+            OP_ENDIF
         }
     }
 

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1650,9 +1650,6 @@ impl G1Affine {
                     c = (c + c).into_affine();
                 }
             }
-            // if i == i_step * 2 {
-            //     break;
-            // }
 
             // squeeze a bucket scalar
             loop_scripts.push(script! {

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1532,10 +1532,7 @@ impl G1Affine {
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    let double_loop = script! {
-                        // check before usage
-                        { G1Affine::check_double(double_coeff.0, double_coeff.1) }
-                    };
+                    let double_loop = G1Affine::check_double(double_coeff.0, double_coeff.1);
                     loop_scripts.push(double_loop.clone());
                 }
             }

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -2035,7 +2035,7 @@ impl G1Affine {
         script! {
             { Fq::is_zero_keep_element(0) }
             OP_TOALTSTACK
-            { Fq::is_zero_keep_element(0) }
+            { Fq::is_zero_keep_element(1) }
             OP_FROMALTSTACK
             OP_BOOLAND
         }

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1394,6 +1394,35 @@ impl G1Affine {
         }
     }
 
+    pub fn hinted_check_tangent_line(t: ark_bn254::G1Affine, c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+        let mut hints = vec![];
+
+        let (hinted_script1, hint1) = Fq::hinted_mul_by_constant_stable(t.y + t.y, &c3);
+        let (hinted_script2, hint2) = Fq::hinted_square(t.x);
+        let (hinted_script3, hint3) = Self::hinted_check_line_through_point(t.x, c3, c4);
+
+        let script = script! {                    // x, y
+            { Fq::copy(0) }                                         // x, y, y
+            { Fq::double(0) }                                       // x, y, 2y
+            { hinted_script1 }                                      // x, y, alpha * (2 * y)
+            { Fq::copy(2) }                                         // x, y, alpha * (2 * y), x
+            { hinted_script2 }                                      // x, y, alpha * (2 * y), x^2
+            { Fq::copy(0) }                                         // x, y, alpha * (2 * y), x^2, x^2
+            { Fq::double(0) }                                       // x, y, alpha * (2 * y), x^2, 2x^2
+            { Fq::add(1, 0) }                                       // x, y, alpha * (2 * y), 3 * x^2
+            { Fq::neg(0) }                                          // x, y, alpha * (2 * y), -3 * x^2
+            { Fq::add(1, 0) }                                       // x, y, alpha * (2 * y) - 3 * x^2
+            { Fq::is_zero(0) } OP_VERIFY                            // x, y
+            { hinted_script3 }
+        };
+
+        hints.extend(hint1);
+        hints.extend(hint2);
+        hints.extend(hint3);
+
+        (script, hints)
+    }
+
     pub fn push_zero() -> Script {
         script! {
             { Fq::push_zero() }
@@ -1609,23 +1638,17 @@ impl G1Affine {
             let depth = min(Fr::N_BITS - i, i_step);
             // double(step-size) point
             if i > 0 {
-                let double_coeff = coeff_iter.next().unwrap();
-                let step = step_p_iter.next().unwrap();
-                let point_after_double = trace_iter.next().unwrap();
+                for _ in 0..depth {
+                    let double_coeff = coeff_iter.next().unwrap();
+                    let step = step_p_iter.next().unwrap();
+                    let point_after_double = trace_iter.next().unwrap();
 
-                let (double_loop_script, doulbe_hints) =
-                    G1Affine::hinted_check_add(c, *step, double_coeff.0, double_coeff.1);
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
 
-                let double_loop = script! {
-                    // query bucket point through lookup table
-                    { G1Affine::push_not_montgomery(*step) }
-                    // check before usage
-                    { double_loop_script }
-                };
-                loop_scripts.push(double_loop.clone());
-                hints.extend(doulbe_hints);
-
-                c = (c + *step).into_affine();
+                    loop_scripts.push(double_loop_script);
+                    hints.extend(double_hints);
+                    c = (c + c).into_affine();
+                }
             }
             // if i == i_step * 2 {
             //     break;
@@ -1646,32 +1669,26 @@ impl G1Affine {
             }
 
             // add point
-            let add_coeff = if i > 0 {
-                *coeff_iter.next().unwrap()
-            } else {
-                (ark_bn254::Fq::ZERO, ark_bn254::Fq::ZERO)
-            };
-            let point_after_add = trace_iter.next().unwrap();
-            let (add_script, add_hints) =
-                G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
-            let add_loop = script! {
-                // query bucket point through lookup table
-                { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }
-                // check before usage
-                if i > 0 {
-                    { add_script }
-                }
-            };
-            loop_scripts.push(add_loop.clone());
-            if mask != 0 {
-                if i > 0 {
-                    hints.extend(add_hints);
-                }
-                c = (c + p_mul[mask as usize]).into_affine();
+            if i == 0 {
+                loop_scripts.push(G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul));
+                let point_after_add = trace_iter.next().unwrap();
             }
-            // if i == i_step * 21 {
-            //     break;
-            // }
+            else {
+                let add_coeff = *coeff_iter.next().unwrap();
+                let point_after_add = trace_iter.next().unwrap();
+                let (add_script, add_hints) =
+                G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
+                let add_loop = script! {
+                    // query bucket point through lookup table
+                    { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }
+                    // check before usage
+                    { add_script }
+                };
+                loop_scripts.push(add_loop.clone());
+                hints.extend(add_hints);
+            }
+            c = (c + p_mul[mask as usize]).into_affine();
+
             i += i_step;
         }
         assert!(coeff_iter.next() == None);
@@ -1715,22 +1732,31 @@ impl G1Affine {
         let (hinted_script1, hint1) = Self::hinted_check_chord_line(t, q, c3, c4);
         let (hinted_script2, hint2) = Self::hinted_add(t, q, c3, c4);
 
-        let script_lines = vec![
-            Fq::copy(3),
-            Fq::roll(3),
-            Fq::copy(3),
-            Fq::roll(3),
-            hinted_script1,
-            hinted_script2,
-        ];
+        let script = script! {
+            { G1Affine::is_zero_keep_element() }
+            OP_IF
+                { G1Affine::drop() }
+            OP_ELSE
+                { G1Affine::roll(1) }
+                { G1Affine::is_zero_keep_element() }
+                OP_IF
+                    { G1Affine::drop() }
+                OP_ELSE
+                    { G1Affine::roll(1) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { Fq::copy(3) }
+                    { Fq::roll(3) }
+                    { hinted_script1 }
+                    { hinted_script2 }
+                OP_ENDIF
+            OP_ENDIF
+        };
 
-        let mut script = script! {};
-
-        for script_line in script_lines {
-            script = script.push_script(script_line.compile());
+        if !t.is_zero() && !q.is_zero() {
+            hints.extend(hint1);
+            hints.extend(hint2);
         }
-        hints.extend(hint1);
-        hints.extend(hint2);
 
         (script, hints)
     }
@@ -1869,6 +1895,40 @@ impl G1Affine {
         }
     }
 
+    pub fn hinted_double(t: ark_bn254::G1Affine, c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+        let mut hints = Vec::new();
+
+        let var1 = c3.square(); //alpha^2
+        let var2 = var1 - t.x - t.x; // calculate x' = alpha^2 - 2 * T.x
+
+        let (hinted_script1, hint1) = Fq::hinted_square(c3);
+        let (hinted_script2, hint2) = Fq::hinted_mul(2, c3, 0, var2);
+        hints.push(Hint::Fq(c3));
+        hints.extend(hint1);
+        hints.extend(hint2);
+        hints.push(Hint::Fq(c4));
+        
+        let script = script! {  // x
+            { Fq::double(0) }                     // 2x
+            { Fq::neg(0) }                        // -2x
+            for _ in 0..Fq::N_LIMBS {
+                OP_DEPTH OP_1SUB OP_ROLL // hints for c3
+            }                                     // -2x, alpha
+            { Fq::copy(0) }                       // -2x, alpha, alpha
+            { hinted_script1 }                    // -2x, alpha, alpha^2
+            { Fq::add(2, 0) }                     // alpha, alpha^2-2x
+            { Fq::copy(0) }                       // alpha, x', x'
+            { hinted_script2 }                    // x', alpha * x'
+            { Fq::neg(0) }                        // x', -alpha * x'
+            for _ in 0..Fq::N_LIMBS {
+                OP_DEPTH OP_1SUB OP_ROLL // hints for c4
+            }                                     // x', -alpha * x', -bias
+            { Fq::add(1, 0) }                     // x', y'
+        };
+
+        (script, hints)
+    }
+
     pub fn check_double(c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> Script {
         script! {
             { Fq::copy(1) }
@@ -1876,6 +1936,30 @@ impl G1Affine {
             { G1Affine::check_tangent_line(c3, c4) }
             { G1Affine::double(c3, c4) }
         }
+    }
+
+    pub fn hinted_check_double(t: ark_bn254::G1Affine, c3: ark_bn254::Fq, c4: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+        let mut hints = vec![];
+
+        let (hinted_script1, hint1) = Self::hinted_check_tangent_line(t, c3, c4);
+        let (hinted_script2, hint2) = Self::hinted_double(t, c3, c4);
+
+        let script = script! {         // x, y
+            { G1Affine::is_zero_keep_element() }         // x, y, 0/1
+            OP_NOTIF
+                { Fq::copy(1) }                          // x, y, x
+                { Fq::roll(1) }                          // x, x, y
+                { hinted_script1 }                       // x
+                { hinted_script2 }                       // x', y'
+            OP_ENDIF
+        };
+
+        if !t.is_zero() {
+            hints.extend(hint1);
+            hints.extend(hint2);
+        }
+        
+        (script, hints)
     }
 
     pub fn identity() -> Script {
@@ -2402,6 +2486,42 @@ mod test {
         println!(
             "hinted_add_line: {} @ {} stack",
             hinted_check_add.len(),
+            exec_result.stats.max_nb_stack_items
+        );
+    }
+
+    #[test]
+    fn test_g1_affine_hinted_check_double() {
+        //println!("G1.hinted_add: {} bytes", G1Affine::check_add().len());
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        let t = ark_bn254::G1Affine::rand(&mut prng);
+        let alpha = (t.x.square() + t.x.square() + t.x.square()) / (t.y + t.y);
+        // -bias
+        let bias_minus = alpha * t.x - t.y;
+
+        let x = alpha.square() - t.x - t.x;
+        let y = bias_minus - alpha * x;
+
+        let (hinted_check_double, hints) = G1Affine::hinted_check_double(t, alpha, bias_minus);
+
+        let script = script! {
+            for hint in hints {
+                { hint.push() }
+            }
+            { fq_push_not_montgomery(t.x) }
+            { fq_push_not_montgomery(t.y) }
+            { hinted_check_double.clone() }
+            { fq_push_not_montgomery(y) }
+            { Fq::equalverify(1,0) }
+            { fq_push_not_montgomery(x) }
+            { Fq::equalverify(1,0) }
+            OP_TRUE
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+        println!(
+            "hinted_check_double: {} @ {} stack",
+            hinted_check_double.len(),
             exec_result.stats.max_nb_stack_items
         );
     }

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -49,31 +49,129 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
         let depth = min(Fr::N_BITS - i, i_step);
         // double(step-size) point
         if i > 0 {
-            let double_coeff = coeff_iter.next().unwrap();
-            let step = step_p_iter.next().unwrap();
-            let point_after_double = trace_iter.next().unwrap();
-
-            let (double_loop_script, doulbe_hints) =
-                G1Affine::hinted_check_add(c, *step, double_coeff.0, double_coeff.1);
-
-            let double_loop = script! {
-                // query bucket point through lookup table
-                // { G1Affine::push_not_montgomery(*step) }
-                for _ in 0..Fq::N_LIMBS {
-                    OP_DEPTH OP_1SUB OP_ROLL // hints step.x
+            // divide this part into three to fit into 4mb chunk and 1000 stack limit
+            if depth > i_step / 3 {
+                for _ in 0..(i_step / 3) {
+                    let double_coeff = coeff_iter.next().unwrap();
+                    let step = step_p_iter.next().unwrap();
+                    let point_after_double = trace_iter.next().unwrap();
+    
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+    
+                    loop_scripts.push(double_loop_script);
+                    hints.extend(double_hints);
+    
+                    c = (c + c).into_affine();
                 }
-                for _ in 0..Fq::N_LIMBS {
-                    OP_DEPTH OP_1SUB OP_ROLL // hints step.y
-                }
-                // check before usage
-                { double_loop_script }
-            };
-            loop_scripts.push(double_loop.clone());
-            hints.push(Hint::Fq(step.x));
-            hints.push(Hint::Fq(step.y));
-            hints.extend(doulbe_hints);
 
-            c = (c + *step).into_affine();
+                let mut segment_script = script! {};
+                for script in loop_scripts.clone() {
+                    segment_script = segment_script.push_script(script.compile());
+                }
+                loop_scripts.clear();
+
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_1", prefix, i));
+                update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
+                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_1", prefix, i), segment_script)
+                    .add_parameter(&type_acc)
+                    .add_result(&update)
+                    .add_hint(hints.clone());
+                hints.clear();
+                segments.push(segment);
+
+                type_acc = update;
+
+                for _ in (i_step / 3)..(2 * i_step / 3) {
+                    let double_coeff = coeff_iter.next().unwrap();
+                    let step = step_p_iter.next().unwrap();
+                    let point_after_double = trace_iter.next().unwrap();
+    
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+    
+                    loop_scripts.push(double_loop_script);
+                    hints.extend(double_hints);
+    
+                    c = (c + c).into_affine();
+                }
+
+                let mut segment_script = script! {};
+                for script in loop_scripts.clone() {
+                    segment_script = segment_script.push_script(script.compile());
+                }
+                loop_scripts.clear();
+
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_1", prefix, i));
+                update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
+                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_1", prefix, i), segment_script)
+                    .add_parameter(&type_acc)
+                    .add_result(&update)
+                    .add_hint(hints.clone());
+                hints.clear();
+                segments.push(segment);
+
+                type_acc = update;
+
+                for _ in (2 * i_step / 3)..depth {
+                    let double_coeff = coeff_iter.next().unwrap();
+                    let step = step_p_iter.next().unwrap();
+                    let point_after_double = trace_iter.next().unwrap();
+    
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+    
+                    loop_scripts.push(double_loop_script);
+                    hints.extend(double_hints);
+    
+                    c = (c + c).into_affine();
+                }
+
+                let mut segment_script = script! {};
+                for script in loop_scripts.clone() {
+                    segment_script = segment_script.push_script(script.compile());
+                }
+                loop_scripts.clear();
+
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_2", prefix, i));
+                update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
+                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_2", prefix, i), segment_script)
+                    .add_parameter(&type_acc)
+                    .add_result(&update)
+                    .add_hint(hints.clone());
+                hints.clear();
+                segments.push(segment);
+
+                type_acc = update;
+            }
+            else {
+                for _ in 0..depth {
+                    let double_coeff = coeff_iter.next().unwrap();
+                    let step = step_p_iter.next().unwrap();
+                    let point_after_double = trace_iter.next().unwrap();
+    
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+    
+                    loop_scripts.push(double_loop_script);
+                    hints.extend(double_hints);
+    
+                    c = (c + c).into_affine();
+                }
+
+                let mut segment_script = script! {};
+                for script in loop_scripts.clone() {
+                    segment_script = segment_script.push_script(script.compile());
+                }
+                loop_scripts.clear();
+
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece", prefix, i));
+                update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
+                let segment = Segment::new_with_name(format!("{}_loop_{}_piece", prefix, i), segment_script)
+                    .add_parameter(&type_acc)
+                    .add_result(&update)
+                    .add_hint(hints.clone());
+                hints.clear();
+                segments.push(segment);
+
+                type_acc = update;
+            }
         }
 
         // squeeze a bucket scalar
@@ -98,29 +196,25 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
         }
 
         // add point
-        let add_coeff = if i > 0 {
-            *coeff_iter.next().unwrap()
-        } else {
-            (ark_bn254::Fq::ZERO, ark_bn254::Fq::ZERO)
-        };
-        let point_after_add = trace_iter.next().unwrap();
-        let (add_script, add_hints) =
-            G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
-        let add_loop = script! {
-            // query bucket point through lookup table
-            { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }
-            // check before usage
-            if i > 0 {
-                { add_script }
-            }
-        };
-        loop_scripts.push(add_loop.clone());
-        if mask != 0 {
-            if i > 0 {
-                hints.extend(add_hints);
-            }
-            c = (c + p_mul[mask as usize]).into_affine();
+        if i == 0 {
+            loop_scripts.push(G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul));
+            let point_after_add = trace_iter.next().unwrap();
         }
+        else {
+            let add_coeff = *coeff_iter.next().unwrap();
+            let point_after_add = trace_iter.next().unwrap();
+            let (add_script, add_hints) =
+            G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
+            let add_loop = script! {
+                // query bucket point through lookup table
+                { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }
+                // check before usage
+                { add_script }
+            };
+            loop_scripts.push(add_loop.clone());
+            hints.extend(add_hints);
+        }
+        c = (c + p_mul[mask as usize]).into_affine();
 
         let mut segment_script = script! {
             { Fr::convert_to_le_bits_toaltstack() }
@@ -316,7 +410,8 @@ mod tests {
             }
             assert!(
                 script.len() + lenw < 4000000,
-                "script and witness len is over 4M {}",
+                "script and witness len is over 4M {} in {}",
+                script.len() + lenw,
                 segment.name
             );
 
@@ -326,8 +421,9 @@ mod tests {
             assert_eq!(res.final_stack.get(0), zero, "{}", segment.name);
             assert!(
                 res.stats.max_nb_stack_items < 1000,
-                "{}",
-                res.stats.max_nb_stack_items
+                "stack limit exceeded {} in {}",
+                res.stats.max_nb_stack_items,
+                segment.name
             );
         }
     }

--- a/src/groth16/test.rs
+++ b/src/groth16/test.rs
@@ -3,7 +3,7 @@ use crate::{execute_script, execute_script_without_stack_limit};
 use ark_bn254::Bn254;
 use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_ec::pairing::Pairing;
-use ark_ff::PrimeField;
+use ark_ff::{BigInt, PrimeField};
 use ark_groth16::Groth16;
 use ark_relations::lc;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
@@ -86,6 +86,36 @@ fn test_groth16_verifier_native() {
 }
 
 #[test]
+fn test_groth16_verifier_native_small_public() {
+    type E = Bn254;
+    let k = 6;
+    let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+    let circuit = DummyCircuit::<<E as Pairing>::ScalarField> {
+        a: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
+        b: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
+        num_variables: 10,
+        num_constraints: 1 << k,
+    };
+    let (pk, vk) = Groth16::<E>::setup(circuit, &mut rng).unwrap();
+
+    let c = circuit.a.unwrap() * circuit.b.unwrap();
+
+    let proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
+
+    let start = start_timer!(|| "collect_script");
+    let script = Verifier::verify_proof(&vec![c], &proof, &vk);
+    end_timer!(start);
+
+    println!("groth16::test_verify_proof = {} bytes", script.len());
+
+    let start = start_timer!(|| "execute_script");
+    let exec_result = execute_script_without_stack_limit(script);
+    end_timer!(start);
+
+    assert!(exec_result.success);
+}
+
+#[test]
 fn test_hinted_groth16_verifier() {
     type E = Bn254;
     let k = 6;
@@ -93,6 +123,48 @@ fn test_hinted_groth16_verifier() {
     let circuit = DummyCircuit::<<E as Pairing>::ScalarField> {
         a: Some(<E as Pairing>::ScalarField::rand(&mut rng)),
         b: Some(<E as Pairing>::ScalarField::rand(&mut rng)),
+        num_variables: 10,
+        num_constraints: 1 << k,
+    };
+    let (pk, vk) = Groth16::<E>::setup(circuit, &mut rng).unwrap();
+
+    let c = circuit.a.unwrap() * circuit.b.unwrap();
+
+    let proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
+
+    let (hinted_groth16_verifier, hints) = Verifier::hinted_verify(&vec![c], &proof, &vk);
+
+    println!(
+        "hinted_groth16_verifier: {:?} bytes",
+        hinted_groth16_verifier.len()
+    );
+
+    let start = start_timer!(|| "collect_script");
+    let script = script! {
+        for hint in hints {
+            { hint.push() }
+        }
+        { hinted_groth16_verifier }
+    };
+    end_timer!(start);
+
+    println!("groth16::test_hinted_verify_proof = {} bytes", script.len());
+
+    let start = start_timer!(|| "execute_script");
+    let exec_result = execute_script_without_stack_limit(script);
+    end_timer!(start);
+
+    assert!(exec_result.success);
+}
+
+#[test]
+fn test_hinted_groth16_verifier_small_public() {
+    type E = Bn254;
+    let k = 6;
+    let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+    let circuit = DummyCircuit::<<E as Pairing>::ScalarField> {
+        a: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
+        b: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
         num_variables: 10,
         num_constraints: 1 << k,
     };


### PR DESCRIPTION
This PR fixes the issue with affine infinity as the inputs of affine_add and affine_double functions. Also, T+(2^w-1)T logic is changed to w times doubling in G1 scalar multiplication. Slightly (around %6) increases the script size. This error occurs mainly for small public inputs so some tests covering this are added. Closes #137 