### PR TITLE
feat: add hinted fp12 inverse

### DIFF
--- a/src/bn254/fq2.rs
+++ b/src/bn254/fq2.rs
@@ -1,7 +1,7 @@
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::treepp::{script, Script};
-use ark_ff::Fp2Config;
+use ark_ff::{Field, Fp2Config};
 use std::ops::Add;
 
 use utils::Hint;
@@ -222,6 +222,63 @@ impl Fq2 {
         }
     }
 
+    pub fn hinted_inv(a: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
+        let (a0_sq, a0_sq_hint) = Fq::hinted_square(a.c0);
+        let (a1_sq, a1_sq_hint) = Fq::hinted_square(a.c1);
+        let t0 = a.c0 * a.c0 + a.c1 * a.c1;
+        let t1 = t0.inverse().unwrap();
+        let (idmul, idmul_hint) = Fq::hinted_mul(0, t1, 1, t0);
+        let (t1a0, t1a0_hint) = Fq::hinted_mul(0, a.c0, 1, t1);
+        let (t1a1, t1a1_hint) = Fq::hinted_mul(0, t1, 1, a.c1);
+        // [t0inv, a0, a1]
+        let scr = script! {
+            // copy c1
+            { Fq::copy(0) }
+
+            // compute v1 = c1^2
+            { a1_sq }
+            // [t0inv, a0, a1, a1_sq]
+            // copy c0
+            { Fq::copy(2) }
+
+            // compute v0 = c0^2 + v1
+            { a0_sq }
+            // [t0inv, a0, a1, a1_sq, a0_sq]
+            { Fq::add(1, 0) } // t0 = a0^2 + a1^2
+            // [t0inv, a0, a1, t0]
+            {Fq::copy(3)}
+            // [t0inv, a0, a1, t0, t0inv]
+            // compute inv v0
+            { idmul} // t1 <- t0.inv
+            { utils::fq_push_not_montgomery(ark_bn254::Fq::ONE)}
+            { Fq::equalverify(1, 0)}
+            {Fq::roll(2)}
+            // [a0, a1, t1]
+            // dup inv v0 // c0 <- a0. t1
+            { Fq::copy(0) }
+            // [a0, a1, t1, t1]
+
+            // compute c0
+            { Fq::roll(3) }
+            // [a1, t1, t1, a0]
+            { t1a0 }
+            // [a1, t1, a0.t1]
+            // compute c1 // c1<-[-a1, t1]
+            { Fq::roll(2) }
+            { Fq::roll(2) }
+            // [a0.t1, a1, t1]
+            { t1a1 }
+            { Fq::neg(0) }
+            //[a0.t1, -a1.t1]
+        };
+
+        let mut all_hints = vec![];
+        for h in [a1_sq_hint, a0_sq_hint, idmul_hint, t1a0_hint, t1a1_hint].iter() {
+            all_hints.extend_from_slice(h);
+        }
+        return (scr, all_hints);
+    }
+
     pub fn inv() -> Script {
         script! {
             // copy c1
@@ -400,7 +457,7 @@ impl Fq2 {
 mod test {
     use crate::bn254::fq::Fq;
     use crate::bn254::fq2::Fq2;
-    use crate::bn254::utils::fq2_push_not_montgomery;
+    use crate::bn254::utils::{fq2_push_not_montgomery, fq_push_not_montgomery};
     use crate::bn254::{fp254impl::Fp254Impl, utils::fq2_push};
     use crate::treepp::*;
     use ark_ff::Field;
@@ -603,6 +660,40 @@ mod test {
             };
             run(script);
         }
+    }
+
+    #[test]
+    fn test_bn254_hinted_fq2_inv() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
+
+            let a = ark_bn254::Fq2::rand(&mut prng);
+            assert_ne!(a, ark_bn254::Fq2::ZERO);
+
+            let b = a.inverse().unwrap();
+
+            let (invs, hints) = Fq2::hinted_inv(a);
+            let t0 = a.c0 * a.c0 + a.c1 * a.c1;
+            // if a is not zero, t0 is never zero
+            let t1 = t0.inverse().unwrap();
+
+            let script = script! {
+                for hint in hints {
+                    { hint.push() }
+                }
+                { fq_push_not_montgomery(t1)}
+                { fq2_push_not_montgomery(a) }
+                { invs }
+                { fq2_push_not_montgomery(b) }
+                { Fq2::equalverify() }
+                OP_TRUE
+            };
+            let len = script.len();
+            let res = execute_script(script);
+            for i in 0..res.final_stack.len() {
+                println!("{i:3}: {:?}", res.final_stack.get(i));
+            }
+            println!("fq2 inv len {}", len);
     }
 
     #[test]

--- a/src/bn254/fq6.rs
+++ b/src/bn254/fq6.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::fq2::Fq2;
@@ -876,6 +878,171 @@ impl Fq6 {
         }
     }
 
+    pub fn aux_hints_for_fp6_inv(a: ark_bn254::Fq6) -> ark_bn254::Fq {
+        let nine = ark_bn254::Fq::from_str("9").unwrap();
+        let nonresidue: ark_bn254::Fq2 = ark_bn254::Fq2::new(nine, ark_bn254::Fq::ONE);
+        
+        let t0 = a.c0 * a.c0;
+        let t1 = a.c1 * a.c1;
+        let t2 = a.c2 * a.c2;
+
+        let t3 = a.c0 * a.c1;
+        let t4 = a.c0 * a.c2;
+        let t5 = a.c1 * a.c2;
+
+        let s0 = t0 - t5 * nonresidue;
+        let s1 = t2 * nonresidue - t3;
+        let s2 = t1 - t4;
+
+        let a1 = a.c2 * s1;
+        let a2 = a.c1 * s2;
+        let a3 = (a1 + a2) * nonresidue;
+
+        let t6 = a.c0 * s0 + a3;
+
+        let t6aux = (t6.c0 * t6.c0 + t6.c1 *t6.c1).inverse().unwrap();
+
+        t6aux
+    }
+
+    pub fn hinted_inv(a: ark_bn254::Fq6) -> (Script, Vec<Hint>) { 
+        let nine = ark_bn254::Fq::from_str("9").unwrap();
+        let nonresidue: ark_bn254::Fq2 = ark_bn254::Fq2::new(nine, ark_bn254::Fq::ONE);
+
+        let t0 = a.c0 * a.c0;
+        let t1 = a.c1 * a.c1;
+        let t2 = a.c2 * a.c2;
+
+        let t3 = a.c0 * a.c1;
+        let t4 = a.c0 * a.c2;
+        let t5 = a.c1 * a.c2;
+
+        let s0 = t0 - t5 * nonresidue;
+        let s1 = t2 * nonresidue - t3;
+        let s2 = t1 - t4;
+
+        let a1 = a.c2 * s1;
+        let a2 = a.c1 * s2;
+        let a3 = (a1 + a2) * nonresidue;
+
+        let t6 = a.c0 * s0 + a3;
+        let t6inv = t6.inverse().unwrap();
+
+        let c0 = s0 * t6inv;
+        let c1 = s1 * t6inv;
+        let c2 = s2 * t6inv;
+        assert_eq!(ark_bn254::Fq6::new(c0, c1, c2), a.inverse().unwrap());
+
+        let (s_t0, h_t0) = Fq2::hinted_square(a.c0);
+        let (s_t1, h_t1) = Fq2::hinted_square(a.c1);
+        let (s_t2, h_t2) = Fq2::hinted_square(a.c2);
+        let (s_t3, h_t3) = Fq2::hinted_mul(0, a.c1, 2, a.c0);
+        let (s_t4, h_t4) = Fq2::hinted_mul(0, a.c2, 2, a.c0);
+        let (s_t5, h_t5) = Fq2::hinted_mul(0, a.c2, 2, a.c1);
+
+        let (s_a1, h_a1) = Fq2::hinted_mul(0, s1, 8, a.c2);
+        let (s_a2, h_a2) = Fq2::hinted_mul(0, s2, 10, a.c1);
+        
+        let (s_t6, h_t6) = Fq2::hinted_mul(0, s0, 10, a.c0);
+        let (s_t6inv, h_t6inv) = Fq2::hinted_inv(t6);
+
+        let (s_c0, h_c0) = Fq2::hinted_mul(0, t6inv, 8, s0);
+        let (s_c1, h_c1) = Fq2::hinted_mul(0, t6inv, 8, s1);
+        let (s_c2, h_c2) = Fq2::hinted_mul(4, t6inv, 6, s2);
+
+        let mut hints: Vec<Hint> = vec![];
+        for hint in vec![h_t0, h_t1, h_t2, h_t3, h_t4, h_t5, h_a1, h_a2, h_t6, h_t6inv, h_c0, h_c1, h_c2] {
+            hints.extend_from_slice(&hint);
+        }
+
+        let scr = script! {
+            // [t6aux, a0, a1, a2]
+            // compute t0 = c0^2, t1 = c1^2, t2 = c2^2
+            { Fq2::copy(4) }
+            { s_t0 }
+            { Fq2::copy(4) }
+            { s_t1 }
+            { Fq2::copy(4) }
+            { s_t2 }
+             // [a0, a1, a2, t0, t1, t2, t3, t4,t5]
+
+            // compute t3 = c0 * c1, t4 = c0 * c2, t5 = c1 * c2
+            { Fq2::copy(10) }
+            { Fq2::copy(10) }
+            { s_t3 }
+            { Fq2::copy(12) }
+            { Fq2::copy(10) }
+            { s_t4 }
+            { Fq2::copy(12) }
+            { Fq2::copy(12) }
+            { s_t5 }
+
+            // [a0, a1, a2, t0, t1, t2, t3, t4, t5]
+            // update t5 = t5 * beta
+            { Fq6::mul_fq2_by_nonresidue() }
+
+            // compute s0 = t0 - t5
+            { Fq2::sub(10, 0) }
+            // [a0, a1, a2, t1, t2, t3, t4, s0]
+
+            // compute s1 = t2 * beta - t3
+            { Fq2::roll(6) }
+            { Fq6::mul_fq2_by_nonresidue() }
+            { Fq2::sub(0, 6) }
+            // [a0, a1, a2, t1, t4, s0, s1]
+
+            // compute s2 = t1 - t4
+            { Fq2::sub(6, 4) }
+            // [c0, c1, c2, s0, s1, s2]
+
+            // compute a1 = c2 * s1
+            { Fq2::copy(2) }
+            { s_a1 }
+            // [c0, c1, s0, s1, s2, a1]
+
+            // compute a2 = c1 * s2
+            { Fq2::copy(2) }
+            { s_a2 }
+            // [c0, s0, s1, s2, a1, a2]
+
+            // compute a3 = beta * (a1 + a2)
+            { Fq2::add(2, 0) }
+            { Fq6::mul_fq2_by_nonresidue() }
+            // [c0, s0, s1, s2, a3]
+
+            // compute t6 = c0 * s0 + a3
+            { Fq2::copy(6) }
+            // [c0, s0, s1, s2, a3, s0]
+            { s_t6 }
+            { Fq2::add(2, 0) }
+            // [t6aux, s0, s1, s2, t6]
+
+            // inverse t6
+            {Fq2::toaltstack()}
+            {Fq::roll(6)}
+            {Fq2::fromaltstack()}
+            { s_t6inv }
+            // [s0, s1, s2, t6]
+
+            // compute final c0 = s0 * t6
+            { Fq2::copy(0) }
+            { s_c0 }
+            // [s1, s2, t6, c0]
+
+            // compute final c1 = s1 * t6
+            { Fq2::copy(2) }
+            { s_c1 }
+            // [s2, t6, c0, c1]
+
+            // compute final c2 = s2 * t6
+            { s_c2 }
+            // [c0, c1, c2]
+        };
+    
+        return (scr, hints);
+    }
+
+
     pub fn inv() -> Script {
         script! {
             // compute t0 = c0^2, t1 = c1^2, t2 = c2^2
@@ -1018,7 +1185,7 @@ impl Fq6 {
 #[cfg(test)]
 mod test {
     use crate::bn254::fq6::Fq6;
-    use crate::bn254::utils::{fq2_push, fq2_push_not_montgomery, fq6_push, fq6_push_not_montgomery};
+    use crate::bn254::utils::{fq2_push, fq2_push_not_montgomery, fq6_push, fq6_push_not_montgomery, fq_push_not_montgomery};
     use crate::treepp::*;
     use ark_ff::Field;
     use ark_std::UniformRand;
@@ -1237,6 +1404,38 @@ mod test {
                 OP_TRUE
             };
             run(script);
+        }
+    }
+
+    #[test]
+    fn test_bn254_fq6_hinted_inv() {
+        let mut prng = ChaCha20Rng::seed_from_u64(1);
+
+        for _ in 0..1 {
+            let a = ark_bn254::Fq6::rand(&mut prng);
+            let b = a.inverse().unwrap();
+            let (_, hints) = Fq6::hinted_inv(a);
+            let (scr, _) = Fq6::hinted_inv(ark_bn254::Fq6::ONE);
+            let aux_t6 = Fq6::aux_hints_for_fp6_inv(a);
+            let len = scr.len();
+            
+            let script = script! {
+                for hint in hints {
+                    {hint.push()}
+                }
+                { fq_push_not_montgomery(aux_t6) } // auxilary hint
+                { fq6_push_not_montgomery(a) }
+                { scr }
+                { fq6_push_not_montgomery(b) }
+                { Fq6::equalverify() }
+                OP_TRUE
+            };
+
+            let res = execute_script(script);
+            for i in 0..res.final_stack.len() {
+                println!("{i:3}: {:?}", res.final_stack.get(i));
+            }
+            println!("fq6 inv len {} and stack {}", len, res.stats.max_nb_stack_items);
         }
     }
 


### PR DESCRIPTION
This PR requests addition of hinted Fp12 inverse.
It is useful because pairing operation makes use of auxiliary hint "[c](https://github.com/BitVM/BitVM/blob/main/src/groth16/offchain_checker.rs#L96)" and its inverse.

It seems cheaper to do the inverse directly on-script instead of receiving it as bit commitment input.
Script and max stack size used by a single joint script is  6,168,525 bytes and stack 1116 respectively.
This script can be split into 3 chunks with the intermediates hashed, each of these chunks fit within 4 MB and stack limit.

In total, the cost on Assert Tx is from having to bit commit 3 hashed elements.

Tests have been added and does not impact any other code.