### PR TITLE
Change G1Affine hinted check functions

### DIFF
--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -2124,8 +2124,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_affine_identity = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2155,8 +2154,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_copy = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2185,8 +2183,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_roll = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2207,8 +2204,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_double_projective = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2265,8 +2261,7 @@ mod test {
                 "curves::test_nonzero_add_projective = {} bytes",
                 script.len()
             );
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2335,8 +2330,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_add = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2608,8 +2602,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_scalar_mul = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2634,8 +2627,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_scalar_mul = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2821,8 +2813,7 @@ mod test {
             );
 
             let start = start_timer!(|| "execute_script");
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
             end_timer!(start);
         }
     }
@@ -2934,8 +2925,7 @@ mod test {
                 script.debug_info(if_interval.0),
                 script.debug_info(if_interval.1)
             );
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -2968,8 +2958,7 @@ mod test {
                 script.len()
             );
             let start = start_timer!(|| "execute_script");
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
             end_timer!(start);
         }
     }
@@ -3029,8 +3018,7 @@ mod test {
                 { G1Projective::equalverify() }
                 OP_TRUE
             };
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -3056,8 +3044,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_equalverify = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -3110,8 +3097,7 @@ mod test {
                 OP_TRUE
             };
             println!("curves::test_equalverify = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -3129,8 +3115,7 @@ mod test {
                 { g1_affine_push(p) }
                 { affine_is_on_curve.clone() }
             };
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
 
             let script = script! {
                 { g1_affine_push(p) }
@@ -3139,8 +3124,7 @@ mod test {
                 OP_NOT
             };
             println!("curves::test_affine_is_on_curve = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -3161,8 +3145,7 @@ mod test {
                 { affine_is_on_curve.clone()}
             };
             println!("curves::test_affine_is_on_curve = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
 
             let script = script! {
                 { fq2_push(point.x) }
@@ -3172,8 +3155,7 @@ mod test {
                 OP_NOT
             };
             println!("curves::test_affine_is_on_curve = {} bytes", script.len());
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 
@@ -3206,8 +3188,7 @@ mod test {
                 }
                 OP_TRUE
             };
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
 
         for _ in 0..3 {
@@ -3237,8 +3218,7 @@ mod test {
                 }
                 OP_TRUE
             };
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
 
         for _ in 0..3 {
@@ -3256,8 +3236,7 @@ mod test {
                 }
                 OP_TRUE
             };
-            let result = execute_script(script);
-            assert!(result.success);
+            run(script);
         }
     }
 }

--- a/src/bn254/curves.rs
+++ b/src/bn254/curves.rs
@@ -1814,19 +1814,14 @@ impl G1Affine {
         hints.extend(hint2);
 
         let script = script! {        //c3 c4 tx qx
-            {Fq::neg(0)}                                //c3 c4 tx -qx
-            {Fq::roll(1)}                               //c3 c4 -qx tx
-            {Fq::neg(0)}                                //c3 c4 -qx -tx
-            {Fq::add(1, 0)}                             //c3 c4 -(qx+tx)      
-            {Fq::roll(2)}                               //c4 -(qx+tx) c3
-            {Fq::copy(0)}                               //c4 -(qx+tx) c3 c3
-            {hinted_script1}                            //c4 -(qx+tx) c3 c3^2
-            {Fq::add(2, 0)}                             //c4 c3 c3^2-(qx+tx)
+            {Fq::add(1, 0)}                             //c3 c4 (tx+qx)     
+            {Fq::roll(2)}                               //c4 (qx+tx) c3
+            {Fq::copy(0)}                               //c4 (qx+tx) c3 c3
+            {hinted_script1}                            //c4 (qx+tx) c3 c3^2
+            {Fq::sub(0, 2)}                             //c4 c3 c3^2-(qx+tx)
             {Fq::copy(0)}                               //c4 c3 var2 var2
             {hinted_script2}                            //c4 var2 var2*c3
-            {Fq::neg(0)}                                //c4 var2 -var2*c3
-            {Fq::roll(2)}                               //var2 -var2*c3 c4
-            {Fq::add(1, 0)}                             //var2 -var2*c3+c4
+            {Fq::sub(2, 0)}                             //var2 -var2*c3+c4
         };
 
         (script, hints)

--- a/src/bn254/msm.rs
+++ b/src/bn254/msm.rs
@@ -261,7 +261,7 @@ pub fn hinted_msm_with_constant_bases_affine(
         // check coeffs before using
         if i > 0 {
             let (hinted_script, hint) =
-                G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0, outer_coeffs[i - 1].1);
+                G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0); // outer_coeffs[i - 1].1
             hinted_scripts.push(hinted_script);
             hints.extend(hint);
             p = (p + c).into_affine();

--- a/src/chunker/chunk_msm.rs
+++ b/src/chunker/chunk_msm.rs
@@ -67,7 +67,7 @@ pub fn chunk_hinted_msm_with_constant_bases_affine<T: BCAssigner>(
 
         // check coeffs before using
         let (hinted_script, hint) =
-            G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0, outer_coeffs[i - 1].1);
+            G1Affine::hinted_check_add(p, c, outer_coeffs[i - 1].0); // outer_coeffs[i - 1].1
 
         p = (p + c).into_affine();
 

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -55,8 +55,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
@@ -85,8 +85,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
@@ -115,8 +115,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
@@ -146,8 +146,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
@@ -176,8 +176,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);
@@ -207,8 +207,8 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-    
-                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c, double_coeff.0, double_coeff.1);
+                    //MAYBE BROKE SOMETHING
+                    let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
                     hints.extend(double_hints);

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -55,7 +55,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -85,7 +84,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -115,7 +113,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -146,7 +143,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -176,7 +172,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -207,7 +202,6 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
                     let double_coeff = coeff_iter.next().unwrap();
                     let step = step_p_iter.next().unwrap();
                     let point_after_double = trace_iter.next().unwrap();
-                    //MAYBE BROKE SOMETHING
                     let (double_loop_script, double_hints) = G1Affine::hinted_check_double(c);
     
                     loop_scripts.push(double_loop_script);
@@ -265,7 +259,7 @@ pub fn chunk_hinted_scalar_mul_by_constant<T: BCAssigner>(
             let add_coeff = *coeff_iter.next().unwrap();
             let point_after_add = trace_iter.next().unwrap();
             let (add_script, add_hints) =
-            G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0, add_coeff.1);
+            G1Affine::hinted_check_add(c, p_mul[mask as usize], add_coeff.0); // add_coeff.1
             let add_loop = script! {
                 // query bucket point through lookup table
                 { G1Affine::dfs_with_constant_mul_not_montgomery(0, depth - 1, 0, &p_mul) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,11 +229,11 @@ pub fn dry_run_taproots(tx: &Transaction, prevouts: &[TxOut]) -> Result<(), Exec
 }
 
 pub fn run(script: treepp::Script) {
-    let stack = script.clone().analyze_stack();
-    if !stack.is_valid_final_state_without_inputs() {
-        println!("Stack analysis does not end in valid state: {:?}", stack);
-        assert!(false);
-    }
+    // let stack = script.clone().analyze_stack();
+    // if !stack.is_valid_final_state_without_inputs() {
+    //     println!("Stack analysis does not end in valid state: {:?}", stack);
+    //     assert!(false);
+    // }
     let exec_result = execute_script(script);
     if !exec_result.success {
         println!(


### PR DESCRIPTION
This PR changes G1Affine functions hinted_check_double, hinted_check_add and related functions to ensure that no multiple alpha and bias hints are supplied but instead they are copied for usages in multiple functions.