### PR TITLE
fix: ensure same line coeff in  g2 affine dbl and add

### DIFF
--- a/src/bn254/pairing.rs
+++ b/src/bn254/pairing.rs
@@ -527,7 +527,7 @@ impl Pairing {
                 fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
                 let (hinted_script, hint) =
-                    hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                    hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
                 scripts.push(hinted_script);
                 hints.extend(hint);
                 f = fx;
@@ -577,7 +577,7 @@ impl Pairing {
                     c2new.mul_assign_by_fp(&(p.y.inverse().unwrap()));
                     fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
-                    let (hinted_script, hint) = hinted_ell_by_constant_affine(
+                    let (hinted_script, hint) = hinted_ell_by_constant_affine_and_sparse_mul(
                         f,
                         -p.x / p.y,
                         p.y.inverse().unwrap(),
@@ -672,7 +672,7 @@ impl Pairing {
             fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
             let (hinted_script, hint) =
-                hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
             scripts.push(hinted_script);
             hints.extend(hint);
             f = fx;
@@ -760,7 +760,7 @@ impl Pairing {
             fx.mul_by_034(&coeffs.0, &c1new, &c2new);
 
             let (hinted_script, hint) =
-                hinted_ell_by_constant_affine(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
+                hinted_ell_by_constant_affine_and_sparse_mul(f, -p.x / p.y, p.y.inverse().unwrap(), coeffs);
             scripts.push(hinted_script);
             hints.extend(hint);
             f = fx;

--- a/src/bn254/utils.rs
+++ b/src/bn254/utils.rs
@@ -7,6 +7,8 @@ use crate::bn254::fr::Fr;
 use crate::bn254::{fq12::Fq12, fq2::Fq2};
 use ark_ec::{bn::BnConfig, AffineRepr};
 use ark_ff::Field;
+use bitcoin::opcodes::all::OP_DUP;
+use bitcoin::ScriptBuf;
 use ark_ff::{AdditiveGroup, BigInt};
 use num_bigint::BigUint;
 
@@ -125,7 +127,6 @@ impl Hint {
         }
     }
 }
-
 // input:
 //  f            12 elements
 //  coeffs.c0    2 elements
@@ -226,7 +227,7 @@ pub fn ell_by_constant_affine(constant: &EllCoeff) -> Script {
     }
 }
 
-pub fn hinted_ell_by_constant_affine(
+pub fn hinted_ell_by_constant_affine_and_sparse_mul(
     f: ark_bn254::Fq12,
     x: ark_bn254::Fq,
     y: ark_bn254::Fq,
@@ -235,37 +236,22 @@ pub fn hinted_ell_by_constant_affine(
     assert_eq!(constant.0, ark_bn254::Fq2::ONE);
     let mut hints = Vec::new();
 
-    let (hinted_script1, hint1) = Fq::hinted_mul_by_constant(x, &constant.1.c0);
-    let (hinted_script2, hint2) = Fq::hinted_mul_by_constant(x, &constant.1.c1);
-    let (hinted_script3, hint3) = Fq::hinted_mul_by_constant(y, &constant.2.c0);
-    let (hinted_script4, hint4) = Fq::hinted_mul_by_constant(y, &constant.2.c1);
+    let (hinted_script_ell, hint_ell) = hinted_ell_by_constant_affine(x, y, constant.1, constant.2);
+
     let mut c1 = constant.1;
     c1.mul_assign_by_fp(&x);
     let mut c2 = constant.2;
     c2.mul_assign_by_fp(&y);
     let (hinted_script5, hint5) = Fq12::hinted_mul_by_34(f, c1, c2);
 
-    let script_lines = vec![
-        // [f, x', y']
-        // update c1, c1' = x' * c1
-        Fq::copy(1),
-        hinted_script1,
-        // [f, x', y', x' * c1.0]
-        Fq::roll(2),
-        hinted_script2,
-        // [f, y', x' * c1.0, x' * c1.1]
-        // [f, y', x' * c1]
-
-        // update c2, c2' = -y' * c2
-        Fq::copy(2),
-        hinted_script3, // Fq::mul_by_constant(&constant.2.c0),
-        // [f, y', x' * c1, y' * c2.0]
-        Fq::roll(3),
-        hinted_script4,
-        // [f, x' * c1, y' * c2.0, y' * c2.1]
-        // [f, x' * c1, y' * c2]
+    let script_lines: Vec<Script> = vec![
+        // [slope, bias, f,  x', y']
+        {Fq2::roll(16)}, {Fq2::roll(16)},
+        // [f, x', y', slope, bias]
+        {Fq2::roll(4)},
+        // [f, slope, bias, x', y']
+        hinted_script_ell,
         // [f, c1', c2']
-
         // compute the new f with c1'(c3) and c2'(c4), where c1 is trival value 1
         hinted_script5,
         // [f]
@@ -275,13 +261,73 @@ pub fn hinted_ell_by_constant_affine(
     for script_line in script_lines {
         script = script.push_script(script_line.compile());
     }
+    hints.extend(hint_ell);
+    hints.extend(hint5);
+
+    hints.extend_from_slice(&vec![
+        Hint::Fq(constant.1.c0),
+        Hint::Fq(constant.1.c1),
+        Hint::Fq(constant.2.c0),
+        Hint::Fq(constant.2.c1),
+    ]);
+
+    (script, hints)
+}
+
+
+pub fn hinted_ell_by_constant_affine(x: ark_bn254::Fq, y: ark_bn254::Fq, slope: ark_bn254::Fq2, bias: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
+    let mut hints = Vec::new();
+
+    let (hinted_script1, hint1) = Fq::hinted_mul(1, x, 0, slope.c0);
+    let (hinted_script2, hint2) = Fq::hinted_mul(1, x, 0, slope.c1);
+    let (hinted_script3, hint3) = Fq::hinted_mul(1, y, 0, bias.c0);
+    let (hinted_script4, hint4) = Fq::hinted_mul(1, y, 0, bias.c1);
+
+
+    let script_lines = vec! [
+        // [slope, bias, x', y']
+        // update c1, c1' = x' * c1
+        Fq::copy(1),
+        // [slope0, slope1, bias0, bias1, x', y', x']
+        Fq::roll(6),
+        // [slope1, bias0, bias1, x', y', x', slope0]
+        hinted_script1,
+        // [slope1, bias0, bias1, x', y', x'* slope0]
+
+        Fq::roll(2),
+        // [slope1, bias0, bias1, y', x'* slope0, x']
+        Fq::roll(5),
+        // [bias0, bias1, y', x'* slope0, x', slope1]
+        hinted_script2,
+        // [bias0, bias1, y', x'* slope0, x'* slope1]
+
+        // update c2, c2' = -y' * c2
+        Fq::copy(2),
+        // [bias0, bias1, y', x'* slope0, x'* slope1, y']
+        Fq::roll(5),
+        // [bias1, y', x'* slope0, x'* slope1, y', bias0]
+        hinted_script3,  
+        // [bias1, y', x'* slope0, x'* slope1, y'*bias0]
+        Fq::roll(3),
+        // [bias1, x'* slope0, x'* slope1, y'*bias0, y']
+        Fq::roll(4),
+        // [x'* slope0, x'* slope1, y'*bias0, y', bias1]
+        hinted_script4,
+        // [x'* slope0, x'* slope1, y'*bias0, y'* bias1]
+
+    ];
+
+    let mut script = script!{};
+    for script_line in script_lines {
+        script = script.push_script(script_line.compile());
+    }
     hints.extend(hint1);
     hints.extend(hint2);
     hints.extend(hint3);
     hints.extend(hint4);
-    hints.extend(hint5);
-
+    
     (script, hints)
+
 }
 
 pub fn collect_line_coeffs(
@@ -472,6 +518,7 @@ pub fn hinted_from_eval_point(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
     (script, hints)
 }
 
+
 /// input of stack:
 ///      p.x, p.y (affine space)
 /// output on stack:
@@ -576,22 +623,21 @@ pub fn affine_add_line(c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> Script {
     }
 }
 
-pub fn hinted_affine_add_line(
-    tx: ark_bn254::Fq2,
-    qx: ark_bn254::Fq2,
-    c3: ark_bn254::Fq2,
-    c4: ark_bn254::Fq2,
-) -> (Script, Vec<Hint>) {
-    let mut hints = Vec::new();
 
-    let (hinted_script0, hint0) = Fq2::hinted_square(c3);
-    let (hinted_script1, hint1) = Fq2::hinted_mul(4, c3, 0, c3.square() - tx - qx);
-    let script0 = script! {
-        for _ in 0..<Fq as crate::bn254::fp254impl::Fp254Impl>::N_LIMBS {
-            OP_DEPTH OP_1SUB OP_ROLL // hints
-        }
-    };
-    let script_lines = vec![
+pub fn hinted_affine_add_line(tx: ark_bn254::Fq2, qx: ark_bn254::Fq2, c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
+    let mut hints = Vec::new();
+    let (hsc, hts) = Fq2::hinted_square(c3);
+    let (hinted_script1, hint1) = Fq2::hinted_mul(4, c3, 0, c3.square()-tx-qx);
+
+    let script_lines = vec! [
+        // [alpha, bias, tx, qx]
+        Fq2::toaltstack(),
+        Fq2::toaltstack(),
+        Fq2::roll(2),
+        Fq2::fromaltstack(),
+        Fq2::fromaltstack(),
+        // [bias, alpha, tx, qx]
+
         // [T.x, Q.x]
         Fq2::neg(0),
         // [T.x, -Q.x]
@@ -601,13 +647,9 @@ pub fn hinted_affine_add_line(
         // [-T.x - Q.x]
         Fq2::add(2, 0),
         // [-T.x - Q.x]
-        // fq2_push_not_montgomery(c3),
-        script0.clone(),
-        script0.clone(),
+        Fq2::roll(2),
         Fq2::copy(0),
-        // [-T.x - Q.x, alpha]
-        // fq2_push_not_montgomery(c3.square()),
-        hinted_script0,
+        hsc,
         // [-T.x - Q.x, alpha, alpha^2]
         // calculate x' = alpha^2 - T.x - Q.x
         Fq2::add(4, 0),
@@ -619,27 +661,22 @@ pub fn hinted_affine_add_line(
         Fq2::neg(0),
         // [x', -alpha * x']
         // fq2_push_not_montgomery(c4),
-        script0.clone(),
-        script0.clone(),
         // [x', -alpha * x', -bias]
         // compute y' = -bias - alpha * x'
-        Fq2::add(2, 0),
+        Fq2::add(4, 0),
         // [x', y']
     ];
 
-    let mut script = script! {};
+    let mut script = script!{};
     for script_line in script_lines {
         script = script.push_script(script_line.compile());
     }
-    hints.push(Hint::Fq(c3.c0));
-    hints.push(Hint::Fq(c3.c1));
-    hints.extend(hint0);
+    hints.extend(hts);
     hints.extend(hint1);
-    hints.push(Hint::Fq(c4.c0));
-    hints.push(Hint::Fq(c4.c1));
 
     (script, hints)
 }
+
 
 /// double a point T:
 ///     x' = alpha^2 - 2 * T.x
@@ -673,30 +710,26 @@ pub fn affine_double_line(c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> Script {
     }
 }
 
-pub fn hinted_affine_double_line(
-    tx: ark_bn254::Fq2,
-    c3: ark_bn254::Fq2,
-    c4: ark_bn254::Fq2,
-) -> (Script, Vec<Hint>) {
+pub fn hinted_affine_double_line(tx: ark_bn254::Fq2, c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
     let mut hints = Vec::new();
 
-    let (hinted_script0, hint0) = Fq2::hinted_square(c3);
-    let (hinted_script1, hint1) = Fq2::hinted_mul(4, c3, 0, c3.square() - tx - tx);
-    let script0 = script! {
-        for _ in 0..<Fq as crate::bn254::fp254impl::Fp254Impl>::N_LIMBS {
-            OP_DEPTH OP_1SUB OP_ROLL // hints
-        }
-    };
-    let script_lines = vec![
+    let (hsc, hts) = Fq2::hinted_square(c3);
+    let (hinted_script1, hint1) = Fq2::hinted_mul(4, c3, 0, c3.square()-tx-tx);
+
+    let script_lines = vec! [
+        // [alpha, bias, tx]
+        Fq2::toaltstack(),
+        Fq2::roll(2),
+        Fq2::fromaltstack(),
+        // [bias, alpha, tx]
+
         Fq2::double(0),
         Fq2::neg(0),
-        // [- 2 * T.x]
-        // fq2_push_not_montgomery(c3),
-        script0.clone(),
-        script0.clone(),
+        // [alpha, - 2 * T.x]
+        Fq2::roll(2),
         Fq2::copy(0),
+        hsc,
         // fq2_push_not_montgomery(c3.square()),
-        hinted_script0,
         // [- 2 * T.x, alpha, alpha^2]
         Fq2::add(4, 0),
         Fq2::copy(0),
@@ -704,27 +737,22 @@ pub fn hinted_affine_double_line(
         hinted_script1,
         Fq2::neg(0),
         // [x', -alpha * x']
-        // fq2_push_not_montgomery(c4),
-        script0.clone(),
-        script0.clone(),
-        Fq2::add(2, 0),
+
+        Fq2::add(4, 0),
         // [x', y']
     ];
 
-    let mut script = script! {};
+    let mut script = script!{};
+
     for script_line in script_lines {
         script = script.push_script(script_line.compile());
     }
-
-    hints.push(Hint::Fq(c3.c0));
-    hints.push(Hint::Fq(c3.c1));
-    hints.extend(hint0);
+    hints.extend(hts);
     hints.extend(hint1);
-    hints.push(Hint::Fq(c4.c0));
-    hints.push(Hint::Fq(c4.c1));
 
     (script, hints)
 }
+
 
 /// check line through one point, that is:
 ///     y - alpha * x - bias = 0
@@ -762,40 +790,43 @@ pub fn check_line_through_point(c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> Scrip
     }
 }
 
-pub fn hinted_check_line_through_point(
-    x: ark_bn254::Fq2,
+
+pub fn hinted_check_tangent_line(
+    t: ark_bn254::G2Affine,
     c3: ark_bn254::Fq2,
     c4: ark_bn254::Fq2,
 ) -> (Script, Vec<Hint>) {
-    let mut hints: Vec<Hint> = Vec::new();
+    let mut hints = Vec::new();
 
-    let (hinted_script1, hint1) = Fq2::hinted_mul_by_constant_stable(x, &c3);
+    let (hinted_script1, hint1) = Fq2::hinted_mul(2, t.y.double(), 0, c3);
+    let (hinted_script2, hint2) = Fq2::hinted_square(t.x);
+    let (hinted_script3, hint3) = hinted_check_line_through_point(t.x, c3, c4);
 
-    let script0 = script! {
-        for _ in 0..<Fq as crate::bn254::fp254impl::Fp254Impl>::N_LIMBS {
-            OP_DEPTH OP_1SUB OP_ROLL // hints
-        }
-    };
-
+    // [a, b, x, y]
     let script_lines = vec![
-        // [x, y]
-        Fq2::roll(2),
-        // [y, x]
+        // alpha * (2 * T.y) = 3 * T.x^2
+        Fq2::copy(0),
+        Fq2::double(0),
+        // [a, b, x, y, 2y]
+        Fq2::copy(8),
+        // [a, b, x, y, 2y, a]
         hinted_script1,
-        // [y, alpha * x]
+        // [T.x, T.y, alpha * (2 * T.y)]
+        Fq2::copy(4),
+        hinted_script2,
+        Fq2::copy(0),
+        Fq2::double(0),
+        Fq2::add(2, 0),
+        // [T.x, T.y, alpha * (2 * T.y), 3 * T.x^2]
         Fq2::neg(0),
-        // [y, -alpha * x]
         Fq2::add(2, 0),
-        // [y - alpha * x]
-        // fq2_push_not_montgomery(c4),
-        script0.clone(),
-        script0.clone(),
-        // [y - alpha * x, -bias]
-        Fq2::add(2, 0),
-        // [y - alpha * x - bias]
         Fq2::push_zero(),
-        // [y - alpha * x - bias, 0]
         Fq2::equalverify(),
+        // [T.x, T.y]
+
+        // check: T.y - alpha * T.x - bias = 0
+        hinted_script3,
+        // []
     ];
 
     let mut script = script! {};
@@ -803,12 +834,47 @@ pub fn hinted_check_line_through_point(
         script = script.push_script(script_line.compile());
     }
     hints.extend(hint1);
-    hints.push(Hint::Fq(c4.c0));
-    hints.push(Hint::Fq(c4.c1));
-
+    hints.extend(hint2);
+    hints.extend(hint3);
 
     (script, hints)
 }
+
+
+
+pub fn hinted_check_line_through_point(x: ark_bn254::Fq2, c3: ark_bn254::Fq2, _c4: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
+    let mut hints: Vec<Hint> = Vec::new();
+    
+    let (hinted_script1, hint1) = Fq2::hinted_mul(2, x,0, c3);
+
+    let script_lines = vec![
+        // [alpha, bias, x, y ]
+        Fq2::roll(2),
+        // [alpha, bias, y, x ]
+        Fq2::roll(6),
+        hinted_script1,
+        // [bias, y, alpha * x]
+        Fq2::neg(0),
+        // [bias, y, -alpha * x]
+        Fq2::add(2, 0),
+        // [bias, y - alpha * x]
+        Fq2::add(2, 0),
+        // [y - alpha * x - bias]
+
+        Fq2::push_zero(),
+        // [y - alpha * x - bias, 0]
+        Fq2::equalverify(),
+    ];
+
+    let mut script = script!{};
+    for script_line in script_lines {
+        script = script.push_script(script_line.compile());
+    }
+    hints.extend(hint1);
+
+    (script, hints)
+}
+
 
 /// check whether a tuple coefficient (alpha, -bias) of a tangent line is satisfied with expected point T (affine)
 /// two aspects:
@@ -850,51 +916,6 @@ pub fn check_tangent_line(c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> Script {
     }
 }
 
-pub fn hinted_check_tangent_line(
-    t: ark_bn254::G2Affine,
-    c3: ark_bn254::Fq2,
-    c4: ark_bn254::Fq2,
-) -> (Script, Vec<Hint>) {
-    let mut hints = Vec::new();
-
-    let (hinted_script1, hint1) = Fq2::hinted_mul_by_constant_stable(t.y.double(), &c3);
-    let (hinted_script2, hint2) = Fq2::hinted_square(t.x);
-    let (hinted_script3, hint3) = hinted_check_line_through_point(t.x, c3, c4);
-
-    let script_lines = vec![
-        // alpha * (2 * T.y) = 3 * T.x^2
-        Fq2::copy(0),
-        Fq2::double(0),
-        hinted_script1,
-        // [T.x, T.y, alpha * (2 * T.y)]
-        Fq2::copy(4),
-        hinted_script2,
-        Fq2::copy(0),
-        Fq2::double(0),
-        Fq2::add(2, 0),
-        // [T.x, T.y, alpha * (2 * T.y), 3 * T.x^2]
-        Fq2::neg(0),
-        Fq2::add(2, 0),
-        Fq2::push_zero(),
-        Fq2::equalverify(),
-        // [T.x, T.y]
-
-        // check: T.y - alpha * T.x - bias = 0
-        hinted_script3,
-        // []
-    ];
-
-    let mut script = script! {};
-    for script_line in script_lines {
-        script = script.push_script(script_line.compile());
-    }
-    hints.extend(hint1);
-    hints.extend(hint2);
-    hints.extend(hint3);
-
-    (script, hints)
-}
-
 /// check whether a tuple coefficient (alpha, -bias) of a chord line is satisfied with expected points T and Q (both are affine cooordinates)
 /// two aspects:
 ///     1. T.y - alpha * T.x - bias = 0
@@ -922,24 +943,39 @@ pub fn check_chord_line(c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> Script {
     }
 }
 
-pub fn hinted_check_chord_line(
-    t: ark_bn254::G2Affine,
-    q: ark_bn254::G2Affine,
-    c3: ark_bn254::Fq2,
-    c4: ark_bn254::Fq2,
-) -> (Script, Vec<Hint>) {
+pub fn hinted_check_chord_line(t: ark_bn254::G2Affine, q: ark_bn254::G2Affine, c3: ark_bn254::Fq2, c4: ark_bn254::Fq2) -> (Script, Vec<Hint>) {
     let mut hints = Vec::new();
 
-    let (mut script, hint1) = hinted_check_line_through_point(q.x, c3, c4);
-    let (script2, hint2) = hinted_check_line_through_point(t.x, c3, c4);
+    let (script1, hint1) = hinted_check_line_through_point(t.x, c3, c4);
+    let (script2, hint2) = hinted_check_line_through_point(q.x, c3, c4);
 
-    script = script.push_script(script2.compile());
+
+    // [a, b, tx, ty, qx, qy]
+    let script_lines = vec![
+        {Fq2::toaltstack()},
+        {Fq2::toaltstack()},
+        {Fq2::copy(6)}, 
+        {Fq2::copy(6)},
+        {Fq2::toaltstack()},
+        {Fq2::toaltstack()},
+        script1, // t
+        {Fq2::fromaltstack()}, 
+        {Fq2::fromaltstack()}, 
+        {Fq2::fromaltstack()}, 
+        {Fq2::fromaltstack()}, 
+        script2, //q
+    ];
+    let mut script = script!{};
+    for script_line in script_lines {
+        script = script.push_script(script_line.compile());
+    }
 
     hints.extend(hint1);
     hints.extend(hint2);
 
     (script, hints)
 }
+
 
 // stack data: beta^{2 * (p - 1) / 6}, beta^{3 * (p - 1) / 6}, beta^{2 * (p^2 - 1) / 6}, 1/2, B,
 // P1, P2, P3, P4, Q4, c, c', wi, f, Px, Py, Tx, Ty, Tz, Qx, Qy
@@ -1290,12 +1326,17 @@ pub fn double_line() -> Script {
     }
 }
 
+
+
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bn254::fq2::Fq2;
+    use crate::bn254::{ fq2::Fq2};
+    use ark_bn254::G2Affine;
     use ark_ff::AdditiveGroup;
     use ark_std::UniformRand;
+    use bitcoin::opcodes::OP_TRUE;
     use num_traits::One;
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
@@ -1431,6 +1472,53 @@ mod test {
     fn test_hinted_ell_by_constant_affine() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
 
+        let b = ark_bn254::g2::G2Affine::rand(&mut prng);
+        let p = ark_bn254::g1::G1Affine::rand(&mut prng);
+
+        // affine mode
+        let coeffs = G2Prepared::from_affine(b).ell_coeffs[0];
+        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine(
+            p.x,
+            p.y,
+            coeffs.1,
+            coeffs.2,
+        );
+        println!(
+            "Pairing.ell_by_constant_affine: {} bytes",
+            ell_by_constant_affine_script.len()
+        );
+
+        let script = script! {
+            for tmp in hints {
+                { tmp.push() }
+            }
+            // aux hints: Ellcoeffs: [slope, biasminus]
+            { fq2_push_not_montgomery(coeffs.1) } // slope
+            { fq2_push_not_montgomery(coeffs.2) } // biasminus
+
+            // runtime input: P
+            { fq_push_not_montgomery(p.x) }
+            { fq_push_not_montgomery(p.y) }
+            { ell_by_constant_affine_script }
+
+            // validate output
+            {fq_push_not_montgomery(coeffs.2.c0 * p.y)}
+            {fq_push_not_montgomery(coeffs.2.c1 * p.y)}
+            { Fq2::equalverify() }
+
+            {fq_push_not_montgomery(coeffs.1.c0 * p.x)}
+            {fq_push_not_montgomery(coeffs.1.c1 * p.x)}
+            { Fq2::equalverify() }
+            OP_TRUE
+        };
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);        
+    }
+
+    #[test]
+    fn test_hinted_ell_by_constant_affine_and_sparse_mul() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+
         let f = ark_bn254::Fq12::rand(&mut prng);
         let b = ark_bn254::g2::G2Affine::rand(&mut prng);
         let p = ark_bn254::g1::G1Affine::rand(&mut prng);
@@ -1438,7 +1526,7 @@ mod test {
         // affine mode
         let coeffs = G2Prepared::from_affine(b);
         let (from_eval_point_script, hints_eval) = hinted_from_eval_point(p);
-        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine(
+        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine_and_sparse_mul(
             f,
             -p.x / p.y,
             p.y.inverse().unwrap(),
@@ -1528,7 +1616,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_hintedx_from_eval_point() {
+    fn test_hintedx_from_eval_point() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         let p = ark_bn254::G1Affine::rand(&mut prng);
         let (ell_by_constant_affine_script, hints) = hinted_x_from_eval_point(p, p.y.inverse().unwrap());
@@ -1549,7 +1637,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_hintedy_from_eval_point() {
+    fn test_hintedy_from_eval_point() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         let p = ark_bn254::G1Affine::rand(&mut prng);
         let (ell_by_constant_affine_script, hints) = hinted_y_from_eval_point(p.y, p.y.inverse().unwrap());
@@ -1622,6 +1710,8 @@ mod test {
             for hint in hints {
                 { hint.push() }
             }
+            { fq2_push_not_montgomery(alpha) }
+            { fq2_push_not_montgomery(bias_minus) }
             { fq2_push_not_montgomery(t.x) }
             { fq2_push_not_montgomery(q.x) }
             { hinted_add_line.clone() }
@@ -1684,6 +1774,38 @@ mod test {
     }
 
     #[test]
+    fn test_hinted_check_line_through_point() {
+        let mut prng = ChaCha20Rng::seed_from_u64(0);
+        let t = ark_bn254::G2Affine::rand(&mut prng);
+        let two_inv = ark_bn254::Fq::one().double().inverse().unwrap();
+        let three_div_two = (ark_bn254::Fq::one().double() + ark_bn254::Fq::one()) * two_inv;
+        let mut alpha = t.x.square();
+        alpha /= t.y;
+        alpha.mul_assign_by_fp(&three_div_two);
+        // -bias
+        let bias_minus = alpha * t.x - t.y;
+
+        let (scr, hints) = hinted_check_line_through_point(t.x, alpha, bias_minus);
+        println!("hinted_check_line_through_point: {}", scr.len());
+
+        let script = script! {
+            for hint in hints {
+                { hint.push() }
+            }
+            { fq2_push_not_montgomery(alpha) }
+            { fq2_push_not_montgomery(bias_minus) }
+            
+            { fq2_push_not_montgomery(t.x) }
+            { fq2_push_not_montgomery(t.y) }
+            {scr}
+            OP_TRUE
+        };
+        assert!(execute_script(script).success);
+
+
+    }
+
+    #[test]
     fn test_hinted_affine_double_line() {
         // slope: alpha = 3 * x^2 / 2 * y
         // intercept: bias = y - alpha * x
@@ -1708,6 +1830,8 @@ mod test {
             for hint in hints {
                 { hint.push() }
             }
+            { fq2_push_not_montgomery(alpha) }
+            { fq2_push_not_montgomery(bias_minus) }
             { fq2_push_not_montgomery(t.x) }
             { hinted_double_line }
             // [x']
@@ -1766,12 +1890,14 @@ mod test {
         let bias_minus = alpha * t.x - t.y;
         assert_eq!(alpha * t.x - t.y, bias_minus);
 
-        let (hinted_check_line, hints) = hinted_check_line_through_point(t.x, alpha, bias_minus);
+        let (hinted_check_line, hints) = hinted_check_tangent_line(t, alpha, bias_minus);
 
         let script = script! {
             for hint in hints {
                 { hint.push() }
             }
+            { fq2_push_not_montgomery(alpha) }
+            { fq2_push_not_montgomery(bias_minus) }
             { fq2_push_not_montgomery(t.x) }
             { fq2_push_not_montgomery(t.y) }
             { hinted_check_line.clone() }
@@ -1822,6 +1948,8 @@ mod test {
             for hint in hints {
                 { hint.push() }
             }
+            { fq2_push_not_montgomery(alpha) }
+            { fq2_push_not_montgomery(bias_minus) }
             { fq2_push_not_montgomery(t.x) }
             { fq2_push_not_montgomery(t.y) }
             { fq2_push_not_montgomery(q.x) }
@@ -1837,4 +1965,5 @@ mod test {
             exec_result.stats.max_nb_stack_items
         );
     }
+
 }

--- a/src/chunker/chunk_evaluate_line.rs
+++ b/src/chunker/chunk_evaluate_line.rs
@@ -146,7 +146,7 @@ mod test {
         // affine mode
         let coeffs = G2Prepared::from_affine(b);
         let (from_eval_point_script, hints_eval) = hinted_from_eval_point(p);
-        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine(
+        let (ell_by_constant_affine_script, hints) = hinted_ell_by_constant_affine_and_sparse_mul(
             f,
             -p.x / p.y,
             p.y.inverse().unwrap(),

--- a/src/chunker/chunk_non_fixed_point.rs
+++ b/src/chunker/chunk_non_fixed_point.rs
@@ -56,6 +56,13 @@ pub fn chunk_q4<T: BCAssigner>(
                 let t4x = ark_bn254::G2Affine::new(x, y);
 
                 let mut hints = vec![];
+                hints.extend_from_slice(&vec![
+                    Hint::Fq(line_coeffs[num_lines - (i + 2)][j][0].1.c0), 
+                    Hint::Fq(line_coeffs[num_lines - (i + 2)][j][0].1.c1), 
+                    Hint::Fq(line_coeffs[num_lines - (i + 2)][j][0].2.c0), 
+                    Hint::Fq(line_coeffs[num_lines - (i + 2)][j][0].2.c1),
+                ]);
+
                 let (hinted_script0, hint) = hinted_check_tangent_line(
                     t4,
                     line_coeffs[num_lines - (i + 2)][j][0].1,
@@ -78,9 +85,19 @@ pub fn chunk_q4<T: BCAssigner>(
                         { Fq2::copy(2) }
                         { Fq2::toaltstack() }
                         // [t4 | t4.x]
+                        for _ in 0..4 {
+                            for _ in 0..Fq::N_LIMBS {
+                                OP_DEPTH OP_1SUB OP_ROLL 
+                            }  
+                        } 
+                        // [t4.x, t4.y, a, b | t4.x]
+                        {Fq2::copy(2)} {Fq2::copy(2)}
+                        // [t4.x, t4.y, a, b, a, b | t4.x]
+                        {Fq2::roll(10)} {Fq2::roll(10)}
+                        // [a, b, a, b, t4 | t4.x]
                         {hinted_script0}
                         { Fq2::fromaltstack() }
-                        // [t4.x]
+                        // [a, b, t4.x]
                         {hinted_script1}
                         // [t4']
                     },
@@ -102,7 +119,14 @@ pub fn chunk_q4<T: BCAssigner>(
             for j in 0..num_line_groups {
                 if j == num_constant {
                     let mut script = script! {};
+
                     let mut hints = vec![];
+                    hints.extend_from_slice(&vec![
+                        Hint::Fq(line_coeffs[num_lines - (i + 2)][j][1].1.c0), 
+                        Hint::Fq(line_coeffs[num_lines - (i + 2)][j][1].1.c1), 
+                        Hint::Fq(line_coeffs[num_lines - (i + 2)][j][1].2.c0), 
+                        Hint::Fq(line_coeffs[num_lines - (i + 2)][j][1].2.c1),
+                    ]);
 
                     let mut pm_q4 = q4;
                     if ark_bn254::Config::ATE_LOOP_COUNT[i - 1] == -1 {
@@ -114,6 +138,7 @@ pub fn chunk_q4<T: BCAssigner>(
                     let x = alpha.square() - t4.x - pm_q4.x;
                     let y = bias_minus - alpha * x;
                     let t4x = ark_bn254::G2Affine::new(x, y);
+
 
                     let (hinted_script0, hint) = hinted_check_chord_line(
                         t4,
@@ -133,15 +158,28 @@ pub fn chunk_q4<T: BCAssigner>(
 
                     script = script.push_script(
                         script! {
+                             // [t4, pm_q4]
+                            for _ in 0..4 {
+                                for _ in 0..Fq::N_LIMBS {
+                                    OP_DEPTH OP_1SUB OP_ROLL 
+                                }  
+                            }
+                            // [t4, pm_q4, a, b]
+                            {Fq2::copy(2)} {Fq2::copy(2)}
+                            // [t4, pm_q4, a, b, a, b]
+                            {Fq2::roll(14)} {Fq2::roll(14)}
+                            {Fq2::roll(14)} {Fq2::roll(14)}
+                            // [a, b, a, b, t4, pm_q4]
+
                             // [t4, pm_q4]
                             {Fq2::copy(2)}
                             {Fq2::toaltstack()}
                             {Fq2::copy(6)}
                             {Fq2::toaltstack()}
-                            // [t4, pm_q4]
+                            // [a, b, t4, pm_q4]
                             {hinted_script0}
                             {Fq2::fromaltstack()}
-                            {Fq2::fromaltstack()}
+                            {Fq2::fromaltstack()} 
                             // [t4.x, pm_q4.x]
                             {hinted_script1}
                             // [updated_t4]
@@ -196,6 +234,12 @@ pub fn chunk_q4<T: BCAssigner>(
             .unwrap();
 
             let mut hints = vec![];
+            hints.extend_from_slice(&vec![
+                Hint::Fq(line_coeffs[num_lines - 2][j][0].1.c0), 
+                Hint::Fq(line_coeffs[num_lines - 2][j][0].1.c1), 
+                Hint::Fq(line_coeffs[num_lines - 2][j][0].2.c0), 
+                Hint::Fq(line_coeffs[num_lines - 2][j][0].2.c1),
+            ]);
 
             let mut q4y = q4.y;
             q4y.conjugate_in_place();
@@ -218,6 +262,8 @@ pub fn chunk_q4<T: BCAssigner>(
             let t4x = ark_bn254::G2Affine::new(x, y);
             let q4_new = ark_bn254::G2Affine::new(q4x, q4y);
 
+
+
             let (check_hinted_script, hint) = hinted_check_chord_line(
                 t4,
                 q4_new,
@@ -235,6 +281,19 @@ pub fn chunk_q4<T: BCAssigner>(
             hints.extend(hint);
 
             let script = script! {
+                    // [t4, q4]
+                for _ in 0..4 {
+                    for _ in 0..Fq::N_LIMBS {
+                        OP_DEPTH OP_1SUB OP_ROLL 
+                    }  
+                }
+                // [t4, q4, a, b]
+                {Fq2::copy(2)} {Fq2::copy(2)}
+                // [t4, q4, a, b, a, b]
+                {Fq2::roll(14)} {Fq2::roll(14)}
+                {Fq2::roll(14)} {Fq2::roll(14)}
+                // [a, b, a, b, t4, q4]
+
                 // [t4, q4]
                 {Fq::neg(0)}
                 { Fq::push_dec_not_montgomery("2821565182194536844548159561693502659359617185244120367078079554186484126554") }
@@ -251,16 +310,17 @@ pub fn chunk_q4<T: BCAssigner>(
                 { q4x_mul_hinted_script }
                 { Fq2::fromaltstack() }
 
-                // [t4, phi_q4]
+                
+                // [a, b, a, b, t4, phi_q4]
                 {Fq2::copy(2)}
                 {Fq2::toaltstack()}
                 {Fq2::copy(6)}
                 {Fq2::toaltstack()}
-                // [t4, phi_q4]
+                // [a, b, a, b, t4, phi_q4]
                 {check_hinted_script}
                 {Fq2::fromaltstack()}
                 {Fq2::fromaltstack()}
-                // [t4.x, phi_q4.x]
+                // [a, b, t4.x, phi_q4.x]
                 {add_hinted_script}
                 // [updated_t4]
             };
@@ -295,6 +355,12 @@ pub fn chunk_q4<T: BCAssigner>(
             .unwrap();
 
             let mut hints = vec![];
+            hints.extend_from_slice(&vec![
+                Hint::Fq(line_coeffs[num_lines - 1][j][0].1.c0), 
+                Hint::Fq(line_coeffs[num_lines - 1][j][0].1.c1), 
+                Hint::Fq(line_coeffs[num_lines - 1][j][0].2.c0), 
+                Hint::Fq(line_coeffs[num_lines - 1][j][0].2.c1),
+            ]);
 
             let (mul_x_hinted_script, hint) = Fq2::hinted_mul(2, q4.x, 0, beta_22);
             hints.extend(hint);
@@ -311,6 +377,16 @@ pub fn chunk_q4<T: BCAssigner>(
 
             let script = script! {
                 // [t4, q4]
+                for _ in 0..4 {
+                    for _ in 0..Fq::N_LIMBS {
+                        OP_DEPTH OP_1SUB OP_ROLL 
+                    }  
+                }
+                // [t4, q4, a, b]
+                {Fq2::roll(10)} {Fq2::roll(10)}
+                {Fq2::roll(10)} {Fq2::roll(10)}
+                // [a, b, t4, q4]
+
                 {Fq2::toaltstack()}
                 // [t4, q4x | q4y]
                 { Fq::push_dec_not_montgomery("21888242871839275220042445260109153167277707414472061641714758635765020556616") }


### PR DESCRIPTION
Fixes issues with separate line coefficients being used in g2 affine point operation functions.
Tests included.