### PR TITLE
Disprove execution

### DIFF
--- a/src/bn254/pairing.rs
+++ b/src/bn254/pairing.rs
@@ -931,7 +931,7 @@ impl Pairing {
                                                          // [beta_12(2), beta_13(2), beta_22(2), P1(2), P2(2), P3(2), P4(2), Q4(4), wi(12), T4(4), f(12), c_inv^{p^3}(12)]
         script_lines.push(scripts_iter.next().unwrap()); // Fq12::mul(12, 0)
                                                          // [beta_12(2), beta_13(2), beta_22(2), P1(2), P2(2), P3(2), P4(2), Q4(4), wi(12), T4(4), f(12)]
-        // update f with scalar wi, say f = f * wi
+                                                         // update f with scalar wi, say f = f * wi
         script_lines.push(Fq12::roll(16));
         // [beta_12(2), beta_13(2), beta_22(2), P1(2), P2(2), P3(2), P4(2), Q4(4), T4(4), f(12), wi(12)]
         script_lines.push(scripts_iter.next().unwrap()); // Fq12::mul(12, 0)

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -64,6 +64,11 @@ impl BCAssigner for DummyAssinger {
         &self,
         elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
     ) -> Vec<Vec<RawWitness>> {
+        for (key, _) in self.bc_map.iter() {
+            if !elements.contains_key(key) {
+                println!("unconsistent key: {}", key)
+            }
+        }
         assert_eq!(elements.len(), self.bc_map.len());
         vec![elements
             .iter()

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -17,8 +17,10 @@ pub trait BCAssigner: Default {
         elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
     ) -> Vec<Vec<RawWitness>>;
     /// recover hashes from witnesses
-    fn recover_from_witness(&self, witnesses: Vec<Vec<RawWitness>>)
-        -> BTreeMap<String, BLAKE3HASH>;
+    fn recover_from_witness(
+        &mut self,
+        witnesses: Vec<Vec<RawWitness>>,
+    ) -> BTreeMap<String, BLAKE3HASH>;
 }
 
 #[derive(Default)]
@@ -28,6 +30,9 @@ pub struct DummyAssinger {
 
 impl BCAssigner for DummyAssinger {
     fn create_hash(&mut self, id: &str) {
+        if self.bc_map.contains_key(id) {
+            panic!("varible name is repeated, check {}", id);
+        }
         self.bc_map.insert(id.to_string(), id.to_string());
     }
 
@@ -40,7 +45,7 @@ impl BCAssigner for DummyAssinger {
     }
 
     fn recover_from_witness(
-        &self,
+        &mut self,
         witnesses: Vec<Vec<RawWitness>>,
     ) -> BTreeMap<String, BLAKE3HASH> {
         let mut btree_map: BTreeMap<String, BLAKE3HASH> = Default::default();

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -1,18 +1,35 @@
 use super::{common::*, elements::ElementTrait};
 use crate::treepp::*;
+use std::{collections::BTreeMap, rc::Rc};
 
 /// Implement `BCAssinger` to adapt with bridge.
-pub trait BCAssigner {
+pub trait BCAssigner: Default {
     /// check hash
     fn create_hash(&mut self, id: &str);
+    /// return a element of
     fn locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script;
     fn get_witness<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> RawWitness;
+    /// output sciprt for all elements, used by assert transaction
+    fn all_intermediate_scripts(&self) -> Vec<Vec<Script>>;
+    /// output witness for all elements, used by assert transaction
+    fn all_intermeidate_witnesses(
+        &self,
+        elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
+    ) -> Vec<Vec<RawWitness>>;
+    /// recover hashes from witnesses
+    fn recover_from_witness(&self, witnesses: Vec<Vec<RawWitness>>)
+        -> BTreeMap<String, BLAKE3HASH>;
 }
 
-pub struct DummyAssinger {}
+#[derive(Default)]
+pub struct DummyAssinger {
+    bc_map: BTreeMap<String, String>,
+}
 
 impl BCAssigner for DummyAssinger {
-    fn create_hash(&mut self, _: &str) {}
+    fn create_hash(&mut self, id: &str) {
+        self.bc_map.insert(id.to_string(), id.to_string());
+    }
 
     fn locking_script<T: ElementTrait + ?Sized>(&self, _: &Box<T>) -> Script {
         script! {}
@@ -20,5 +37,37 @@ impl BCAssigner for DummyAssinger {
 
     fn get_witness<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> RawWitness {
         element.to_hash_witness().unwrap()
+    }
+
+    fn recover_from_witness(
+        &self,
+        witnesses: Vec<Vec<RawWitness>>,
+    ) -> BTreeMap<String, BLAKE3HASH> {
+        let mut btree_map: BTreeMap<String, BLAKE3HASH> = Default::default();
+        // flat the witnesses and recover to btreemap
+        let flat_witnesses: Vec<RawWitness> = witnesses.into_iter().fold(vec![], |mut w, x| {
+            w.extend(x);
+            w
+        });
+        assert_eq!(flat_witnesses.len(), self.bc_map.len());
+        for ((id, _), idx) in self.bc_map.iter().zip(0..flat_witnesses.len()) {
+            btree_map.insert(id.to_owned(), witness_to_array(flat_witnesses[idx].clone()));
+        }
+        btree_map
+    }
+
+    fn all_intermediate_scripts(&self) -> Vec<Vec<Script>> {
+        vec![self.bc_map.iter().map(|(_, _)| script! {}).collect()]
+    }
+
+    fn all_intermeidate_witnesses(
+        &self,
+        elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
+    ) -> Vec<Vec<RawWitness>> {
+        assert_eq!(elements.len(), self.bc_map.len());
+        vec![elements
+            .iter()
+            .map(|(_, element)| self.get_witness(element))
+            .collect()]
     }
 }

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -12,7 +12,7 @@ pub trait BCAssigner: Default {
     /// output sciprt for all elements, used by assert transaction
     fn all_intermediate_scripts(&self) -> Vec<Vec<Script>>;
     /// output witness for all elements, used by assert transaction
-    fn all_intermeidate_witnesses(
+    fn all_intermediate_witnesses(
         &self,
         elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
     ) -> Vec<Vec<RawWitness>>;
@@ -60,7 +60,7 @@ impl BCAssigner for DummyAssinger {
         vec![self.bc_map.iter().map(|(_, _)| script! {}).collect()]
     }
 
-    fn all_intermeidate_witnesses(
+    fn all_intermediate_witnesses(
         &self,
         elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
     ) -> Vec<Vec<RawWitness>> {

--- a/src/chunker/chunk_accumulator.rs
+++ b/src/chunker/chunk_accumulator.rs
@@ -201,7 +201,6 @@ pub fn chunk_accumulator<T: BCAssigner>(
     param_f = r;
     f = fx;
 
-
     let c_inv_p3 = c_inv.frobenius_map(3);
     let (hinted_script, hint) = Fq12::hinted_frobenius_map(3, c_inv);
     let (s, r) = make_chunk_frobenius_map(
@@ -297,6 +296,8 @@ pub fn chunk_accumulator<T: BCAssigner>(
         param_f = r;
         f = fx;
     }
+
+    // evaluate L3
     (segments, param_f, f)
 }
 
@@ -422,7 +423,7 @@ mod test {
         );
 
         println!("chunk:");
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
         let mut pa = Fq12Type::new(&mut assigner, &format!("i_a"));
         pa.fill_with_data(Fq12Data(b));
         let (segments, r) = make_chunk_square(

--- a/src/chunker/chunk_evaluate_line.rs
+++ b/src/chunker/chunk_evaluate_line.rs
@@ -1,10 +1,10 @@
 use super::elements::{
-    DataType::Fq12Data, DataType::Fq2Data, DataType::FqData,DataType::Fq6Data, ElementTrait, Fq12Type, Fq2Type,
-    FqType,Fq6Type
+    DataType::Fq12Data, DataType::Fq2Data, DataType::Fq6Data, DataType::FqData, ElementTrait,
+    Fq12Type, Fq2Type, Fq6Type, FqType,
 };
 use super::{assigner::BCAssigner, segment::Segment};
-use crate::bn254::{ell_coeffs::EllCoeff, fp254impl::Fp254Impl, fq::Fq, fq2::Fq2,fq12::Fq12};
 use crate::bn254::curves::{G1Affine, G2Affine};
+use crate::bn254::{ell_coeffs::EllCoeff, fp254impl::Fp254Impl, fq::Fq, fq12::Fq12, fq2::Fq2};
 use crate::treepp::*;
 use ark_ff::{AdditiveGroup, Field};
 
@@ -19,7 +19,7 @@ pub fn chunk_evaluate_line_wrapper<T: BCAssigner>(
     let mut pf = Fq12Type::new(assigner, &format!("{}{}", prefix, "f"));
     pf.fill_with_data(Fq12Data(f));
     let mut pxy = Fq2Type::new(assigner, &format!("{}{}", prefix, "xy"));
-    pxy.fill_with_data(Fq2Data(ark_bn254::Fq2::new(x,y)));
+    pxy.fill_with_data(Fq2Data(ark_bn254::Fq2::new(x, y)));
 
     chunk_evaluate_line(assigner, prefix, pf, pxy, f, x, y, constant)
 }
@@ -80,15 +80,16 @@ pub fn chunk_evaluate_line<T: BCAssigner>(
     let mut tr0 = Fq6Type::new(assigner, &format!("{}{}", prefix, "c0"));
     tr0.fill_with_data(Fq6Data(ark_bn254::Fq6::new(c1, c2, ark_bn254::Fq2::ZERO)));
 
-    let segment0 = Segment::new_with_name(format!("{}seg1", prefix), 
+    let segment0 = Segment::new_with_name(
+        format!("{}seg1", prefix),
         script! {
             {script_0}
             {Fq2::push_zero()}
-        }
-        )
-        .add_parameter(&pxy)
-        .add_result(&tr0)
-        .add_hint(hints_0);
+        },
+    )
+    .add_parameter(&pxy)
+    .add_result(&tr0)
+    .add_hint(hints_0);
 
     let mut f1 = f;
     f1.mul_by_034(&constant.0, &c1, &c2);
@@ -101,16 +102,17 @@ pub fn chunk_evaluate_line<T: BCAssigner>(
     //  script_1,
     // // [f, c1', c2']
     //  // [f]
-    let segment1 = Segment::new_with_name(format!("{}seg2", prefix), 
+    let segment1 = Segment::new_with_name(
+        format!("{}seg2", prefix),
         script! {
             {Fq2::drop()}
             {script_1}
-        }
-        )
-        .add_parameter(&pf)
-        .add_parameter(&tr0)
-        .add_result(&tc)
-        .add_hint(hint_1);
+        },
+    )
+    .add_parameter(&pf)
+    .add_parameter(&tr0)
+    .add_result(&tc)
+    .add_hint(hint_1);
 
     (vec![segment0, segment1], tc)
 }
@@ -129,7 +131,7 @@ mod test {
 
     use ark_ff::Field;
     use ark_std::UniformRand;
-    use bitcoin::{hashes::{sha256::Hash as Sha256, Hash},};    
+    use bitcoin::hashes::{sha256::Hash as Sha256, Hash};
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
 
@@ -189,17 +191,18 @@ mod test {
         assert!(exec_result.success);
 
         //
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
         let mut segments = Vec::new();
         let fn_name = format!("F_{}_mul_c_1p{}", 0, 0);
-        let (segments_mul, mul): (Vec<segment::Segment>, elements::Fq12Type) = chunk_evaluate_line_wrapper(
-            &mut assigner,
-            &fn_name,
-            f,
-            -p.x / p.y,
-            p.y.inverse().unwrap(),
-            &coeffs.ell_coeffs[0],
-        );
+        let (segments_mul, mul): (Vec<segment::Segment>, elements::Fq12Type) =
+            chunk_evaluate_line_wrapper(
+                &mut assigner,
+                &fn_name,
+                f,
+                -p.x / p.y,
+                p.y.inverse().unwrap(),
+                &coeffs.ell_coeffs[0],
+            );
         segments.extend(segments_mul);
 
         for segment in segments {
@@ -210,7 +213,12 @@ mod test {
             for w in witness.iter() {
                 lenw += w.len();
             }
-            println!("segment script size {} witness size {} total {}", script.len(), lenw, script.len() + lenw);
+            println!(
+                "segment script size {} witness size {} total {}",
+                script.len(),
+                lenw,
+                script.len() + lenw
+            );
             assert!(
                 script.len() + lenw < 4000000,
                 "script and witness len is over 4M {}",
@@ -219,7 +227,12 @@ mod test {
 
             let hash1 = Sha256::hash(segment.script.clone().compile().as_bytes());
             let hash2 = Sha256::hash(script.clone().compile().as_bytes());
-            println!("segment {} hash {} {} ", segment.name, hash1.clone(), hash2.clone());
+            println!(
+                "segment {} hash {} {} ",
+                segment.name,
+                hash1.clone(),
+                hash2.clone()
+            );
 
             let res = execute_script_with_inputs(script.clone(), witness.clone());
             println!("segment exec_result: {}", res);

--- a/src/chunker/chunk_fq12_multiplication.rs
+++ b/src/chunker/chunk_fq12_multiplication.rs
@@ -157,7 +157,7 @@ mod test {
 
     #[test]
     fn test_fq12_wrapper() {
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         let mut a_type = Fq12Type::new(&mut assigner, "a");
         let mut b_type = Fq12Type::new(&mut assigner, "b");

--- a/src/chunker/chunk_fq12_multiplication.rs
+++ b/src/chunker/chunk_fq12_multiplication.rs
@@ -14,7 +14,7 @@ pub fn fq12_mul_wrapper<T: BCAssigner>(
     a: ark_bn254::Fq12,
     b: ark_bn254::Fq12,
 ) -> (Vec<Segment>, Fq12Type) {
-    chunk_fq12_multiplication(assigner, prefix, pa,pb, a,b)
+    chunk_fq12_multiplication(assigner, prefix, pa, pb, a, b)
 }
 
 /// a * b -> c
@@ -34,25 +34,25 @@ pub fn chunk_fq12_multiplication<T: BCAssigner>(
     // intermediate states
     let mut a0b0 = Fq6Type::new(assigner, &format!("{}{}", prefix, "a0b0"));
     let mut a1b1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "a1b1"));
-    let mut a0_a1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "a0_a1")); // means a0+a1
-    let mut b0_b1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "b0_b1")); // means b0+b1
+    // let mut a0_a1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "a0_a1")); // means a0+a1
+    // let mut b0_b1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "b0_b1")); // means b0+b1
     let mut ab = Fq6Type::new(assigner, &format!("{}{}", prefix, "a0_a1 * b0_b1"));
 
     a0b0.fill_with_data(Fq6Data(a.c0.mul(b.c0)));
     a1b1.fill_with_data(Fq6Data(a.c1.mul(b.c1)));
-    a0_a1.fill_with_data(Fq6Data(a.c0.add(a.c1)));
-    b0_b1.fill_with_data(Fq6Data(b.c0.add(b.c1)));
+    // a0_a1.fill_with_data(Fq6Data(a.c0.add(a.c1)));
+    // b0_b1.fill_with_data(Fq6Data(b.c0.add(b.c1)));
     ab.fill_with_data(Fq6Data(a.c0.add(a.c1).mul(b.c0.add(b.c1))));
 
     // final states
-    let mut c0 = Fq6Type::new(assigner, &format!("{}{}", prefix, "c0"));
-    let mut c1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "c1"));
+    // let mut c0 = Fq6Type::new(assigner, &format!("{}{}", prefix, "c0"));
+    // let mut c1 = Fq6Type::new(assigner, &format!("{}{}", prefix, "c1"));
 
-    c0.fill_with_data(Fq6Data(c.c0));
-    c1.fill_with_data(Fq6Data(c.c1));
+    // c0.fill_with_data(Fq6Data(c.c0));
+    // c1.fill_with_data(Fq6Data(c.c1));
 
     let segment1 = Segment::new_with_name(
-        format!("{}{}", prefix, "a0 * b0"), 
+        format!("{}{}", prefix, "a0 * b0"),
         script! {
             //[a0,a1, b0, b1]
             {Fq6::drop()}
@@ -62,14 +62,15 @@ pub fn chunk_fq12_multiplication<T: BCAssigner>(
             {Fq6::drop()}
             // [a0, b0]
             {hinted_script1}
-        }
-        )
-        .add_parameter(&pa)
-        .add_parameter(&pb)
-        .add_result(&a0b0)
-        .add_hint(hint1);
+        },
+    )
+    .add_parameter(&pa)
+    .add_parameter(&pb)
+    .add_result(&a0b0)
+    .add_hint(hint1);
 
-    let segment2 = Segment::new_with_name(format!("{}{}", prefix, "a1 * b1"), 
+    let segment2 = Segment::new_with_name(
+        format!("{}{}", prefix, "a1 * b1"),
         script! {
             //[a0,a1, b0, b1]
             {Fq6::roll(6)}
@@ -81,12 +82,12 @@ pub fn chunk_fq12_multiplication<T: BCAssigner>(
             {Fq6::drop()}
             // [a1, b1]
             {hinted_script2}
-        }
-        )
-        .add_parameter(&pa)
-        .add_parameter(&pb)
-        .add_result(&a1b1)
-        .add_hint(hint2);
+        },
+    )
+    .add_parameter(&pa)
+    .add_parameter(&pb)
+    .add_result(&a1b1)
+    .add_hint(hint2);
 
     let segment4 = Segment::new_with_name(
         format!("{}{}", prefix, "(a0 + a1) * (b0 + b1)"),
@@ -101,7 +102,6 @@ pub fn chunk_fq12_multiplication<T: BCAssigner>(
     .add_parameter(&pb)
     .add_result(&ab)
     .add_hint(hint3);
-
 
     let mut tc = Fq12Type::new(assigner, &format!("{}{}", prefix, "c"));
     tc.fill_with_data(Fq12Data(c));
@@ -134,7 +134,8 @@ pub fn chunk_fq12_multiplication<T: BCAssigner>(
 
     (
         vec![
-            segment1, segment2, /*segment3,*/ segment4, /*segment5,*/ segment6, /*segment7,*/
+            segment1, segment2, /*segment3,*/ segment4,
+            /*segment5,*/ segment6, /*segment7,*/
         ],
         tc,
     )
@@ -147,8 +148,9 @@ mod test {
         chunker::{
             assigner::DummyAssinger,
             elements::{DataType::Fq12Data, DataType::Fq6Data, ElementTrait, Fq12Type, Fq6Type},
-            segment::{Segment},
-        }, execute_script_with_inputs,
+            segment::Segment,
+        },
+        execute_script_with_inputs,
     };
     use ark_ff::UniformRand;
     use rand::SeedableRng;
@@ -184,7 +186,12 @@ mod test {
             for w in witness.clone() {
                 lenw += w.len();
             }
-            println!("segment name {} script size {} witness size {}", segment.name, segment.script.clone().len(),lenw );
+            println!(
+                "segment name {} script size {} witness size {}",
+                segment.name,
+                segment.script.clone().len(),
+                lenw
+            );
 
             let res = execute_script_with_inputs(script, witness);
             let zero: Vec<u8> = vec![];

--- a/src/chunker/chunk_g1_points.rs
+++ b/src/chunker/chunk_g1_points.rs
@@ -130,7 +130,7 @@ mod test {
         // assert!(exec_result.success);
         println!("exec_result {}", exec_result);
 
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
         let g1a = expect;
         let mut g1p = G1PointType::new(&mut assigner, &format!("{}", "test"));
         g1p.fill_with_data(G1PointData(g1a));

--- a/src/chunker/chunk_groth16_verifier.rs
+++ b/src/chunker/chunk_groth16_verifier.rs
@@ -171,7 +171,7 @@ mod tests {
             todo!()
         }
 
-        fn all_intermeidate_witnesses(
+        fn all_intermediate_witnesses(
             &self,
             elements: std::collections::BTreeMap<String, std::rc::Rc<Box<dyn ElementTrait>>>,
         ) -> Vec<Vec<RawWitness>> {
@@ -296,8 +296,14 @@ mod tests {
         let k = 6;
         let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
         let circuit = DummyCircuit::<<E as Pairing>::ScalarField> {
-            a: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
-            b: Some(<E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng))).unwrap()),
+            a: Some(
+                <E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng)))
+                    .unwrap(),
+            ),
+            b: Some(
+                <E as Pairing>::ScalarField::from_bigint(BigInt::from(u32::rand(&mut rng)))
+                    .unwrap(),
+            ),
             num_variables: 10,
             num_constraints: 1 << k,
         };

--- a/src/chunker/chunk_groth16_verifier.rs
+++ b/src/chunker/chunk_groth16_verifier.rs
@@ -72,8 +72,9 @@ pub fn groth16_verify_to_segments<T: BCAssigner>(
 
     let mut segments = vec![];
 
-    let mut scalar_types = vec![];
-    for (idx, scalar) in scalars.iter().enumerate() {
+    // skip the first scalar
+    let mut scalar_types = vec![FrType::new_dummy("scalar_0")];
+    for (idx, scalar) in scalars.iter().enumerate().skip(1) {
         let mut scalar_type = FrType::new(assigner, &format!("scalar_{}", idx));
         scalar_type.fill_with_data(crate::chunker::elements::DataType::FrData(scalar.clone()));
         scalar_types.push(scalar_type);

--- a/src/chunker/chunk_groth16_verifier.rs
+++ b/src/chunker/chunk_groth16_verifier.rs
@@ -156,6 +156,9 @@ mod tests {
 
     impl BCAssigner for StatisticAssinger {
         fn create_hash(&mut self, id: &str) {
+            if self.commitments.contains_key(id) {
+                panic!("varible name is repeated, check {}", id);
+            }
             self.commitments.insert(id.to_owned(), 1);
         }
 
@@ -179,7 +182,7 @@ mod tests {
         }
 
         fn recover_from_witness(
-            &self,
+            &mut self,
             witnesses: Vec<Vec<RawWitness>>,
         ) -> std::collections::BTreeMap<String, BLAKE3HASH> {
             todo!()
@@ -247,7 +250,6 @@ mod tests {
         let c = circuit.a.unwrap() * circuit.b.unwrap();
 
         let mut proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
-        proof.a = G1Affine::rand(&mut rng);
 
         let mut assigner = StatisticAssinger::new();
 

--- a/src/chunker/chunk_hinted_accumulator.rs
+++ b/src/chunker/chunk_hinted_accumulator.rs
@@ -1,17 +1,21 @@
+use super::common::not_equal;
 use super::elements::Fq12Type;
 use super::segment::Segment;
-use crate::bn254::fq12::Fq12;
+use crate::bn254::fp254impl::Fp254Impl;
+use crate::bn254::fq::Fq;
 use crate::bn254::utils::fq12_push_not_montgomery;
 use crate::treepp::*;
 
 pub fn verify_accumulator(pa: Fq12Type) -> Vec<Segment> {
     let script = script! {
         {fq12_push_not_montgomery(<ark_bn254::Fq12 as ark_ff::Field>::ONE)}
-        {Fq12::equalverify()}
+        {not_equal(Fq::N_LIMBS as usize * 12)}
     };
 
     let mut segments = vec![];
-    let segment = Segment::new_with_name(format!("{}", "verify_f"), script).add_parameter(&pa);
+    let segment = Segment::new_with_name(format!("{}", "verify_f"), script)
+        .add_parameter(&pa)
+        .mark_final();
 
     segments.push(segment);
     segments

--- a/src/chunker/chunk_hinted_accumulator.rs
+++ b/src/chunker/chunk_hinted_accumulator.rs
@@ -4,18 +4,14 @@ use crate::bn254::fq12::Fq12;
 use crate::bn254::utils::fq12_push_not_montgomery;
 use crate::treepp::*;
 
-pub fn verify_accumulator(
-    pa: Fq12Type,
-) -> Vec<Segment> {
+pub fn verify_accumulator(pa: Fq12Type) -> Vec<Segment> {
     let script = script! {
         {fq12_push_not_montgomery(<ark_bn254::Fq12 as ark_ff::Field>::ONE)}
         {Fq12::equalverify()}
     };
 
-
     let mut segments = vec![];
-    let segment = Segment::new_with_name(format!("{}", "verify_f"), script)
-    .add_parameter(&pa);
+    let segment = Segment::new_with_name(format!("{}", "verify_f"), script).add_parameter(&pa);
 
     segments.push(segment);
     segments
@@ -26,32 +22,32 @@ mod test {
     use super::*;
     use crate::bn254::ell_coeffs::G2Prepared;
     use crate::bn254::fp254impl::Fp254Impl;
-    
+
     use crate::chunker::assigner::*;
     use crate::chunker::chunk_accumulator::*;
-    use crate::chunker::elements::{DataType::Fq12Data, ElementTrait, G1PointType};
     use crate::chunker::chunk_g1_points::*;
     use crate::chunker::elements::DataType::G1PointData;
+    use crate::chunker::elements::{DataType::Fq12Data, ElementTrait, G1PointType};
     use crate::execute_script_with_inputs;
     use crate::groth16::constants::{LAMBDA, P_POW3};
     use crate::groth16::offchain_checker::compute_c_wi;
-    
-    use ark_bn254::Bn254;    
+
+    use ark_bn254::Bn254;
     use ark_bn254::G1Projective;
     use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
-    use ark_ec::{AffineRepr, CurveGroup,pairing::Pairing, VariableBaseMSM};
     use ark_ec::pairing::Pairing as ark_Pairing;
+    use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup, VariableBaseMSM};
     use ark_ff::{Field, PrimeField};
     use ark_groth16::Groth16;
     use ark_groth16::{Proof, VerifyingKey};
     use ark_relations::lc;
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
-    use ark_std::{test_rng,UniformRand};
-    
+    use ark_std::{test_rng, UniformRand};
+
     use core::ops::Neg;
+    use rand::RngCore;
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
-    use rand::RngCore;
 
     #[derive(Copy)]
     struct DummyCircuit<F: PrimeField> {
@@ -176,7 +172,6 @@ mod test {
         (q_prepared.to_vec(), c, c_inv, wi, p_lst, q4)
     }
 
-        
     pub fn generate_f(
         public_inputs: &Vec<<Bn254 as ark_Pairing>::ScalarField>,
         proof: &Proof<Bn254>,
@@ -187,7 +182,8 @@ mod test {
             public_inputs.clone(),
         ]
         .concat();
-        let msm_g1 = G1Projective::msm(&vk.gamma_abc_g1, &scalars).expect("failed to calculate msm");
+        let msm_g1 =
+            G1Projective::msm(&vk.gamma_abc_g1, &scalars).expect("failed to calculate msm");
         let (exp, sign) = if LAMBDA.gt(&P_POW3) {
             (&*LAMBDA - &*P_POW3, true)
         } else {
@@ -215,7 +211,7 @@ mod test {
     }
 
     fn test_g1_points() {
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         type E = Bn254;
         let k = 6;
@@ -263,7 +259,7 @@ mod test {
 
     #[test]
     fn test_chunk_accumulator() {
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         type E = Bn254;
         let k = 6;
@@ -284,7 +280,7 @@ mod test {
         let rc = ark_bn254::Fq12::rand(&mut prng);
         let mut tc = Fq12Type::new(&mut assigner, &format!("{}{}", "test".to_owned(), "c"));
         tc.fill_with_data(Fq12Data(rc));
-        let  tf = generate_f(&vec![c], &proof, &vk);
+        let tf = generate_f(&vec![c], &proof, &vk);
         let mut tc = Fq12Type::new(&mut assigner, &format!("{}{}", "test".to_owned(), "c1"));
         tc.fill_with_data(Fq12Data(tf));
 
@@ -325,7 +321,7 @@ mod test {
 
     #[test]
     fn test_verify_accumulator() {
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         type E = Bn254;
         let k = 6;
@@ -346,7 +342,7 @@ mod test {
         let rc = ark_bn254::Fq12::rand(&mut prng);
         let mut tc = Fq12Type::new(&mut assigner, &format!("{}{}", "test".to_owned(), "c"));
         tc.fill_with_data(Fq12Data(rc));
-        let  f = generate_f(&vec![c], &proof, &vk);
+        let f = generate_f(&vec![c], &proof, &vk);
         let mut tc1 = Fq12Type::new(&mut assigner, &format!("{}{}", "test".to_owned(), "c1"));
         tc1.fill_with_data(Fq12Data(f));
 

--- a/src/chunker/chunk_msm.rs
+++ b/src/chunker/chunk_msm.rs
@@ -112,7 +112,7 @@ mod tests {
         let k = 2;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         let scalars = (0..n - 1)
             .map(|_| ark_bn254::Fr::rand(rng))

--- a/src/chunker/chunk_non_fixed_point.rs
+++ b/src/chunker/chunk_non_fixed_point.rs
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn test_check_q4() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         // exp = 6x + 2 + p - p^2 = lambda - p^3
         let q1 = ark_bn254::g2::G2Affine::rand(&mut prng);

--- a/src/chunker/chunk_non_fixed_point.rs
+++ b/src/chunker/chunk_non_fixed_point.rs
@@ -8,6 +8,7 @@ use crate::chunker::elements::ElementTrait;
 use crate::treepp::*;
 use ark_ec::bn::BnConfig;
 use ark_ff::{AdditiveGroup, Field};
+use bitcoin::opcodes::OP_FALSE;
 use num_bigint::BigUint;
 use num_traits::One;
 use std::{ops::Neg, str::FromStr};
@@ -340,7 +341,7 @@ mod tests {
     use crate::chunker::elements::{ElementTrait, G2PointType};
     use crate::execute_script_with_inputs;
     use ark_std::UniformRand;
-    use bitcoin::{hashes::{sha256::Hash as Sha256, Hash},};    
+    use bitcoin::hashes::{sha256::Hash as Sha256, Hash};
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
 
@@ -382,7 +383,12 @@ mod tests {
 
             let hash1 = Sha256::hash(segment.script.clone().compile().as_bytes());
             let hash2 = Sha256::hash(script.clone().compile().as_bytes());
-            println!("segment {} hash {} {} ", segment.name, hash1.clone(), hash2.clone());
+            println!(
+                "segment {} hash {} {} ",
+                segment.name,
+                hash1.clone(),
+                hash2.clone()
+            );
 
             let mut lenw = 0;
             for w in witness.iter() {

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -342,7 +342,7 @@ mod tests {
         let k = 0;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         let mut bases = (0..n)
             .map(|_| ark_bn254::G1Projective::rand(rng).into_affine())
@@ -433,7 +433,7 @@ mod tests {
         let k = 0;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         let scalars = (0..n).map(|_| ark_bn254::Fr::rand(rng)).collect::<Vec<_>>();
 

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -55,12 +55,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -72,10 +73,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
 
                 let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_1", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_1", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_1", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
@@ -85,12 +89,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -100,12 +105,15 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                 }
                 loop_scripts.clear();
 
-                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_1", prefix, i));
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_2", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_1", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_2", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
@@ -115,12 +123,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -130,28 +139,31 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                 }
                 loop_scripts.clear();
 
-                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_2", prefix, i));
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_3", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_2", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_3", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
                 type_acc = update;
-            }
-            else if depth > i_step / 3 {
+            } else if depth > i_step / 3 {
                 for _ in 0..(i_step / 3) {
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -163,10 +175,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
 
                 let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_1", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_1", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_1", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
@@ -176,12 +191,13 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -193,26 +209,29 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
 
                 let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_2", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece_2", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_2", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
                 type_acc = update;
-            }
-            else {
+            } else {
                 for _ in 0..depth {
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
-    
+
+                    let (double_loop_script, double_hints) =
+                        G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
-    
+
                     c = (c + c).into_affine();
                 }
 
@@ -222,12 +241,15 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                 }
                 loop_scripts.clear();
 
-                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece", prefix, i));
+                let mut update = G1PointType::new(assigner, &format!("{}_{}_piece_3", prefix, i));
                 update.fill_with_data(crate::chunker::elements::DataType::G1PointData(c));
-                let segment = Segment::new_with_name(format!("{}_loop_{}_piece", prefix, i), segment_script)
-                    .add_parameter(&type_acc)
-                    .add_result(&update)
-                    .add_hint(hints.clone());
+                let segment = Segment::new_with_name(
+                    format!("{}_loop_{}_piece_3", prefix, i),
+                    segment_script,
+                )
+                .add_parameter(&type_acc)
+                .add_result(&update)
+                .add_hint(hints.clone());
                 hints.clear();
                 segments.push(segment);
 
@@ -258,14 +280,18 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
 
         // add point
         if i == 0 {
-            loop_scripts.push(G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul));
+            loop_scripts.push(G1Affine::dfs_with_constant_mul_not_montgomery(
+                0,
+                depth - 1,
+                0,
+                &p_mul,
+            ));
             let point_after_add = trace_iter.next().unwrap();
-        }
-        else {
+        } else {
             let add_coeff = *coeff_iter.next().unwrap();
             let point_after_add = trace_iter.next().unwrap();
             let (add_script, add_hints) =
-            G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
+                G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
             let add_loop = script! {
                 // query bucket point through lookup table
                 { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }

--- a/src/chunker/common.rs
+++ b/src/chunker/common.rs
@@ -1,3 +1,5 @@
+use bitcoin::script::write_scriptint;
+
 use crate::{treepp::*, ExecuteInfo};
 
 /// Define Witness
@@ -54,7 +56,7 @@ pub fn not_equal(n: usize) -> Script {
 }
 
 /// From witness to hash
-pub fn witness_to_array(witness: Vec<Vec<u8>>) -> BLAKE3HASH {
+pub fn witness_to_array(witness: RawWitness) -> BLAKE3HASH {
     assert_eq!(witness.len(), BLAKE3_HASH_LENGTH);
     let mut res: BLAKE3HASH = [0; BLAKE3_HASH_LENGTH];
     for (idx, byte) in witness.iter().enumerate() {
@@ -67,8 +69,19 @@ pub fn witness_to_array(witness: Vec<Vec<u8>>) -> BLAKE3HASH {
     res
 }
 
+/// From hash to witness
+pub fn array_to_witness(hash: BLAKE3HASH) -> RawWitness {
+    let mut witness = vec![];
+    for byte in hash {
+        let mut out: [u8; 8] = [0; 8];
+        let length = write_scriptint(&mut out, byte as i64);
+        witness.push(out[0..length].to_vec());
+    }
+    witness
+}
+
 /// Extract witness from stack.
-pub fn extract_witness_from_stack(res: ExecuteInfo) -> Vec<Vec<u8>> {
+pub fn extract_witness_from_stack(res: ExecuteInfo) -> RawWitness {
     res.final_stack.0.iter_str().fold(vec![], |mut vector, x| {
         vector.push(x);
         vector

--- a/src/chunker/disprove_execution.rs
+++ b/src/chunker/disprove_execution.rs
@@ -201,7 +201,7 @@ mod tests {
         }
 
         // get all witnesses
-        let assert_witnesses = assigner.all_intermeidate_witnesses(elements);
+        let assert_witnesses = assigner.all_intermediate_witnesses(elements);
 
         // must find some avalible chunk
         let (id, witness) = disprove_exec(&assigner, assert_witnesses, wrong_proof).unwrap();
@@ -253,7 +253,7 @@ mod tests {
         elements.insert(modify_id.to_string(), Rc::new(Box::new(new_element)));
 
         // get all witnesses
-        let assert_witnesses = assigner.all_intermeidate_witnesses(elements);
+        let assert_witnesses = assigner.all_intermediate_witnesses(elements);
 
         // must find some avalible chunk
         let (id, witness) = disprove_exec(&assigner, assert_witnesses, wrong_proof).unwrap();

--- a/src/chunker/disprove_execution.rs
+++ b/src/chunker/disprove_execution.rs
@@ -167,41 +167,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_wrong_proof_direct() {
-        let mut right_proof = gen_right_proof();
-
-        // make it wrong
-        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
-        right_proof.proof.a = G1Affine::rand(&mut rng);
-        let wrong_proof = right_proof;
-
-        // assert witness
-        let mut assigner = DummyAssinger::default();
-        let segments = groth16_verify_to_segments(
-            &mut assigner,
-            &wrong_proof.public,
-            &wrong_proof.proof,
-            &wrong_proof.vk,
-        );
-
-        let segment = segments.last().unwrap();
-
-        let witness = segment.witness(&assigner);
-        let script = segment.script(&assigner);
-        let res = execute_script_with_inputs(script, witness);
-
-        let one: Vec<u8> = vec![1];
-        assert_eq!(res.final_stack.len(), 1, "{}", segment.name); // only one element left
-        assert_eq!(res.final_stack.get(0), one, "{}", segment.name);
-        assert!(
-            res.stats.max_nb_stack_items < 1000,
-            "{} in {}",
-            res.stats.max_nb_stack_items,
-            segment.name
-        );
-    }
-
     /// test wrong proof, doesn't modify any intermediate value
     /// diprove exec will return the final chunk
     #[test]

--- a/src/chunker/disprove_execution.rs
+++ b/src/chunker/disprove_execution.rs
@@ -1,0 +1,207 @@
+use std::rc::Rc;
+
+use ark_groth16::{Proof, VerifyingKey};
+
+use super::{
+    assigner::BCAssigner, chunk_groth16_verifier::groth16_verify_to_segments, common::RawWitness,
+    elements::dummy_element,
+};
+
+#[derive(Clone)]
+pub struct RawProof {
+    pub proof: Proof<ark_bn254::Bn254>,
+    pub public: Vec<<ark_bn254::Bn254 as ark_ec::pairing::Pairing>::ScalarField>,
+    pub vk: VerifyingKey<ark_bn254::Bn254>,
+}
+
+pub fn disprove_exec<A: BCAssigner>(
+    assigner: &A,
+    assert_witness: Vec<Vec<RawWitness>>,
+    wrong_proof: RawProof,
+) -> Option<(usize, RawWitness)> {
+    // 0. TODO: if 'wrong_proof' is correct, return none
+
+    // 1. derive assigner from wrong proof
+    let mut wrong_proof_assigner = A::default();
+    let mut segments = groth16_verify_to_segments(
+        &mut wrong_proof_assigner,
+        &wrong_proof.public,
+        &wrong_proof.proof,
+        &wrong_proof.vk,
+    );
+    let segment_length = segments.len();
+
+    // 2. recover assigner from witness
+    let hash_map = assigner.recover_from_witness(assert_witness);
+
+    // 3. find which chunk is unconsistent
+    for (idx, segment) in segments.iter_mut().enumerate() {
+        let mut is_param_equal = true;
+        for param in segment.parameter_list.iter() {
+            if param.to_hash().unwrap() != hash_map.get(param.id()).unwrap().clone() {
+                is_param_equal = false;
+            }
+        }
+        let mut is_result_equal = true;
+        for result in segment.result_list.iter_mut() {
+            if result.to_hash().unwrap() != hash_map.get(result.id()).unwrap().clone() {
+                is_result_equal = false;
+                // replace the result to hash_map
+                *result = Rc::new(Box::new(dummy_element(
+                    &result.id(),
+                    hash_map.get(result.id()).unwrap().clone(),
+                )));
+            }
+        }
+
+        if is_param_equal && !is_result_equal {
+            let disprove_witness = segment.witness(assigner);
+            return Some((idx, disprove_witness));
+        }
+    }
+
+    // if all intermediate values is identical, then ireturn the last chunk
+    let disprove_witness = segments.last().unwrap().witness(assigner);
+    return Some((segment_length - 1, disprove_witness));
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bridge::transactions::disprove;
+    use crate::chunker::assigner::*;
+    use crate::chunker::chunk_groth16_verifier::groth16_verify_to_segments;
+    use crate::chunker::disprove_execution::RawProof;
+    use crate::chunker::{common::*, elements::ElementTrait};
+    use crate::execute_script_with_inputs;
+    use crate::treepp::*;
+
+    use ark_bn254::g1::G1Affine;
+    use ark_bn254::Bn254;
+    use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
+    use ark_ec::pairing::Pairing;
+    use ark_ff::PrimeField;
+    use ark_groth16::Groth16;
+    use ark_groth16::{ProvingKey, VerifyingKey};
+    use ark_relations::lc;
+    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+    use ark_std::{test_rng, UniformRand};
+    use bitcoin::hashes::{sha256::Hash as Sha256, Hash};
+    use rand::{RngCore, SeedableRng};
+    use std::collections::{BTreeMap, HashMap};
+
+    use super::disprove_exec;
+
+    #[derive(Copy)]
+    struct DummyCircuit<F: PrimeField> {
+        pub a: Option<F>,
+        pub b: Option<F>,
+        pub num_variables: usize,
+        pub num_constraints: usize,
+    }
+
+    impl<F: PrimeField> Clone for DummyCircuit<F> {
+        fn clone(&self) -> Self {
+            DummyCircuit {
+                a: self.a,
+                b: self.b,
+                num_variables: self.num_variables,
+                num_constraints: self.num_constraints,
+            }
+        }
+    }
+
+    impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
+        fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+            let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+            let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
+            let c = cs.new_input_variable(|| {
+                let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+                let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+
+                Ok(a * b)
+            })?;
+
+            for _ in 0..(self.num_variables - 3) {
+                let _ =
+                    cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+            }
+
+            for _ in 0..self.num_constraints - 1 {
+                cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+            }
+
+            cs.enforce_constraint(lc!(), lc!(), lc!())?;
+
+            Ok(())
+        }
+    }
+
+    fn gen_right_proof() -> RawProof {
+        type E = Bn254;
+        let k = 6;
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+        let circuit = DummyCircuit::<<E as Pairing>::ScalarField> {
+            a: Some(<E as Pairing>::ScalarField::rand(&mut rng)),
+            b: Some(<E as Pairing>::ScalarField::rand(&mut rng)),
+            num_variables: 10,
+            num_constraints: 1 << k,
+        };
+        let (pk, vk) = Groth16::<E>::setup(circuit, &mut rng).unwrap();
+
+        let c = circuit.a.unwrap() * circuit.b.unwrap();
+
+        let mut proof = Groth16::<E>::prove(&pk, circuit, &mut rng).unwrap();
+
+        RawProof {
+            proof: proof,
+            public: vec![c],
+            vk: vk,
+        }
+    }
+
+    /// test wrong proof, doesn't modify any intermediate value
+    /// diprove exec will return the final chunk
+    #[test]
+    fn test_wrong_proof() {
+        let mut right_proof = gen_right_proof();
+
+        // make it wrong
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+        right_proof.proof.a = G1Affine::rand(&mut rng);
+        let wrong_proof = right_proof;
+
+        // assert witness
+        let mut assigner = DummyAssinger::default();
+        let segments = groth16_verify_to_segments(
+            &mut assigner,
+            &wrong_proof.public,
+            &wrong_proof.proof,
+            &wrong_proof.vk,
+        );
+
+        // get all elements
+        let mut elements: BTreeMap<String, std::rc::Rc<Box<dyn ElementTrait>>> = BTreeMap::new();
+        for segment in segments.iter() {
+            for parameter in segment.parameter_list.iter() {
+                elements.insert(parameter.id().to_owned(), parameter.clone());
+            }
+            for result in segment.result_list.iter() {
+                elements.insert(result.id().to_owned(), result.clone());
+            }
+        }
+
+        // get all witnesses
+        let assert_witnesses = assigner.all_intermeidate_witnesses(elements);
+
+        // must find some avalible chunk
+        let (id, witness) = disprove_exec(&assigner, assert_witnesses, wrong_proof).unwrap();
+        let script = segments[id].script(&assigner);
+        let res = execute_script_with_inputs(script, witness);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_wrong_proof_and_modify_intermediates() {
+        todo!()
+    }
+}

--- a/src/chunker/elements.rs
+++ b/src/chunker/elements.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use super::common::*;
 use crate::bn254::curves::{G1Affine, G2Affine};
 use crate::bn254::utils::{
@@ -8,6 +6,8 @@ use crate::bn254::utils::{
 };
 use crate::treepp::*;
 use crate::{chunker::assigner::BCAssigner, execute_script_with_inputs};
+use std::any::Any;
+use std::fmt::Debug;
 
 /// FqElements are used in the chunker, representing muliple Fq.
 #[derive(Debug, Clone)]
@@ -38,7 +38,7 @@ pub enum DataType {
 }
 
 /// This trait defines the intermediate values
-pub trait ElementTrait {
+pub trait ElementTrait: Debug {
     /// Fill data by a specific value
     fn fill_with_data(&mut self, x: DataType);
     /// Convert the intermediate values to witness
@@ -67,6 +67,17 @@ macro_rules! impl_element_trait {
             /// Create a new element by using bitcommitment assigner
             pub fn new<F: BCAssigner>(assigner: &mut F, id: &str) -> Self {
                 assigner.create_hash(id);
+                Self {
+                    0: FqElement {
+                        identity: id.to_owned(),
+                        size: $size,
+                        witness_data: None,
+                        data: None,
+                    },
+                }
+            }
+
+            pub fn new_dummy(id: &str) -> Self {
                 Self {
                     0: FqElement {
                         identity: id.to_owned(),

--- a/src/chunker/elements.rs
+++ b/src/chunker/elements.rs
@@ -199,7 +199,7 @@ impl ElementTrait for DummyElement {
     }
 
     fn to_hash_witness(&self) -> Option<RawWitness> {
-        None
+        Some(array_to_witness(self.hash))
     }
 
     fn size(&self) -> usize {

--- a/src/chunker/elements.rs
+++ b/src/chunker/elements.rs
@@ -165,3 +165,48 @@ impl_element_trait!(Fq12Type, Fq12Data, 12, fq12_push_not_montgomery);
 impl_element_trait!(G1PointType, G1PointData, 2, G1Affine::push_not_montgomery);
 // (x: Fq, y: Fq2)
 impl_element_trait!(G2PointType, G2PointData, 4, G2Affine::push_not_montgomery);
+
+#[derive(Debug, Clone)]
+pub struct DummyElement {
+    id: String,
+    hash: BLAKE3HASH,
+}
+
+impl ElementTrait for DummyElement {
+    fn fill_with_data(&mut self, _: DataType) {}
+
+    fn to_witness(&self) -> Option<RawWitness> {
+        None
+    }
+
+    fn to_data(&self) -> Option<DataType> {
+        None
+    }
+
+    fn to_hash(&self) -> Option<BLAKE3HASH> {
+        Some(self.hash)
+    }
+
+    fn to_hash_witness(&self) -> Option<RawWitness> {
+        None
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn witness_size(&self) -> usize {
+        0
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+pub fn dummy_element(id: &str, hash: BLAKE3HASH) -> DummyElement {
+    DummyElement {
+        id: id.to_owned(),
+        hash,
+    }
+}

--- a/src/chunker/mod.rs
+++ b/src/chunker/mod.rs
@@ -9,5 +9,6 @@ pub mod chunk_msm;
 pub mod chunk_non_fixed_point;
 pub mod chunk_scalar_mul;
 pub mod common;
+pub mod disprove_execution;
 pub mod elements;
 pub mod segment;

--- a/src/chunker/segment.rs
+++ b/src/chunker/segment.rs
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_segment_by_simple_case() {
-        let mut assigner = DummyAssinger {};
+        let mut assigner = DummyAssinger::default();
 
         let mut a0 = Fq6Type::new(&mut assigner, "a0");
         a0.fill_with_data(Fq6Data(ark_bn254::Fq6::from(1)));

--- a/src/groth16/offchain_checker.rs
+++ b/src/groth16/offchain_checker.rs
@@ -11,6 +11,37 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use std::str::FromStr;
 
+#[macro_export]
+macro_rules! log_assert_eq {
+    ($left:expr, $right:expr) => {
+        if $left != $right {
+            // log error
+            println! {"fail assert"}
+        }
+    };
+    ($left:expr, $right:expr, $message: expr) => {
+        if $left != $right {
+            // log error
+            println! {"fail assert: {}", $message}
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! log_assert_ne {
+    ($left:expr, $right:expr) => {
+        if $left == $right {
+            println! {"fail assert"}
+        }
+    };
+    ($left:expr, $right:expr, $message: expr) => {
+        if $left == $right {
+            // log error
+            println! {"fail assert: {}", $message}
+        }
+    };
+}
+
 // refer table 3 of https://eprint.iacr.org/2009/457.pdf
 // a: Fp12 which is cubic residue
 // c: random Fp12 which is cubic non-residue
@@ -55,7 +86,7 @@ fn tonelli_shanks_cubic(
         r = r.inverse().unwrap();
     }
 
-    assert_eq!(r.pow([3_u64]), a);
+    log_assert_eq!(r.pow([3_u64]), a);
     r
 }
 
@@ -80,7 +111,7 @@ pub fn compute_c_wi(f: ark_bn254::Fq12) -> (ark_bn254::Fq12, ark_bn254::Fq12) {
     let cofactor_cubic = 3_u32.pow(s - 1) * &t;
 
     // make sure f is r-th residue
-    assert_eq!(f.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
+    log_assert_eq!(f.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
 
     // sample a proper scalar w which is cubic non-residue
     let w = {
@@ -98,8 +129,8 @@ pub fn compute_c_wi(f: ark_bn254::Fq12) -> (ark_bn254::Fq12, ark_bn254::Fq12) {
         w
     };
     // make sure 27-th root w, is 3-th non-residue and r-th residue
-    assert_ne!(w.pow(cofactor_cubic.to_u64_digits()), ark_bn254::Fq12::ONE);
-    assert_eq!(w.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
+    log_assert_ne!(w.pow(cofactor_cubic.to_u64_digits()), ark_bn254::Fq12::ONE);
+    log_assert_eq!(w.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
 
     // options for wi are 1, w, w^2
     let mut wi = ark_bn254::Fq12::ONE;
@@ -107,35 +138,35 @@ pub fn compute_c_wi(f: ark_bn254::Fq12) -> (ark_bn254::Fq12, ark_bn254::Fq12) {
         wi *= w;
         if (f * wi).pow(cofactor_cubic.to_u64_digits()) != ark_bn254::Fq12::ONE {
             wi *= w;
-            assert_eq!(
+            log_assert_eq!(
                 (f * wi).pow(cofactor_cubic.to_u64_digits()),
                 ark_bn254::Fq12::ONE
             );
         }
     }
-    assert_eq!(wi.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
+    log_assert_eq!(wi.pow(h.to_u64_digits()), ark_bn254::Fq12::ONE);
 
-    assert_eq!(LAMBDA.clone(), d * &mm * &r);
+    log_assert_eq!(LAMBDA.clone(), d * &mm * &r);
     // f1 is scaled f
     let f1 = f * wi;
 
     // r-th root of f1, say f2
     let r_inv = r.modinv(&h).unwrap();
-    assert_ne!(r_inv, BigUint::one());
+    log_assert_ne!(r_inv, BigUint::one());
     let f2 = f1.pow(r_inv.to_u64_digits());
-    assert_ne!(f2, ark_bn254::Fq12::ONE);
+    log_assert_ne!(f2, ark_bn254::Fq12::ONE);
 
     // m'-th root of f, say f3
     let mm_inv = mm.modinv(&(r * h)).unwrap();
-    assert_ne!(mm_inv, BigUint::one());
+    log_assert_ne!(mm_inv, BigUint::one());
     let f3 = f2.pow(mm_inv.to_u64_digits());
-    assert_eq!(f3.pow(cofactor_cubic.to_u64_digits()), ark_bn254::Fq12::ONE);
-    assert_ne!(f3, ark_bn254::Fq12::ONE);
+    log_assert_eq!(f3.pow(cofactor_cubic.to_u64_digits()), ark_bn254::Fq12::ONE);
+    log_assert_ne!(f3, ark_bn254::Fq12::ONE);
 
     // d-th (cubic) root, say c
     let c = tonelli_shanks_cubic(f3, w, s, t, k);
-    assert_ne!(c, ark_bn254::Fq12::ONE);
-    assert_eq!(c.pow(LAMBDA.to_u64_digits()), f * wi);
+    log_assert_ne!(c, ark_bn254::Fq12::ONE);
+    log_assert_eq!(c.pow(LAMBDA.to_u64_digits()), f * wi);
 
     (c, wi)
 }

--- a/src/groth16/offchain_checker.rs
+++ b/src/groth16/offchain_checker.rs
@@ -2,6 +2,7 @@
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 
+use crate::chunker::disprove_execution::RawProof;
 use crate::groth16::constants::LAMBDA;
 use ark_ff::UniformRand;
 use ark_ff::{Field, One};


### PR DESCRIPTION
This PR offers a function to find which chunk is available when the operator did some malicious thing. This function re-runs chunker using the wrong proof to get a wrong-proof assigner, then checks the inconsistency between the wrong-proof assigner and the assigner recovered by assert transaction.

There are two cases a malicious operator can do.
-  Operator put a wrong proof to generate all intermediate values, say $$S$$. In this case, the final accumulator will be wrong, and the challenger can take collateral by executing the "accumulator verifier" chunk. This case is covered by unit test `test_wrong_proof`.
-  Operator put a wrong proof and modify some intermediate values to make some chunks pass, say $$S'$$. In this case, there must be a chunk whose `parameter` is the same as in $$S$$, but the `result` is different in $$S$$. The challenger can execute this chunk. This case is covered by unit test `test_wrong_proof_and_modify_intermediates`.