### PR TITLE
Draft: Integrate Winternitz logic into assigner

### DIFF
--- a/src/bridge/connectors/connector_c.rs
+++ b/src/bridge/connectors/connector_c.rs
@@ -102,8 +102,6 @@ fn disprove_leaf() -> DisproveLeaf {
 
 fn generate_assert_leaves() -> (Vec<ScriptBuf>, Vec<UnlockWitnessData>) {
     // TODO: Scripts with n_of_n_public_key and one of the commitments disprove leaves in each leaf (Winternitz signatures)
-    let assigner = DummyAssigner::default();
-    assigner.winternitz_locking_script(element);
     let mut locks = Vec::with_capacity(1000);
     let mut unlocks = Vec::with_capacity(1000);
     let locking_template = disprove_leaf().lock;

--- a/src/bridge/connectors/connector_c.rs
+++ b/src/bridge/connectors/connector_c.rs
@@ -1,4 +1,4 @@
-use crate::treepp::script;
+use crate::{chunker::assigner::{BCAssigner, DummyAssigner}, treepp::script};
 use bitcoin::{
     hashes::{ripemd160, Hash},
     key::Secp256k1,
@@ -102,6 +102,8 @@ fn disprove_leaf() -> DisproveLeaf {
 
 fn generate_assert_leaves() -> (Vec<ScriptBuf>, Vec<UnlockWitnessData>) {
     // TODO: Scripts with n_of_n_public_key and one of the commitments disprove leaves in each leaf (Winternitz signatures)
+    let assigner = DummyAssigner::default();
+    assigner.winternitz_locking_script(element);
     let mut locks = Vec::with_capacity(1000);
     let mut unlocks = Vec::with_capacity(1000);
     let locking_template = disprove_leaf().lock;

--- a/src/bridge/transactions/signing_winternitz.rs
+++ b/src/bridge/transactions/signing_winternitz.rs
@@ -5,7 +5,7 @@ use crate::signatures::{
     winternitz::{
         generate_public_key, Parameters, PublicKey, SecretKey,
     },
-    winternitz_hash::{sign_hash, WINTERNITZ_HASH_VERIFIER, WINTERNITZ_MESSAGE_VERIFIER},
+    winternitz_hash::{sign_hash, WINTERNITZ_HASH_PARAMETERS, WINTERNITZ_HASH_VERIFIER, WINTERNITZ_MESSAGE_VERIFIER},
 };
 use crate::treepp::{Script, script};
 
@@ -23,11 +23,21 @@ impl WinternitzSecret {
         rand::RngCore::fill_bytes(&mut rng, &mut buffer);
 
         // TODO: Figure out the best parameters
-        //let parameters = Parameters::new((BLAKE3_HASH_LENGTH * 2) as u32, 4);
         let parameters = Parameters::new((message_size * 2) as u32, 4);
         WinternitzSecret {
             secret_key: hex::encode(buffer).into(),
             parameters,
+        }
+    }
+
+    pub fn new_hash() -> Self {
+        let mut buffer = [0u8; 20];
+        let mut rng = rand::rngs::OsRng::default();
+        rand::RngCore::fill_bytes(&mut rng, &mut buffer);
+
+        WinternitzSecret {
+            secret_key: hex::encode(buffer).into(),
+            parameters: WINTERNITZ_HASH_PARAMETERS.clone(),
         }
     }
 

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -1,5 +1,5 @@
 use super::{common::*, elements::ElementTrait};
-use crate::{bridge::transactions::signing_winternitz::WinternitzPublicKey, signatures::winternitz_hash::WINTERNITZ_HASH_VERIFIER, treepp::*};
+use crate::{bridge::transactions::signing_winternitz::{WinternitzPublicKey, WinternitzSecret}, signatures::{winternitz::PublicKey, winternitz_hash::{WINTERNITZ_HASH_PARAMETERS, WINTERNITZ_HASH_VERIFIER}}, treepp::*};
 use std::{collections::BTreeMap, rc::Rc};
 
 /// Implement `BCAssinger` to adapt with bridge.
@@ -83,28 +83,29 @@ impl BCAssigner for DummyAssigner {
 }
 
 #[derive(Default)]
-pub struct Groth16Assigner {
-    // TODO: Store an Option for WinternitzPublicKey from bridge::transactions::signing_winternitz.rs for each
-    // bit commitment.
-    // TODO: If we are operator store the secret_key to create WinternitzPublicKey from.
-    bc_map: BTreeMap<String, String>,
+pub struct OperatorAssigner {
+    bc_map: BTreeMap<String, WinternitzSecret>,
 }
 
-impl BCAssigner for Groth16Assigner {
+#[derive(Default)]
+//TODO: Fill in operator_public_keys from on chain txs or file store.
+pub struct VerifierAssigner {
+    bc_map: BTreeMap<String, WinternitzPublicKey>,
+    // List of winternitz public keys the operator used in
+    // their scripts in the order they are generated with at
+    // segment creation time.
+    operator_public_keys: Vec<PublicKey>, }
+
+impl BCAssigner for OperatorAssigner {
     fn create_hash(&mut self, id: &str) {
         if self.bc_map.contains_key(id) {
             panic!("variable name is repeated, check {}", id);
         }
-        self.bc_map.insert(id.to_string(), id.to_string());
+        self.bc_map.insert(id.to_string(), WinternitzSecret::new_hash());
     }
 
     fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script {
-        //TODO: Get the winternitz public key for element from storage or create an entry with the
-        //secret_key
-        let winternitz_public_key = WinternitzPublicKey {
-            public_key: todo!(),
-            parameters: todo!(),
-        };
+        let winternitz_public_key: WinternitzPublicKey = self.bc_map.get(element.id()).expect("Missing key.").into();
         WINTERNITZ_HASH_VERIFIER.checksig_verify(&winternitz_public_key.parameters, &winternitz_public_key.public_key)
     }
 
@@ -148,5 +149,64 @@ impl BCAssigner for Groth16Assigner {
             .map(|(_, element)| self.get_witness(element))
             .collect()]
     }
+}
 
+impl BCAssigner for VerifierAssigner {
+    fn create_hash(&mut self, id: &str) {
+        if self.bc_map.contains_key(id) {
+            panic!("variable name is repeated, check {}", id);
+        }
+        let winternitz_public_key = WinternitzPublicKey {
+            public_key: self.operator_public_keys.pop().expect("No operator public key remaining"),
+            parameters: WINTERNITZ_HASH_PARAMETERS.clone(),
+        };
+
+        self.bc_map.insert(id.to_string(), winternitz_public_key);
+    }
+
+    fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script {
+        let winternitz_public_key = self.bc_map.get(element.id()).expect("Missing key.");
+        WINTERNITZ_HASH_VERIFIER.checksig_verify(&winternitz_public_key.parameters, &winternitz_public_key.public_key)
+    }
+
+    fn get_witness<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> RawWitness {
+        element.to_hash_witness().unwrap()
+    }
+
+    fn recover_from_witness(
+        &mut self,
+        witnesses: Vec<Vec<RawWitness>>,
+    ) -> BTreeMap<String, BLAKE3HASH> {
+        let mut btree_map: BTreeMap<String, BLAKE3HASH> = Default::default();
+        // flat the witnesses and recover to btreemap
+        let flat_witnesses: Vec<RawWitness> = witnesses.into_iter().fold(vec![], |mut w, x| {
+            w.extend(x);
+            w
+        });
+        assert_eq!(flat_witnesses.len(), self.bc_map.len());
+        for ((id, _), idx) in self.bc_map.iter().zip(0..flat_witnesses.len()) {
+            btree_map.insert(id.to_owned(), witness_to_array(flat_witnesses[idx].clone()));
+        }
+        btree_map
+    }
+
+    fn all_intermediate_scripts(&self) -> Vec<Vec<Script>> {
+        vec![self.bc_map.iter().map(|(_, _)| script! {}).collect()]
+    }
+
+    fn all_intermediate_witnesses(
+        &self,
+        elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
+    ) -> Vec<Vec<RawWitness>> {
+        for (key, _) in self.bc_map.iter() {
+            if !elements.contains_key(key) {
+                println!("inconsistent key: {}", key)
+            }
+        }
+        assert_eq!(elements.len(), self.bc_map.len());
+        vec![elements
+            .iter()
+            .map(|(_, element)| self.get_witness(element))
+            .collect()]
+    }
 }

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -88,13 +88,10 @@ pub struct OperatorAssigner {
 }
 
 #[derive(Default)]
-//TODO: Fill in operator_public_keys from on chain txs or file store.
+//TODO: Fill in bc_map from file store.
 pub struct VerifierAssigner {
     bc_map: BTreeMap<String, WinternitzPublicKey>,
-    // List of winternitz public keys the operator used in
-    // their scripts in the order they are generated with at
-    // segment creation time.
-    operator_public_keys: Vec<PublicKey>, }
+}
 
 impl BCAssigner for OperatorAssigner {
     fn create_hash(&mut self, id: &str) {
@@ -153,15 +150,9 @@ impl BCAssigner for OperatorAssigner {
 
 impl BCAssigner for VerifierAssigner {
     fn create_hash(&mut self, id: &str) {
-        if self.bc_map.contains_key(id) {
-            panic!("variable name is repeated, check {}", id);
+        if !self.bc_map.contains_key(id) {
+            panic!("variable name does not exist, check {}", id);
         }
-        let winternitz_public_key = WinternitzPublicKey {
-            public_key: self.operator_public_keys.pop().expect("No operator public key remaining"),
-            parameters: WINTERNITZ_HASH_PARAMETERS.clone(),
-        };
-
-        self.bc_map.insert(id.to_string(), winternitz_public_key);
     }
 
     fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script {

--- a/src/chunker/assigner.rs
+++ b/src/chunker/assigner.rs
@@ -1,5 +1,5 @@
 use super::{common::*, elements::ElementTrait};
-use crate::treepp::*;
+use crate::{bridge::transactions::signing_winternitz::WinternitzPublicKey, signatures::winternitz_hash::WINTERNITZ_HASH_VERIFIER, treepp::*};
 use std::{collections::BTreeMap, rc::Rc};
 
 /// Implement `BCAssinger` to adapt with bridge.
@@ -7,7 +7,7 @@ pub trait BCAssigner: Default {
     /// check hash
     fn create_hash(&mut self, id: &str);
     /// return a element of
-    fn locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script;
+    fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script;
     fn get_witness<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> RawWitness;
     /// output sciprt for all elements, used by assert transaction
     fn all_intermediate_scripts(&self) -> Vec<Vec<Script>>;
@@ -24,11 +24,11 @@ pub trait BCAssigner: Default {
 }
 
 #[derive(Default)]
-pub struct DummyAssinger {
+pub struct DummyAssigner {
     bc_map: BTreeMap<String, String>,
 }
 
-impl BCAssigner for DummyAssinger {
+impl BCAssigner for DummyAssigner {
     fn create_hash(&mut self, id: &str) {
         if self.bc_map.contains_key(id) {
             panic!("varible name is repeated, check {}", id);
@@ -36,7 +36,7 @@ impl BCAssigner for DummyAssinger {
         self.bc_map.insert(id.to_string(), id.to_string());
     }
 
-    fn locking_script<T: ElementTrait + ?Sized>(&self, _: &Box<T>) -> Script {
+    fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, _: &Box<T>) -> Script {
         script! {}
     }
 
@@ -80,4 +80,73 @@ impl BCAssigner for DummyAssinger {
             .map(|(_, element)| self.get_witness(element))
             .collect()]
     }
+}
+
+#[derive(Default)]
+pub struct Groth16Assigner {
+    // TODO: Store an Option for WinternitzPublicKey from bridge::transactions::signing_winternitz.rs for each
+    // bit commitment.
+    // TODO: If we are operator store the secret_key to create WinternitzPublicKey from.
+    bc_map: BTreeMap<String, String>,
+}
+
+impl BCAssigner for Groth16Assigner {
+    fn create_hash(&mut self, id: &str) {
+        if self.bc_map.contains_key(id) {
+            panic!("variable name is repeated, check {}", id);
+        }
+        self.bc_map.insert(id.to_string(), id.to_string());
+    }
+
+    fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> Script {
+        //TODO: Get the winternitz public key for element from storage or create an entry with the
+        //secret_key
+        let winternitz_public_key = WinternitzPublicKey {
+            public_key: todo!(),
+            parameters: todo!(),
+        };
+        WINTERNITZ_HASH_VERIFIER.checksig_verify(&winternitz_public_key.parameters, &winternitz_public_key.public_key)
+    }
+
+    fn get_witness<T: ElementTrait + ?Sized>(&self, element: &Box<T>) -> RawWitness {
+        element.to_hash_witness().unwrap()
+    }
+
+    fn recover_from_witness(
+        &mut self,
+        witnesses: Vec<Vec<RawWitness>>,
+    ) -> BTreeMap<String, BLAKE3HASH> {
+        let mut btree_map: BTreeMap<String, BLAKE3HASH> = Default::default();
+        // flat the witnesses and recover to btreemap
+        let flat_witnesses: Vec<RawWitness> = witnesses.into_iter().fold(vec![], |mut w, x| {
+            w.extend(x);
+            w
+        });
+        assert_eq!(flat_witnesses.len(), self.bc_map.len());
+        for ((id, _), idx) in self.bc_map.iter().zip(0..flat_witnesses.len()) {
+            btree_map.insert(id.to_owned(), witness_to_array(flat_witnesses[idx].clone()));
+        }
+        btree_map
+    }
+
+    fn all_intermediate_scripts(&self) -> Vec<Vec<Script>> {
+        vec![self.bc_map.iter().map(|(_, _)| script! {}).collect()]
+    }
+
+    fn all_intermediate_witnesses(
+        &self,
+        elements: BTreeMap<String, Rc<Box<dyn ElementTrait>>>,
+    ) -> Vec<Vec<RawWitness>> {
+        for (key, _) in self.bc_map.iter() {
+            if !elements.contains_key(key) {
+                println!("inconsistent key: {}", key)
+            }
+        }
+        assert_eq!(elements.len(), self.bc_map.len());
+        vec![elements
+            .iter()
+            .map(|(_, element)| self.get_witness(element))
+            .collect()]
+    }
+
 }

--- a/src/chunker/chunk_accumulator.rs
+++ b/src/chunker/chunk_accumulator.rs
@@ -383,7 +383,7 @@ mod test {
     use super::*;
     use crate::bn254::fq12::Fq12;
     use crate::bn254::utils::fq12_push_not_montgomery;
-    use crate::chunker::assigner::DummyAssinger;
+    use crate::chunker::assigner::DummyAssigner;
     use crate::execute_script_with_inputs;
 
     use ark_ff::Field;
@@ -423,7 +423,7 @@ mod test {
         );
 
         println!("chunk:");
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let mut pa = Fq12Type::new(&mut assigner, &format!("i_a"));
         pa.fill_with_data(Fq12Data(b));
         let (segments, r) = make_chunk_square(

--- a/src/chunker/chunk_evaluate_line.rs
+++ b/src/chunker/chunk_evaluate_line.rs
@@ -124,7 +124,7 @@ mod test {
     use crate::bn254::fq12::Fq12;
     use crate::bn254::utils::*;
     use crate::chunker::elements;
-    use crate::chunker::{assigner::DummyAssinger, segment};
+    use crate::chunker::{assigner::DummyAssigner, segment};
     use crate::treepp::*;
 
     use crate::execute_script_with_inputs;
@@ -191,7 +191,7 @@ mod test {
         assert!(exec_result.success);
 
         //
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let mut segments = Vec::new();
         let fn_name = format!("F_{}_mul_c_1p{}", 0, 0);
         let (segments_mul, mul): (Vec<segment::Segment>, elements::Fq12Type) =

--- a/src/chunker/chunk_fq12_multiplication.rs
+++ b/src/chunker/chunk_fq12_multiplication.rs
@@ -146,7 +146,7 @@ mod test {
     use super::{chunk_fq12_multiplication, fq12_mul_wrapper};
     use crate::{
         chunker::{
-            assigner::DummyAssinger,
+            assigner::DummyAssigner,
             elements::{DataType::Fq12Data, DataType::Fq6Data, ElementTrait, Fq12Type, Fq6Type},
             segment::Segment,
         },
@@ -159,7 +159,7 @@ mod test {
 
     #[test]
     fn test_fq12_wrapper() {
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         let mut a_type = Fq12Type::new(&mut assigner, "a");
         let mut b_type = Fq12Type::new(&mut assigner, "b");

--- a/src/chunker/chunk_g1_points.rs
+++ b/src/chunker/chunk_g1_points.rs
@@ -130,7 +130,7 @@ mod test {
         // assert!(exec_result.success);
         println!("exec_result {}", exec_result);
 
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let g1a = expect;
         let mut g1p = G1PointType::new(&mut assigner, &format!("{}", "test"));
         g1p.fill_with_data(G1PointData(g1a));

--- a/src/chunker/chunk_groth16_verifier.rs
+++ b/src/chunker/chunk_groth16_verifier.rs
@@ -162,7 +162,7 @@ mod tests {
             self.commitments.insert(id.to_owned(), 1);
         }
 
-        fn locking_script<T: ElementTrait + ?Sized>(&self, _: &Box<T>) -> Script {
+        fn winternitz_locking_script<T: ElementTrait + ?Sized>(&self, _: &Box<T>) -> Script {
             script! {}
         }
 
@@ -418,7 +418,7 @@ mod tests {
 
         let proof = Groth16::<E>::prove(&pk, circuit, rng).unwrap();
 
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let segments = groth16_verify_to_segments(&mut assigner, &vec![c], &proof, &vk);
 
         println!("segments number: {}", segments.len());

--- a/src/chunker/chunk_hinted_accumulator.rs
+++ b/src/chunker/chunk_hinted_accumulator.rs
@@ -215,7 +215,7 @@ mod test {
     }
 
     fn test_g1_points() {
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         type E = Bn254;
         let k = 6;
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn test_chunk_accumulator() {
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         type E = Bn254;
         let k = 6;
@@ -325,7 +325,7 @@ mod test {
 
     #[test]
     fn test_verify_accumulator() {
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         type E = Bn254;
         let k = 6;

--- a/src/chunker/chunk_msm.rs
+++ b/src/chunker/chunk_msm.rs
@@ -99,7 +99,7 @@ mod tests {
 
     use crate::{
         chunker::{
-            assigner::DummyAssinger,
+            assigner::DummyAssigner,
             elements::{ElementTrait, FrType},
         },
         execute_script_with_inputs,
@@ -112,7 +112,7 @@ mod tests {
         let k = 2;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         let scalars = (0..n - 1)
             .map(|_| ark_bn254::Fr::rand(rng))

--- a/src/chunker/chunk_non_fixed_point.rs
+++ b/src/chunker/chunk_non_fixed_point.rs
@@ -337,7 +337,7 @@ pub fn chunk_q4<T: BCAssigner>(
 mod tests {
     use super::chunk_q4;
     use crate::bn254::ell_coeffs::G2Prepared;
-    use crate::chunker::assigner::DummyAssinger;
+    use crate::chunker::assigner::DummyAssigner;
     use crate::chunker::elements::{ElementTrait, G2PointType};
     use crate::execute_script_with_inputs;
     use ark_std::UniformRand;
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn test_check_q4() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         // exp = 6x + 2 + p - p^2 = lambda - p^3
         let q1 = ark_bn254::g2::G2Affine::rand(&mut prng);

--- a/src/chunker/chunk_scalar_mul.rs
+++ b/src/chunker/chunk_scalar_mul.rs
@@ -350,7 +350,7 @@ mod tests {
     use crate::{
         bn254::{curves::G1Affine, msm::prepare_msm_input},
         chunker::{
-            assigner::DummyAssinger,
+            assigner::DummyAssigner,
             chunk_scalar_mul::chunk_hinted_scalar_mul_by_constant,
             elements::{ElementTrait, FrType},
         },
@@ -368,7 +368,7 @@ mod tests {
         let k = 0;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         let mut bases = (0..n)
             .map(|_| ark_bn254::G1Projective::rand(rng).into_affine())
@@ -459,7 +459,7 @@ mod tests {
         let k = 0;
         let n = 1 << k;
         let rng = &mut test_rng();
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         let scalars = (0..n).map(|_| ark_bn254::Fr::rand(rng)).collect::<Vec<_>>();
 

--- a/src/chunker/common.rs
+++ b/src/chunker/common.rs
@@ -8,7 +8,7 @@ pub type RawWitness = Vec<Vec<u8>>;
 /// Should use u32 version's blake3 hash for fq element
 pub use crate::hash::blake3_u32::blake3_var_length;
 
-/// The depth of a blake3 hash, depending on the defination of `N_DIGEST_U32_LIMBS`
+/// The byte length of a blake3 hash, depending on the definition of `N_DIGEST_U32_LIMBS`
 pub(crate) const BLAKE3_HASH_LENGTH: usize =
     crate::hash::blake3_u32::N_DIGEST_U32_LIMBS as usize * 4;
 pub type BLAKE3HASH = [u8; BLAKE3_HASH_LENGTH];

--- a/src/chunker/disprove_execution.rs
+++ b/src/chunker/disprove_execution.rs
@@ -226,7 +226,7 @@ mod tests {
         let wrong_proof = right_proof;
 
         // assert witness
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let segments = groth16_verify_to_segments(
             &mut assigner,
             &wrong_proof.public,
@@ -271,7 +271,7 @@ mod tests {
         let wrong_proof = right_proof;
 
         // assert witness
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
         let segments = groth16_verify_to_segments(
             &mut assigner,
             &wrong_proof.public,

--- a/src/chunker/segment.rs
+++ b/src/chunker/segment.rs
@@ -80,13 +80,13 @@ impl Segment {
 
             // 1. unlock all bitcommitment
             for result in self.result_list.iter().rev() {
-                {assigner.locking_script(&result)}
+                {assigner.winternitz_locking_script(&result)}
                 for _ in 0..BLAKE3_HASH_LENGTH {
                     OP_TOALTSTACK
                 }
             }
             for parameter in self.parameter_list.iter() {
-                {assigner.locking_script(&parameter)} // verify bit commitment
+                {assigner.winternitz_locking_script(&parameter)} // verify bit commitment
                 for _ in 0..BLAKE3_HASH_LENGTH {
                     OP_TOALTSTACK
                 }
@@ -179,12 +179,12 @@ impl Segment {
 mod tests {
     use super::Segment;
     use crate::chunker::elements::ElementTrait;
-    use crate::chunker::{assigner::DummyAssinger, elements::DataType::Fq6Data, elements::Fq6Type};
+    use crate::chunker::{assigner::DummyAssigner, elements::DataType::Fq6Data, elements::Fq6Type};
     use crate::{execute_script_with_inputs, treepp::*};
 
     #[test]
     fn test_segment_by_simple_case() {
-        let mut assigner = DummyAssinger::default();
+        let mut assigner = DummyAssigner::default();
 
         let mut a0 = Fq6Type::new(&mut assigner, "a0");
         a0.fill_with_data(Fq6Data(ark_bn254::Fq6::from(1)));


### PR DESCRIPTION
`assigner.rs` is the only relevant part. 
Mental model for setup time:
- Operator creates an `OperatorAssigner` that generates all winternitz secrets and public keys for the intermediate values when called with `groth16_verify_to_segments()`
- Operator publicizes their public keys and the script
- Verifier fetches the public keys and stores them in its bit commitment map in `VerifierAssigner`
- Verifier generates the script with the`VerifierAssigner` and `groth16_verify_to_segments()`
- Verifier checks if the scripts are equal

I think scripts should not be stored in the assigner and we should get rid of `all_intermediate_scripts()`. Not sure what purpose it served.