### PR TITLE
fix: ensure same coeff in function hinted_ell_by_constant_affine

### DIFF
--- a/src/bn254/pairing.rs
+++ b/src/bn254/pairing.rs
@@ -527,7 +527,7 @@ impl Pairing {
                 fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
                 let (hinted_script, hint) =
-                    hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                    hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
                 scripts.push(hinted_script);
                 hints.extend(hint);
                 f = fx;
@@ -577,7 +577,7 @@ impl Pairing {
                     c2new.mul_assign_by_fp(&(p.y.inverse().unwrap()));
                     fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
-                    let (hinted_script, hint) = hinted_ell_by_constant_affine(
+                    let (hinted_script, hint) = hinted_ell_by_constant_affine_and_sparse_mul(
                         f,
                         -p.x / p.y,
                         p.y.inverse().unwrap(),
@@ -672,7 +672,7 @@ impl Pairing {
             fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
             let (hinted_script, hint) =
-                hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
             scripts.push(hinted_script);
             hints.extend(hint);
             f = fx;
@@ -760,7 +760,7 @@ impl Pairing {
             fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
             let (hinted_script, hint) =
-                hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
             scripts.push(hinted_script);
             hints.extend(hint);
             f = fx;

--- a/src/chunker/chunk_evaluate_line.rs
+++ b/src/chunker/chunk_evaluate_line.rs
@@ -146,7 +146,7 @@ mod test {
         // affine mode
         let coeffs = G2Prepared::from_affine(b);
         let (from_eval_point_script, hints_eval) = hinted_from_eval_point(p);
-        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine(
+        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine_and_sparse_mul(
             f,
             -p.x / p.y,
             p.y.inverse().unwrap(),


### PR DESCRIPTION
Currently hinted_ell_by_constant_affine function does line evaluation plus fp12 multiplication ("mul_by_34") of the obtained evaluation with the accumulator. The total script size consumed by this function is slightly higher than what is convenient to fit inside a tapscript. As such, implementations (like chunker) have been breaking them manually instead of making using this function.
So first task is to separate the line eval and mul_by_34 part into two utility functions so that they can be used separately.

Secondly, line evaluation is used in conjunction with other line operations like point_add, check_line_through_point, etc. To ensure the same line coefficient is used by this function and the rest, we will assume line coefficients to be available on stack. This PR makes this adjustment.

To ensure the existing functionality (e.g. unchunked groth16 verifier test modules) isn't broken, a replacement function "hinted_ell_by_constant_affine_and_sparse_mul" has been substituted though it is not used with a chunker.

Tests have been added for each.