### PR TITLE
fix: issue where precompute p function bakes runtime input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tmp
 
 # Bridge public and private files
 bridge_data/
+chunker_data*/

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ tmp
 
 # Bridge public and private files
 bridge_data/
-chunker_data*/

--- a/src/bn254/pairing.rs
+++ b/src/bn254/pairing.rs
@@ -1050,8 +1050,7 @@ mod test {
     use crate::bn254::fq2::Fq2;
     use crate::bn254::pairing::Pairing;
     use crate::bn254::utils::{
-        fq12_push, fq12_push_not_montgomery, fq2_push, fq2_push_not_montgomery, from_eval_point,
-        hinted_from_eval_point,
+        fq12_push, fq12_push_not_montgomery, fq2_push, fq2_push_not_montgomery, fq_push_not_montgomery, from_eval_point, hinted_from_eval_point
     };
     use crate::{execute_script_without_stack_limit, treepp::*};
     use ark_bn254::g2::G2Affine;
@@ -1353,9 +1352,21 @@ mod test {
             { Fq::push_u32_le_not_montgomery(&BigUint::from_str("0").unwrap().to_u32_digits()) }
 
             // p1, p2, p3, p4
+            {fq_push_not_montgomery(p1.y.inverse().unwrap())}
+            {fq_push_not_montgomery(p1.x)}
+            {fq_push_not_montgomery(p1.y)}
             { from_eval_p1 }
-            { from_eval_p2 }
-            { from_eval_p3 }
+            {fq_push_not_montgomery(p2.y.inverse().unwrap())}
+            {fq_push_not_montgomery(p2.x)}
+            {fq_push_not_montgomery(p2.y)}
+            {from_eval_p2 }// utils::from_eval_point(p2),
+            {fq_push_not_montgomery(p3.y.inverse().unwrap())}
+            {fq_push_not_montgomery(p3.x)}
+            {fq_push_not_montgomery(p3.y)}
+            {from_eval_p3 }// utils::from_eval_point(p3),
+            {fq_push_not_montgomery(p4.y.inverse().unwrap())}
+            {fq_push_not_montgomery(p4.x)}
+            {fq_push_not_montgomery(p4.y)}
             { from_eval_p4 }
 
             // q4

--- a/src/bn254/utils.rs
+++ b/src/bn254/utils.rs
@@ -373,8 +373,71 @@ pub fn from_eval_point(p: ark_bn254::G1Affine) -> Script {
     }
 }
 
+
 /// input of func (params):
 ///      p.x, p.y
+/// Input Hints On Stack
+///      tmul hints, p.y_inverse
+/// output on stack:
+///      x' = -p.x / p.y
+pub fn hinted_x_from_eval_point(p: ark_bn254::G1Affine, py_inv: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+    let mut hints = Vec::new();
+
+    let (hinted_script1, hint1) = Fq::hinted_mul(1, p.y, 0, py_inv);
+    let (hinted_script2, hint2) = Fq::hinted_mul(1, py_inv, 0, -p.x);
+    let script_lines = vec! [
+        // Stack: [hints, pyd, px, py] 
+        Fq::copy(2),
+        // Stack: [hints, pyd, px, py, pyd] 
+        hinted_script1,
+        Fq::push_one_not_montgomery(),
+        Fq::equalverify(1, 0),
+        // Stack: [hints, pyd, px]
+        Fq::neg(0),
+        // Stack: [hints, pyd, -px]
+        hinted_script2
+    ];
+
+    let mut script = script!{};
+    for script_line in script_lines {
+        script = script.push_script(script_line.compile());
+    }
+    hints.extend(hint1);
+    hints.extend(hint2);
+
+    (script, hints)
+}
+
+/// input of func (params):
+///      p.y
+/// Input Hints On Stack
+///      tmul hints, p.y_inverse
+/// output on stack:
+///      []
+pub fn hinted_y_from_eval_point(py: ark_bn254::Fq, py_inv: ark_bn254::Fq) -> (Script, Vec<Hint>) {
+    let mut hints = Vec::new();
+
+
+    let (hinted_script1, hint1) = Fq::hinted_mul(1, py_inv, 0, py);
+    let script_lines = vec! [
+        // [hints,..., pyd_calc, py]
+        hinted_script1,
+        {Fq::push_one_not_montgomery()},
+        {Fq::equalverify(1,0)}
+    ];
+    let mut script = script!{};
+    for script_line in script_lines {
+        script = script.push_script(script_line.compile());
+    }
+    hints.extend(hint1);
+
+    (script, hints)
+}
+
+/// input of func (params):
+///      p.x, p.y
+/// Input Hints On Stack
+///      tmul hints, p.y_inverse
 /// output on stack:
 ///      x' = -p.x / p.y
 ///      y' = 1 / p.y
@@ -383,34 +446,20 @@ pub fn hinted_from_eval_point(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
 
     let py_inv = p.y().unwrap().inverse().unwrap();
 
-    let (hinted_script1, hint1) = Fq::hinted_mul(2, py_inv, 0, p.y);
-    let (hinted_script2, hint2) = Fq::hinted_mul(2, py_inv, 0, -p.x);
-    let script_lines = vec![
-        Fq::push_u32_le_not_montgomery(&BigUint::from(py_inv).to_u32_digits()),
-        // [1/y]
-        // check p.y.inv() is valid
-        Fq::copy(0),
-        // [1/y, 1/y]
-        Fq::push_u32_le_not_montgomery(&BigUint::from(p.y).to_u32_digits()),
-        // [1/y, 1/y, y]
-        hinted_script1,
-        // [1/y, 1]
-        Fq::push_one_not_montgomery(),
-        // [1/y, 1, 1]
-        Fq::equalverify(1, 0),
-        // [1/y]
+    let (hinted_script1, hint1) = hinted_y_from_eval_point(p.y, py_inv);
+    let (hinted_script2, hint2) = hinted_x_from_eval_point(p, py_inv);
 
-        // -p.x / p.y
-        Fq::copy(0),
-        // [1/y, 1/y]
-        Fq::push_u32_le_not_montgomery(&BigUint::from(p.x).to_u32_digits()),
-        // [1/y, 1/y, x]
-        Fq::neg(0),
-        // [1/y, 1/y, -x]
+    let script_lines = vec![
+        // [hints, yinv, x, y]
+        Fq::copy(2),
+        Fq::copy(1),
+        hinted_script1,
+
+        // [hints, yinv, x, y]
+        Fq::copy(2),
+        Fq::toaltstack(),
         hinted_script2,
-        // [1/y, -x/y]
-        Fq::roll(1),
-        // [-x/y, 1/y]
+        Fq::fromaltstack(),
     ];
 
     let mut script = script! {};
@@ -1423,7 +1472,12 @@ mod test {
                 { tmp.push() }
             }
             { fq12_push_not_montgomery(f) }
+
+            { fq_push_not_montgomery(p.y.inverse().unwrap()) }
+            { fq_push_not_montgomery(p.x) }
+            { fq_push_not_montgomery(p.y) }
             { from_eval_point_script }
+
             { ell_by_constant_affine_script.clone() }
             { fq12_push_not_montgomery(hint) }
             { Fq12::equalverify() }
@@ -1450,18 +1504,62 @@ mod test {
 
     #[test]
     fn test_hinted_from_eval_point() {
-        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        let mut prng = ChaCha20Rng::seed_from_u64(1);
         let p = ark_bn254::G1Affine::rand(&mut prng);
-        let (ell_by_constant_affine_script, hints) = hinted_from_eval_point(p);
+        let (eval_scr, hints) = hinted_from_eval_point(p);
+        let pyinv = p.y.inverse().unwrap();
+
         let script = script! {
             for tmp in hints {
                 { tmp.push() }
             }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(pyinv).to_u32_digits()) } // aux hint
+
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.x).to_u32_digits()) } // input
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.y).to_u32_digits()) }
+            { eval_scr }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(-p.x / p.y).to_u32_digits()) } // expected output
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(pyinv).to_u32_digits()) }
+            { Fq2::equalverify() }
+            OP_TRUE
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+    }
+
+    #[test]
+    fn test_new_hintedx_from_eval_point() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        let p = ark_bn254::G1Affine::rand(&mut prng);
+        let (ell_by_constant_affine_script, hints) = hinted_x_from_eval_point(p, p.y.inverse().unwrap());
+        let script = script! {
+            for tmp in hints { 
+                { tmp.push() }
+            }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.y.inverse().unwrap()).to_u32_digits()) }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.x).to_u32_digits()) }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.y).to_u32_digits()) }
             { ell_by_constant_affine_script.clone() }
             { Fq::push_u32_le_not_montgomery(&BigUint::from(-p.x / p.y).to_u32_digits()) }
+            {Fq::equalverify(1,0)}
+            OP_TRUE
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+    }
+
+    #[test]
+    fn test_new_hintedy_from_eval_point() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        let p = ark_bn254::G1Affine::rand(&mut prng);
+        let (ell_by_constant_affine_script, hints) = hinted_y_from_eval_point(p.y, p.y.inverse().unwrap());
+        let script = script! {
+            for tmp in hints { 
+                { tmp.push() }
+            }
             { Fq::push_u32_le_not_montgomery(&BigUint::from(p.y.inverse().unwrap()).to_u32_digits()) }
-            { Fq::equalverify(2, 0) }
-            { Fq::equalverify(1, 0) }
+            { Fq::push_u32_le_not_montgomery(&BigUint::from(p.y).to_u32_digits()) }
+            { ell_by_constant_affine_script.clone() }
             OP_TRUE
         };
         let exec_result = execute_script(script);

--- a/src/chunker/chunk_evaluate_line.rs
+++ b/src/chunker/chunk_evaluate_line.rs
@@ -179,7 +179,11 @@ mod test {
             for tmp in hints {
                 { tmp.push() }
             }
+
             { fq12_push_not_montgomery(f) }
+            { fq_push_not_montgomery(p.y.inverse().unwrap()) }
+            { fq_push_not_montgomery(p.x) }
+            { fq_push_not_montgomery(p.y) }
             { from_eval_point_script }
             { ell_by_constant_affine_script.clone() }
             { fq12_push_not_montgomery(hint) }

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -8,8 +8,7 @@ use crate::bn254::msm::{
 };
 use crate::bn254::pairing::Pairing;
 use crate::bn254::utils::{
-    fq12_push, fq12_push_not_montgomery, fq2_push, fq2_push_not_montgomery, from_eval_point,
-    hinted_from_eval_point, Hint,
+    fq12_push, fq12_push_not_montgomery, fq2_push, fq2_push_not_montgomery, fq_push_not_montgomery, from_eval_point, hinted_from_eval_point, Hint
 };
 use crate::groth16::constants::{LAMBDA, P_POW3};
 use crate::groth16::offchain_checker::compute_c_wi;
@@ -207,8 +206,17 @@ impl Verifier {
             hinted_script2, // Fq::mul()
             Fq::roll(1),
             // variants of G1 points
+            {fq_push_not_montgomery(p2.y.inverse().unwrap())},
+            {fq_push_not_montgomery(p2.x)},
+            {fq_push_not_montgomery(p2.y)},
             hinted_script3, // utils::from_eval_point(p2),
+            {fq_push_not_montgomery(p3.y.inverse().unwrap())},
+            {fq_push_not_montgomery(p3.x)},
+            {fq_push_not_montgomery(p3.y)},
             hinted_script4, // utils::from_eval_point(p3),
+            {fq_push_not_montgomery(p4.y.inverse().unwrap())},
+            {fq_push_not_montgomery(p4.x)},
+            {fq_push_not_montgomery(p4.y)},
             hinted_script5, // utils::from_eval_point(p4),
             // the only non-fixed G2 point, say q4
             fq2_push_not_montgomery(q4.x),


### PR DESCRIPTION
A function that is supposed to assume runtime input in stack had hardcoded those values on script. This PR fixes the issue.
The function hinted_from_eval_point is used to calculate p'x and p'y given px and py.
The values of px and py are part of groth16 proof.

Unit tests have been added for the function changed.

The function was used in test units, all of which have been appropriately modified i.e. now receive 'p' on stack.