### PR TITLE
Bridge use global secp256k1 context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "openssh-sftp-client",
  "rand",
  "regex",
+ "secp256k1",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitive
 ark-relations = { git = "https://github.com/arkworks-rs/snark/" }
 serial_test = "*"
 tqdm = "0.7"
+secp256k1 = { version = "0.29.1", features = ["global-context"]}
 
 [profile.dev]
 opt-level = 3

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -38,7 +38,7 @@ ark-bn254.workspace = true
 ark-groth16.workspace = true
 ark-ff.workspace = true
 ark-std.workspace = true
-
+secp256k1.workspace = true
 
 [profile.dev]
 opt-level = 3

--- a/bridge/src/client/cli/client_command.rs
+++ b/bridge/src/client/cli/client_command.rs
@@ -39,9 +39,9 @@ impl ClientCommand {
         let config = keys_command.read_config().expect("Failed to read config");
 
         let n_of_n_public_keys = common_args.verifiers.unwrap_or_else(|| {
-            let (_, _, verifier_0_public_key) =
+            let (_, verifier_0_public_key) =
                 generate_keys_from_secret(Network::Bitcoin, VERIFIER_0_SECRET);
-            let (_, _, verifier_1_public_key) =
+            let (_, verifier_1_public_key) =
                 generate_keys_from_secret(Network::Bitcoin, VERIFIER_1_SECRET);
             vec![verifier_0_public_key, verifier_1_public_key]
         });

--- a/bridge/src/client/cli/key_command.rs
+++ b/bridge/src/client/cli/key_command.rs
@@ -135,5 +135,5 @@ impl KeysCommand {
     }
 }
 fn pubkey_of(private_key: &str) -> PublicKey {
-    generate_keys_from_secret(Network::Bitcoin, private_key).2
+    generate_keys_from_secret(Network::Bitcoin, private_key).1
 }

--- a/bridge/src/client/cli/query_command.rs
+++ b/bridge/src/client/cli/query_command.rs
@@ -30,9 +30,9 @@ impl QueryCommand {
         destination_network: DestinationNetwork,
         path_prefix: Option<&str>,
     ) -> Self {
-        let (_, _, verifier_0_public_key) =
+        let (_, verifier_0_public_key) =
             generate_keys_from_secret(Network::Bitcoin, VERIFIER_0_SECRET);
-        let (_, _, verifier_1_public_key) =
+        let (_, verifier_1_public_key) =
             generate_keys_from_secret(Network::Bitcoin, VERIFIER_1_SECRET);
 
         let n_of_n_public_keys: Vec<PublicKey> = vec![verifier_0_public_key, verifier_1_public_key];

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -23,7 +23,7 @@ use crate::{
         peg_in::{PegInDepositorStatus, PegInVerifierStatus},
         peg_out::{CommitmentMessageId, PegOutOperatorStatus},
     },
-    scripts::generate_pay_to_pubkey_script_address
+    scripts::generate_pay_to_pubkey_script_address,
 };
 
 use bitvm::signatures::signing_winternitz::WinternitzSecret;
@@ -202,21 +202,13 @@ impl BitVMClient {
         }
     }
 
-    pub fn get_data(&self) -> &BitVMClientPublicData {
-        &self.data
-    }
+    pub fn get_data(&self) -> &BitVMClientPublicData { &self.data }
 
-    pub async fn sync(&mut self) {
-        self.read().await;
-    }
+    pub async fn sync(&mut self) { self.read().await; }
 
-    pub async fn sync_l2(&mut self) {
-        self.read_from_l2().await;
-    }
+    pub async fn sync_l2(&mut self) { self.read_from_l2().await; }
 
-    pub async fn flush(&mut self) {
-        self.save().await;
-    }
+    pub async fn flush(&mut self) { self.save().await; }
 
     /*
     File syncing flow with data store
@@ -1102,7 +1094,6 @@ impl BitVMClient {
                 .unwrap()
                 .challenge(
                     &self.esplora,
-                    self.depositor_context.as_ref().unwrap(),
                     crowdfundng_inputs,
                     &self.depositor_context.as_ref().unwrap().depositor_keypair,
                     output_script_pubkey,
@@ -1113,7 +1104,6 @@ impl BitVMClient {
                 .unwrap()
                 .challenge(
                     &self.esplora,
-                    self.operator_context.as_ref().unwrap(),
                     crowdfundng_inputs,
                     &self.operator_context.as_ref().unwrap().operator_keypair,
                     output_script_pubkey,
@@ -1124,7 +1114,6 @@ impl BitVMClient {
                 .unwrap()
                 .challenge(
                     &self.esplora,
-                    self.verifier_context.as_ref().unwrap(),
                     crowdfundng_inputs,
                     &self.verifier_context.as_ref().unwrap().verifier_keypair,
                     output_script_pubkey,
@@ -1135,7 +1124,6 @@ impl BitVMClient {
                 .unwrap()
                 .challenge(
                     &self.esplora,
-                    self.withdrawer_context.as_ref().unwrap(),
                     crowdfundng_inputs,
                     &self.withdrawer_context.as_ref().unwrap().withdrawer_keypair,
                     output_script_pubkey,

--- a/bridge/src/connectors/connector_0.rs
+++ b/bridge/src/connectors/connector_0.rs
@@ -60,7 +60,7 @@ impl TaprootConnector for Connector0 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_0.rs
+++ b/bridge/src/connectors/connector_0.rs
@@ -1,8 +1,8 @@
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -60,7 +60,7 @@ impl TaprootConnector for Connector0 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_1.rs
+++ b/bridge/src/connectors/connector_1.rs
@@ -130,7 +130,7 @@ impl TaprootConnector for Connector1 {
             .expect("Unable to add leaf 1")
             .add_leaf(1, self.generate_taproot_leaf_2_script())
             .expect("Unable to add leaf 2")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_1.rs
+++ b/bridge/src/connectors/connector_1.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
 
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
 use bitcoin_script::script;
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     graphs::peg_out::CommitmentMessageId,
-    superblock::{SUPERBLOCK_HASH_MESSAGE_LENGTH, SUPERBLOCK_MESSAGE_LENGTH}
+    superblock::{SUPERBLOCK_HASH_MESSAGE_LENGTH, SUPERBLOCK_MESSAGE_LENGTH},
 };
 
-use bitvm::signatures::signing_winternitz::{winternitz_message_checksig_verify, WinternitzPublicKey};
+use bitvm::signatures::signing_winternitz::{
+    winternitz_message_checksig_verify, WinternitzPublicKey,
+};
 
 use super::{
     super::{
@@ -128,7 +130,7 @@ impl TaprootConnector for Connector1 {
             .expect("Unable to add leaf 1")
             .add_leaf(1, self.generate_taproot_leaf_2_script())
             .expect("Unable to add leaf 2")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_2.rs
+++ b/bridge/src/connectors/connector_2.rs
@@ -4,20 +4,19 @@ use crate::{
     constants::{N_SEQUENCE_FOR_LOCK_TIME, START_TIME_MESSAGE_LENGTH},
     graphs::peg_out::CommitmentMessageId,
 };
-use bitvm::{
-    signatures::{
-        utils::digits_to_number,
-        signing_winternitz::{
-            winternitz_message_checksig, WinternitzPublicKey, LOG_D,
-        },
-    },
-    treepp::script
-};
 use bitcoin::{
     key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use bitvm::{
+    signatures::{
+        signing_winternitz::{winternitz_message_checksig, WinternitzPublicKey, LOG_D},
+        utils::digits_to_number,
+    },
+    treepp::script,
+};
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -102,7 +101,7 @@ impl TaprootConnector for Connector2 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_2.rs
+++ b/bridge/src/connectors/connector_2.rs
@@ -100,7 +100,7 @@ impl TaprootConnector for Connector2 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_2.rs
+++ b/bridge/src/connectors/connector_2.rs
@@ -5,7 +5,6 @@ use crate::{
     graphs::peg_out::CommitmentMessageId,
 };
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };

--- a/bridge/src/connectors/connector_5.rs
+++ b/bridge/src/connectors/connector_5.rs
@@ -60,7 +60,7 @@ impl TaprootConnector for Connector5 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_5.rs
+++ b/bridge/src/connectors/connector_5.rs
@@ -1,8 +1,8 @@
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -60,7 +60,7 @@ impl TaprootConnector for Connector5 {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_6.rs
+++ b/bridge/src/connectors/connector_6.rs
@@ -12,7 +12,6 @@ use bitvm::{
 };
 
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };

--- a/bridge/src/connectors/connector_6.rs
+++ b/bridge/src/connectors/connector_6.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use crate::{
     constants::{DESTINATION_NETWORK_TXID_LENGTH, SOURCE_NETWORK_TXID_LENGTH},
     graphs::peg_out::CommitmentMessageId,
-    transactions::base::Input
+    transactions::base::Input,
 };
 
 use bitvm::{
     signatures::signing_winternitz::{winternitz_message_checksig_verify, WinternitzPublicKey},
-    treepp::script
+    treepp::script,
 };
 
 use bitcoin::{
@@ -17,6 +17,7 @@ use bitcoin::{
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
 
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::base::{generate_default_tx_in, TaprootConnector};
@@ -76,7 +77,7 @@ impl TaprootConnector for Connector6 {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_0_script())
             .expect("Unable to add leaf 0")
-            .finalize(&Secp256k1::new(), self.operator_taproot_public_key) // TODO: should be operator key?
+            .finalize(&SECP256K1, self.operator_taproot_public_key) // TODO: should be operator key?
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_6.rs
+++ b/bridge/src/connectors/connector_6.rs
@@ -76,7 +76,7 @@ impl TaprootConnector for Connector6 {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_0_script())
             .expect("Unable to add leaf 0")
-            .finalize(&SECP256K1, self.operator_taproot_public_key) // TODO: should be operator key?
+            .finalize(SECP256K1, self.operator_taproot_public_key) // TODO: should be operator key?
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_a.rs
+++ b/bridge/src/connectors/connector_a.rs
@@ -1,8 +1,8 @@
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -66,7 +66,7 @@ impl TaprootConnector for ConnectorA {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_a.rs
+++ b/bridge/src/connectors/connector_a.rs
@@ -66,7 +66,7 @@ impl TaprootConnector for ConnectorA {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_b.rs
+++ b/bridge/src/connectors/connector_b.rs
@@ -1,8 +1,8 @@
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -81,7 +81,7 @@ impl TaprootConnector for ConnectorB {
             .expect("Unable to add leaf 1")
             .add_leaf(1, self.generate_taproot_leaf_2_script())
             .expect("Unable to add leaf 2")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_b.rs
+++ b/bridge/src/connectors/connector_b.rs
@@ -81,7 +81,7 @@ impl TaprootConnector for ConnectorB {
             .expect("Unable to add leaf 1")
             .add_leaf(1, self.generate_taproot_leaf_2_script())
             .expect("Unable to add leaf 2")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -109,7 +109,7 @@ impl TaprootConnector for ConnectorC {
 
         TaprootBuilder::with_huffman_tree(script_weights)
             .expect("Unable to add assert leaves")
-            .finalize(&SECP256K1, self.operator_taproot_public_key)
+            .finalize(SECP256K1, self.operator_taproot_public_key)
             .expect("Unable to finalize assert transaction connector c taproot")
     }
 

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -16,7 +16,6 @@ use bitvm::{
 use ark_groth16::VerifyingKey;
 use bitcoin::{
     hashes::{ripemd160, Hash},
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -10,7 +10,7 @@ use bitvm::{
         disprove_execution::{disprove_exec, RawProof},
     },
     signatures::signing_winternitz::WinternitzPublicKey,
-    treepp::script
+    treepp::script,
 };
 
 use ark_groth16::VerifyingKey;
@@ -21,6 +21,7 @@ use bitcoin::{
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
 use num_traits::ToPrimitive;
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{super::transactions::base::Input, base::*};
@@ -109,7 +110,7 @@ impl TaprootConnector for ConnectorC {
 
         TaprootBuilder::with_huffman_tree(script_weights)
             .expect("Unable to add assert leaves")
-            .finalize(&Secp256k1::new(), self.operator_taproot_public_key)
+            .finalize(&SECP256K1, self.operator_taproot_public_key)
             .expect("Unable to finalize assert transaction connector c taproot")
     }
 

--- a/bridge/src/connectors/connector_d.rs
+++ b/bridge/src/connectors/connector_d.rs
@@ -1,8 +1,8 @@
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -50,7 +50,7 @@ impl TaprootConnector for ConnectorD {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_0_script())
             .expect("Unable to add leaf 0")
-            .finalize(&Secp256k1::new(), self.n_of_n_taproot_public_key)
+            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_d.rs
+++ b/bridge/src/connectors/connector_d.rs
@@ -50,7 +50,7 @@ impl TaprootConnector for ConnectorD {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_0_script())
             .expect("Unable to add leaf 0")
-            .finalize(&SECP256K1, self.n_of_n_taproot_public_key)
+            .finalize(SECP256K1, self.n_of_n_taproot_public_key)
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_e.rs
+++ b/bridge/src/connectors/connector_e.rs
@@ -72,7 +72,7 @@ impl TaprootConnector for ConnectorE {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_script(0))
             .expect("Unable to add leaf 0")
-            .finalize(&SECP256K1, self.operator_public_key.into())
+            .finalize(SECP256K1, self.operator_public_key.into())
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_e.rs
+++ b/bridge/src/connectors/connector_e.rs
@@ -3,13 +3,15 @@ use super::{
     base::*,
 };
 use crate::graphs::peg_out::CommitmentMessageId;
-use bitvm::signatures::signing_winternitz::{winternitz_message_checksig_verify, WinternitzPublicKey};
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, PublicKey, ScriptBuf, TxIn,
 };
 use bitcoin_script::script;
+use bitvm::signatures::signing_winternitz::{
+    winternitz_message_checksig_verify, WinternitzPublicKey,
+};
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -70,7 +72,7 @@ impl TaprootConnector for ConnectorE {
         TaprootBuilder::new()
             .add_leaf(0, self.generate_taproot_leaf_script(0))
             .expect("Unable to add leaf 0")
-            .finalize(&Secp256k1::new(), self.operator_public_key.into())
+            .finalize(&SECP256K1, self.operator_public_key.into())
             .expect("Unable to finalize taproot")
     }
 

--- a/bridge/src/connectors/connector_z.rs
+++ b/bridge/src/connectors/connector_z.rs
@@ -1,10 +1,10 @@
 use crate::{constants::NUM_BLOCKS_PER_2_WEEKS, utils::num_blocks_per_network};
-use bitvm::treepp::script;
 use bitcoin::{
-    key::Secp256k1,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Network, ScriptBuf, TxIn, XOnlyPublicKey,
 };
+use bitvm::treepp::script;
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -90,7 +90,7 @@ impl TaprootConnector for ConnectorZ {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&Secp256k1::new(), self.depositor_taproot_public_key) // TODO: should this be depositor or n-of-n
+            .finalize(&SECP256K1, self.depositor_taproot_public_key) // TODO: should this be depositor or n-of-n
             .expect("Unable to finalize ttaproot")
     }
 

--- a/bridge/src/connectors/connector_z.rs
+++ b/bridge/src/connectors/connector_z.rs
@@ -90,7 +90,7 @@ impl TaprootConnector for ConnectorZ {
             .expect("Unable to add leaf 0")
             .add_leaf(1, self.generate_taproot_leaf_1_script())
             .expect("Unable to add leaf 1")
-            .finalize(&SECP256K1, self.depositor_taproot_public_key) // TODO: should this be depositor or n-of-n
+            .finalize(SECP256K1, self.depositor_taproot_public_key) // TODO: should this be depositor or n-of-n
             .expect("Unable to finalize ttaproot")
     }
 

--- a/bridge/src/contexts/base.rs
+++ b/bridge/src/contexts/base.rs
@@ -1,28 +1,23 @@
 use bitcoin::{
-    key::{Keypair, Secp256k1},
-    secp256k1::{All, PublicKey as Secp256k1PublicKey},
-    Network, PrivateKey, PublicKey, XOnlyPublicKey,
+    key::Keypair, secp256k1::PublicKey as Secp256k1PublicKey, Network, PrivateKey, PublicKey,
+    XOnlyPublicKey,
 };
 use musig2::{secp::Point, KeyAggContext};
+use secp256k1::SECP256K1;
 
 pub trait BaseContext {
     fn network(&self) -> Network;
-    fn secp(&self) -> &Secp256k1<All>;
     fn n_of_n_public_keys(&self) -> &Vec<PublicKey>;
     fn n_of_n_public_key(&self) -> &PublicKey;
     fn n_of_n_taproot_public_key(&self) -> &XOnlyPublicKey;
 }
 
-pub fn generate_keys_from_secret(
-    network: Network,
-    secret: &str,
-) -> (Secp256k1<All>, Keypair, PublicKey) {
-    let secp = Secp256k1::new();
-    let keypair = Keypair::from_seckey_str(&secp, secret).unwrap();
+pub fn generate_keys_from_secret(network: Network, secret: &str) -> (Keypair, PublicKey) {
+    let keypair = Keypair::from_seckey_str(&SECP256K1, secret).unwrap();
     let private_key = PrivateKey::new(keypair.secret_key(), network);
-    let public_key = PublicKey::from_private_key(&secp, &private_key);
+    let public_key = PublicKey::from_private_key(&SECP256K1, &private_key);
 
-    (secp, keypair, public_key)
+    (keypair, public_key)
 }
 
 pub fn generate_n_of_n_public_key(n_of_n_public_keys: &[PublicKey]) -> (PublicKey, XOnlyPublicKey) {

--- a/bridge/src/contexts/base.rs
+++ b/bridge/src/contexts/base.rs
@@ -13,9 +13,9 @@ pub trait BaseContext {
 }
 
 pub fn generate_keys_from_secret(network: Network, secret: &str) -> (Keypair, PublicKey) {
-    let keypair = Keypair::from_seckey_str(&SECP256K1, secret).unwrap();
+    let keypair = Keypair::from_seckey_str(SECP256K1, secret).unwrap();
     let private_key = PrivateKey::new(keypair.secret_key(), network);
-    let public_key = PublicKey::from_private_key(&SECP256K1, &private_key);
+    let public_key = PublicKey::from_private_key(SECP256K1, &private_key);
 
     (keypair, public_key)
 }

--- a/bridge/src/contexts/base.rs
+++ b/bridge/src/contexts/base.rs
@@ -13,7 +13,7 @@ pub trait BaseContext {
 }
 
 pub fn generate_keys_from_secret(network: Network, secret: &str) -> (Keypair, PublicKey) {
-    let keypair = Keypair::from_seckey_str(SECP256K1, secret).unwrap();
+    let keypair = Keypair::from_seckey_str_global(secret).unwrap();
     let private_key = PrivateKey::new(keypair.secret_key(), network);
     let public_key = PublicKey::from_private_key(SECP256K1, &private_key);
 

--- a/bridge/src/contexts/depositor.rs
+++ b/bridge/src/contexts/depositor.rs
@@ -1,14 +1,9 @@
-use bitcoin::{
-    key::{Keypair, Secp256k1},
-    secp256k1::All,
-    Network, PublicKey, XOnlyPublicKey,
-};
+use bitcoin::{key::Keypair, Network, PublicKey, XOnlyPublicKey};
 
 use super::base::{generate_keys_from_secret, generate_n_of_n_public_key, BaseContext};
 
 pub struct DepositorContext {
     pub network: Network,
-    pub secp: Secp256k1<All>,
 
     pub depositor_keypair: Keypair,
     pub depositor_public_key: PublicKey,
@@ -21,7 +16,6 @@ pub struct DepositorContext {
 
 impl BaseContext for DepositorContext {
     fn network(&self) -> Network { self.network }
-    fn secp(&self) -> &Secp256k1<All> { &self.secp }
     fn n_of_n_public_keys(&self) -> &Vec<PublicKey> { &self.n_of_n_public_keys }
     fn n_of_n_public_key(&self) -> &PublicKey { &self.n_of_n_public_key }
     fn n_of_n_taproot_public_key(&self) -> &XOnlyPublicKey { &self.n_of_n_taproot_public_key }
@@ -29,13 +23,12 @@ impl BaseContext for DepositorContext {
 
 impl DepositorContext {
     pub fn new(network: Network, depositor_secret: &str, n_of_n_public_keys: &[PublicKey]) -> Self {
-        let (secp, keypair, public_key) = generate_keys_from_secret(network, depositor_secret);
+        let (keypair, public_key) = generate_keys_from_secret(network, depositor_secret);
         let (n_of_n_public_key, n_of_n_taproot_public_key) =
             generate_n_of_n_public_key(n_of_n_public_keys);
 
         DepositorContext {
             network,
-            secp,
 
             depositor_keypair: keypair,
             depositor_public_key: public_key,

--- a/bridge/src/contexts/operator.rs
+++ b/bridge/src/contexts/operator.rs
@@ -1,14 +1,9 @@
-use bitcoin::{
-    key::{Keypair, Secp256k1},
-    secp256k1::All,
-    Network, PublicKey, XOnlyPublicKey,
-};
+use bitcoin::{key::Keypair, Network, PublicKey, XOnlyPublicKey};
 
 use super::base::{generate_keys_from_secret, generate_n_of_n_public_key, BaseContext};
 
 pub struct OperatorContext {
     pub network: Network,
-    pub secp: Secp256k1<All>,
 
     pub operator_keypair: Keypair,
     pub operator_public_key: PublicKey,
@@ -21,7 +16,6 @@ pub struct OperatorContext {
 
 impl BaseContext for OperatorContext {
     fn network(&self) -> Network { self.network }
-    fn secp(&self) -> &Secp256k1<All> { &self.secp }
     fn n_of_n_public_keys(&self) -> &Vec<PublicKey> { &self.n_of_n_public_keys }
     fn n_of_n_public_key(&self) -> &PublicKey { &self.n_of_n_public_key }
     fn n_of_n_taproot_public_key(&self) -> &XOnlyPublicKey { &self.n_of_n_taproot_public_key }
@@ -29,13 +23,12 @@ impl BaseContext for OperatorContext {
 
 impl OperatorContext {
     pub fn new(network: Network, operator_secret: &str, n_of_n_public_keys: &[PublicKey]) -> Self {
-        let (secp, keypair, public_key) = generate_keys_from_secret(network, operator_secret);
+        let (keypair, public_key) = generate_keys_from_secret(network, operator_secret);
         let (n_of_n_public_key, n_of_n_taproot_public_key) =
             generate_n_of_n_public_key(n_of_n_public_keys);
 
         OperatorContext {
             network,
-            secp,
 
             operator_keypair: keypair,
             operator_public_key: public_key,

--- a/bridge/src/contexts/verifier.rs
+++ b/bridge/src/contexts/verifier.rs
@@ -1,14 +1,9 @@
-use bitcoin::{
-    key::{Keypair, Secp256k1},
-    secp256k1::All,
-    Network, PublicKey, XOnlyPublicKey,
-};
+use bitcoin::{key::Keypair, Network, PublicKey, XOnlyPublicKey};
 
 use super::base::{generate_keys_from_secret, generate_n_of_n_public_key, BaseContext};
 
 pub struct VerifierContext {
     pub network: Network,
-    pub secp: Secp256k1<All>,
 
     pub verifier_keypair: Keypair,
     pub verifier_public_key: PublicKey,
@@ -20,7 +15,6 @@ pub struct VerifierContext {
 
 impl BaseContext for VerifierContext {
     fn network(&self) -> Network { self.network }
-    fn secp(&self) -> &Secp256k1<All> { &self.secp }
     fn n_of_n_public_keys(&self) -> &Vec<PublicKey> { &self.n_of_n_public_keys }
     fn n_of_n_public_key(&self) -> &PublicKey { &self.n_of_n_public_key }
     fn n_of_n_taproot_public_key(&self) -> &XOnlyPublicKey { &self.n_of_n_taproot_public_key }
@@ -28,13 +22,12 @@ impl BaseContext for VerifierContext {
 
 impl VerifierContext {
     pub fn new(network: Network, verifier_secret: &str, n_of_n_public_keys: &[PublicKey]) -> Self {
-        let (secp, keypair, public_key) = generate_keys_from_secret(network, verifier_secret);
+        let (keypair, public_key) = generate_keys_from_secret(network, verifier_secret);
         let (n_of_n_public_key, n_of_n_taproot_public_key) =
             generate_n_of_n_public_key(n_of_n_public_keys);
 
         VerifierContext {
             network,
-            secp,
 
             verifier_keypair: keypair,
             verifier_public_key: public_key,

--- a/bridge/src/contexts/withdrawer.rs
+++ b/bridge/src/contexts/withdrawer.rs
@@ -1,14 +1,9 @@
-use bitcoin::{
-    key::{Keypair, Secp256k1},
-    secp256k1::All,
-    Network, PublicKey, XOnlyPublicKey,
-};
+use bitcoin::{key::Keypair, Network, PublicKey, XOnlyPublicKey};
 
 use super::base::{generate_keys_from_secret, generate_n_of_n_public_key, BaseContext};
 
 pub struct WithdrawerContext {
     pub network: Network,
-    pub secp: Secp256k1<All>,
 
     pub withdrawer_keypair: Keypair,
     pub withdrawer_public_key: PublicKey,
@@ -21,7 +16,6 @@ pub struct WithdrawerContext {
 
 impl BaseContext for WithdrawerContext {
     fn network(&self) -> Network { self.network }
-    fn secp(&self) -> &Secp256k1<All> { &self.secp }
     fn n_of_n_public_keys(&self) -> &Vec<PublicKey> { &self.n_of_n_public_keys }
     fn n_of_n_public_key(&self) -> &PublicKey { &self.n_of_n_public_key }
     fn n_of_n_taproot_public_key(&self) -> &XOnlyPublicKey { &self.n_of_n_taproot_public_key }
@@ -33,13 +27,12 @@ impl WithdrawerContext {
         withdrawer_secret: &str,
         n_of_n_public_keys: &[PublicKey],
     ) -> Self {
-        let (secp, keypair, public_key) = generate_keys_from_secret(network, withdrawer_secret);
+        let (keypair, public_key) = generate_keys_from_secret(network, withdrawer_secret);
         let (n_of_n_public_key, n_of_n_taproot_public_key) =
             generate_n_of_n_public_key(n_of_n_public_keys);
 
         WithdrawerContext {
             network,
-            secp,
 
             withdrawer_keypair: keypair,
             withdrawer_public_key: public_key,

--- a/bridge/src/graphs/peg_out.rs
+++ b/bridge/src/graphs/peg_out.rs
@@ -33,9 +33,8 @@ use crate::{
             assert_final::AssertFinalTransaction,
             assert_initial::AssertInitialTransaction,
             utils::{
-                groth16_commitment_secrets_to_public_keys,
-                merge_to_connector_c_commits_public_key, AssertCommit1ConnectorsE,
-                AssertCommit2ConnectorsE, AssertCommitConnectorsF,
+                groth16_commitment_secrets_to_public_keys, merge_to_connector_c_commits_public_key,
+                AssertCommit1ConnectorsE, AssertCommit2ConnectorsE, AssertCommitConnectorsF,
             },
         },
         pre_signed_musig2::PreSignedMusig2Transaction,
@@ -47,8 +46,9 @@ use bitvm::chunker::{
     common::BLAKE3_HASH_LENGTH,
     disprove_execution::{disprove_exec, RawProof},
 };
-use bitvm::signatures::signing_winternitz::{WinternitzSigningInputs, WinternitzPublicKey, WinternitzSecret};
-
+use bitvm::signatures::signing_winternitz::{
+    WinternitzPublicKey, WinternitzSecret, WinternitzSigningInputs,
+};
 
 use super::{
     super::{
@@ -59,7 +59,7 @@ use super::{
             connector_6::Connector6, connector_a::ConnectorA, connector_b::ConnectorB,
             connector_c::ConnectorC,
         },
-        contexts::{base::BaseContext, operator::OperatorContext, verifier::VerifierContext},
+        contexts::{operator::OperatorContext, verifier::VerifierContext},
         transactions::{
             base::{
                 validate_transaction, verify_public_nonces_for_tx, BaseTransaction, Input,
@@ -350,13 +350,9 @@ pub struct PegOutGraph {
 }
 
 impl BaseGraph for PegOutGraph {
-    fn network(&self) -> Network {
-        self.network
-    }
+    fn network(&self) -> Network { self.network }
 
-    fn id(&self) -> &String {
-        &self.id
-    }
+    fn id(&self) -> &String { &self.id }
 
     fn verifier_sign(
         &mut self,
@@ -638,7 +634,6 @@ impl PegOutGraph {
         // assert commit txs
         let mut vout_base = 1;
         let assert_commit1_transaction = AssertCommit1Transaction::new(
-            context,
             &connectors.assert_commit_connectors_e_1,
             &connectors.assert_commit_connectors_f.connector_f_1,
             (0..connectors.assert_commit_connectors_e_1.connectors_num())
@@ -655,7 +650,6 @@ impl PegOutGraph {
         vout_base += connectors.assert_commit_connectors_e_1.connectors_num();
 
         let assert_commit2_transaction = AssertCommit2Transaction::new(
-            context,
             &connectors.assert_commit_connectors_e_2,
             &connectors.assert_commit_connectors_f.connector_f_2,
             (0..connectors.assert_commit_connectors_e_2.connectors_num())
@@ -1562,7 +1556,6 @@ impl PegOutGraph {
     pub async fn challenge(
         &mut self,
         client: &AsyncClient,
-        context: &dyn BaseContext,
         crowdfundng_inputs: &Vec<InputWithScript<'_>>,
         keypair: &Keypair,
         output_script_pubkey: ScriptBuf,
@@ -1575,7 +1568,6 @@ impl PegOutGraph {
         if kick_off_1_status.is_ok_and(|status| status.confirmed) {
             // complete challenge tx
             self.challenge_transaction.add_inputs_and_output(
-                context,
                 crowdfundng_inputs,
                 keypair,
                 output_script_pubkey,
@@ -1947,9 +1939,7 @@ impl PegOutGraph {
         }
     }
 
-    pub fn is_peg_out_initiated(&self) -> bool {
-        self.peg_out_chain_event.is_some()
-    }
+    pub fn is_peg_out_initiated(&self) -> bool { self.peg_out_chain_event.is_some() }
 
     pub async fn match_and_set_peg_out_event(
         &mut self,

--- a/bridge/src/transactions/assert_transactions/assert_commit_1.rs
+++ b/bridge/src/transactions/assert_transactions/assert_commit_1.rs
@@ -5,28 +5,26 @@ use rand::seq::index;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-        graphs::peg_out::CommitmentMessageId,
-        transactions::signing::{
-            populate_p2wsh_witness_with_signatures, populate_taproot_input_witness,
-            push_p2wsh_script_to_witness, push_taproot_leaf_unlock_data_to_witness,
-        },
+    graphs::peg_out::CommitmentMessageId,
+    transactions::signing::{
+        populate_p2wsh_witness_with_signatures, populate_taproot_input_witness,
+        push_p2wsh_script_to_witness, push_taproot_leaf_unlock_data_to_witness,
+    },
 };
 
-use bitvm::{
-    chunker::common::RawWitness,
-    execute_raw_script_with_inputs, execute_script_with_inputs,
-};
 use super::{
     super::{
         super::{
             connectors::{base::*, connector_f_1::ConnectorF1},
-            contexts::operator::OperatorContext,
             graphs::base::FEE_AMOUNT,
         },
         base::*,
         pre_signed::*,
     },
     utils::AssertCommit1ConnectorsE,
+};
+use bitvm::{
+    chunker::common::RawWitness, execute_raw_script_with_inputs, execute_script_with_inputs,
 };
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone)]
@@ -39,26 +37,17 @@ pub struct AssertCommit1Transaction {
 }
 
 impl PreSignedTransaction for AssertCommit1Transaction {
-    fn tx(&self) -> &Transaction {
-        &self.tx
-    }
+    fn tx(&self) -> &Transaction { &self.tx }
 
-    fn tx_mut(&mut self) -> &mut Transaction {
-        &mut self.tx
-    }
+    fn tx_mut(&mut self) -> &mut Transaction { &mut self.tx }
 
-    fn prev_outs(&self) -> &Vec<TxOut> {
-        &self.prev_outs
-    }
+    fn prev_outs(&self) -> &Vec<TxOut> { &self.prev_outs }
 
-    fn prev_scripts(&self) -> &Vec<ScriptBuf> {
-        &self.prev_scripts
-    }
+    fn prev_scripts(&self) -> &Vec<ScriptBuf> { &self.prev_scripts }
 }
 
 impl AssertCommit1Transaction {
     pub fn new(
-        context: &OperatorContext,
         connectors_e: &AssertCommit1ConnectorsE,
         connector_f_1: &ConnectorF1,
         tx_inputs: Vec<Input>,
@@ -114,12 +103,7 @@ impl AssertCommit1Transaction {
         }
     }
 
-    pub fn sign(
-        &mut self,
-        context: &OperatorContext,
-        connectors_e: &AssertCommit1ConnectorsE,
-        witnesses: Vec<RawWitness>,
-    ) {
+    pub fn sign(&mut self, connectors_e: &AssertCommit1ConnectorsE, witnesses: Vec<RawWitness>) {
         assert_eq!(witnesses.len(), connectors_e.connectors_num());
         for (input_index, witness) in (0..connectors_e.connectors_num()).zip(witnesses) {
             let taproot_spend_info = connectors_e
@@ -140,7 +124,5 @@ impl AssertCommit1Transaction {
 }
 
 impl BaseTransaction for AssertCommit1Transaction {
-    fn finalize(&self) -> Transaction {
-        self.tx.clone()
-    }
+    fn finalize(&self) -> Transaction { self.tx.clone() }
 }

--- a/bridge/src/transactions/assert_transactions/assert_commit_2.rs
+++ b/bridge/src/transactions/assert_transactions/assert_commit_2.rs
@@ -6,16 +6,12 @@ use crate::transactions::signing::{
     push_taproot_leaf_unlock_data_to_witness,
 };
 
-use bitvm::{
-    chunker::common::RawWitness,
-    execute_raw_script_with_inputs,
-};
+use bitvm::{chunker::common::RawWitness, execute_raw_script_with_inputs};
 
 use super::{
     super::{
         super::{
             connectors::{base::*, connector_f_2::ConnectorF2},
-            contexts::operator::OperatorContext,
             graphs::base::FEE_AMOUNT,
         },
         base::*,
@@ -34,26 +30,17 @@ pub struct AssertCommit2Transaction {
 }
 
 impl PreSignedTransaction for AssertCommit2Transaction {
-    fn tx(&self) -> &Transaction {
-        &self.tx
-    }
+    fn tx(&self) -> &Transaction { &self.tx }
 
-    fn tx_mut(&mut self) -> &mut Transaction {
-        &mut self.tx
-    }
+    fn tx_mut(&mut self) -> &mut Transaction { &mut self.tx }
 
-    fn prev_outs(&self) -> &Vec<TxOut> {
-        &self.prev_outs
-    }
+    fn prev_outs(&self) -> &Vec<TxOut> { &self.prev_outs }
 
-    fn prev_scripts(&self) -> &Vec<ScriptBuf> {
-        &self.prev_scripts
-    }
+    fn prev_scripts(&self) -> &Vec<ScriptBuf> { &self.prev_scripts }
 }
 
 impl AssertCommit2Transaction {
     pub fn new(
-        context: &OperatorContext,
         connectors_e: &AssertCommit2ConnectorsE,
         connector_f_2: &ConnectorF2,
         tx_inputs: Vec<Input>,
@@ -109,12 +96,7 @@ impl AssertCommit2Transaction {
         }
     }
 
-    pub fn sign(
-        &mut self,
-        context: &OperatorContext,
-        connectors_e: &AssertCommit2ConnectorsE,
-        witnesses: Vec<RawWitness>,
-    ) {
+    pub fn sign(&mut self, connectors_e: &AssertCommit2ConnectorsE, witnesses: Vec<RawWitness>) {
         assert_eq!(witnesses.len(), connectors_e.connectors_num());
         for (input_index, witness) in (0..connectors_e.connectors_num()).zip(witnesses) {
             let taproot_spend_info = connectors_e
@@ -145,7 +127,5 @@ impl AssertCommit2Transaction {
 }
 
 impl BaseTransaction for AssertCommit2Transaction {
-    fn finalize(&self) -> Transaction {
-        self.tx.clone()
-    }
+    fn finalize(&self) -> Transaction { self.tx.clone() }
 }

--- a/bridge/src/transactions/assert_transactions/assert_final.rs
+++ b/bridge/src/transactions/assert_transactions/assert_final.rs
@@ -38,27 +38,17 @@ pub struct AssertFinalTransaction {
 }
 
 impl PreSignedTransaction for AssertFinalTransaction {
-    fn tx(&self) -> &Transaction {
-        &self.tx
-    }
+    fn tx(&self) -> &Transaction { &self.tx }
 
-    fn tx_mut(&mut self) -> &mut Transaction {
-        &mut self.tx
-    }
+    fn tx_mut(&mut self) -> &mut Transaction { &mut self.tx }
 
-    fn prev_outs(&self) -> &Vec<TxOut> {
-        &self.prev_outs
-    }
+    fn prev_outs(&self) -> &Vec<TxOut> { &self.prev_outs }
 
-    fn prev_scripts(&self) -> &Vec<ScriptBuf> {
-        &self.prev_scripts
-    }
+    fn prev_scripts(&self) -> &Vec<ScriptBuf> { &self.prev_scripts }
 }
 
 impl PreSignedMusig2Transaction for AssertFinalTransaction {
-    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> {
-        &self.musig2_nonces
-    }
+    fn musig2_nonces(&self) -> &HashMap<usize, HashMap<PublicKey, PubNonce>> { &self.musig2_nonces }
     fn musig2_nonces_mut(&mut self) -> &mut HashMap<usize, HashMap<PublicKey, PubNonce>> {
         &mut self.musig2_nonces
     }
@@ -78,9 +68,7 @@ impl PreSignedMusig2Transaction for AssertFinalTransaction {
     ) -> &mut HashMap<usize, HashMap<PublicKey, PartialSignature>> {
         &mut self.musig2_signatures
     }
-    fn verifier_inputs(&self) -> Vec<usize> {
-        vec![0]
-    }
+    fn verifier_inputs(&self) -> Vec<usize> { vec![0] }
 }
 
 impl AssertFinalTransaction {
@@ -217,7 +205,6 @@ impl AssertFinalTransaction {
         for input_index in input_indexes {
             pre_sign_p2wsh_input(
                 self,
-                context,
                 input_index,
                 EcdsaSighashType::All,
                 &vec![&context.operator_keypair],
@@ -253,7 +240,5 @@ impl AssertFinalTransaction {
 }
 
 impl BaseTransaction for AssertFinalTransaction {
-    fn finalize(&self) -> Transaction {
-        self.tx.clone()
-    }
+    fn finalize(&self) -> Transaction { self.tx.clone() }
 }

--- a/bridge/src/transactions/base.rs
+++ b/bridge/src/transactions/base.rs
@@ -173,7 +173,6 @@ mod tests {
         PublicKey, Txid,
     };
     use musig2::{secp256k1::schnorr::Signature, PubNonce};
-    use secp256k1::SECP256K1;
 
     use crate::{
         contexts::base::generate_keys_from_secret,
@@ -214,10 +213,8 @@ mod tests {
 
                 nonces.insert(pubkeys[signer], secret_nonce.public_nonce());
 
-                let nonce_signature = SECP256K1.sign_schnorr(
-                    &get_nonce_message(&secret_nonce.public_nonce()),
-                    &keypairs[signer],
-                );
+                let nonce_signature =
+                    keypairs[signer].sign_schnorr(get_nonce_message(&secret_nonce.public_nonce()));
                 sigs.insert(pubkeys[signer], nonce_signature);
             }
             all_nonces.insert(input, nonces);

--- a/bridge/src/transactions/base.rs
+++ b/bridge/src/transactions/base.rs
@@ -168,11 +168,12 @@ mod tests {
     use bitcoin::{
         key::{
             constants::{SCHNORR_SIGNATURE_SIZE, SECRET_KEY_SIZE},
-            Keypair, Secp256k1,
+            Keypair,
         },
         PublicKey, Txid,
     };
     use musig2::{secp256k1::schnorr::Signature, PubNonce};
+    use secp256k1::SECP256K1;
 
     use crate::{
         contexts::base::generate_keys_from_secret,
@@ -194,7 +195,7 @@ mod tests {
         let mut keypairs: Vec<Keypair> = Vec::new();
         let mut pubkeys: Vec<PublicKey> = Vec::new();
         for signer in 0..SIGNERS {
-            let (_, keypair, pubkey) = generate_keys_from_secret(
+            let (keypair, pubkey) = generate_keys_from_secret(
                 bitcoin::Network::Bitcoin,
                 &hex::encode([(signer + 1) as u8; SECRET_KEY_SIZE]),
             );
@@ -213,7 +214,7 @@ mod tests {
 
                 nonces.insert(pubkeys[signer], secret_nonce.public_nonce());
 
-                let nonce_signature = Secp256k1::new().sign_schnorr(
+                let nonce_signature = SECP256K1.sign_schnorr(
                     &get_nonce_message(&secret_nonce.public_nonce()),
                     &keypairs[signer],
                 );

--- a/bridge/src/transactions/challenge.rs
+++ b/bridge/src/transactions/challenge.rs
@@ -153,7 +153,6 @@ impl ChallengeTransaction {
 
             // add witness
             populate_p2wsh_witness(
-                context,
                 &mut self.tx,
                 input_index,
                 sighash_type,

--- a/bridge/src/transactions/challenge.rs
+++ b/bridge/src/transactions/challenge.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 use super::{
     super::{
         connectors::{base::*, connector_a::ConnectorA},
-        contexts::{base::BaseContext, operator::OperatorContext},
+        contexts::operator::OperatorContext,
         graphs::base::FEE_AMOUNT,
         scripts::*,
     },
@@ -101,7 +101,6 @@ impl ChallengeTransaction {
     fn sign_input_0(&mut self, context: &OperatorContext, connector_a: &ConnectorA) {
         pre_sign_taproot_input_default(
             self,
-            context,
             0,
             TapSighashType::SinglePlusAnyoneCanPay,
             connector_a.generate_taproot_spend_info(),
@@ -112,7 +111,6 @@ impl ChallengeTransaction {
     // allows for aggregating multiple inputs and one refund output
     pub fn add_inputs_and_output(
         &mut self,
-        context: &dyn BaseContext,
         inputs: &Vec<InputWithScript>,
         keypair: &Keypair,
         output_script_pubkey: ScriptBuf,

--- a/bridge/src/transactions/kick_off_1.rs
+++ b/bridge/src/transactions/kick_off_1.rs
@@ -123,7 +123,6 @@ impl KickOff1Transaction {
 
         // get schnorr signature
         let schnorr_signature = generate_taproot_leaf_schnorr_signature(
-            context,
             self.tx_mut(),
             prev_outs,
             input_index,

--- a/bridge/src/transactions/kick_off_2.rs
+++ b/bridge/src/transactions/kick_off_2.rs
@@ -105,7 +105,6 @@ impl KickOff2Transaction {
         let mut unlock_data: Vec<Vec<u8>> = Vec::new();
 
         let schnorr_signature = generate_taproot_leaf_schnorr_signature(
-            context,
             self.tx_mut(),
             prev_outs,
             input_index,

--- a/bridge/src/transactions/peg_in_confirm.rs
+++ b/bridge/src/transactions/peg_in_confirm.rs
@@ -142,7 +142,6 @@ impl PegInConfirmTransaction {
     fn generate_and_push_depositor_signature_input_0(&mut self, context: &DepositorContext) {
         let input_index = 0;
         let schnorr_signature = generate_taproot_leaf_schnorr_signature(
-            context,
             &mut self.tx,
             &self.prev_outs,
             input_index,

--- a/bridge/src/transactions/peg_in_deposit.rs
+++ b/bridge/src/transactions/peg_in_deposit.rs
@@ -99,7 +99,6 @@ impl PegInDepositTransaction {
         let input_index = 0;
         pre_sign_p2wsh_input(
             self,
-            context,
             input_index,
             EcdsaSighashType::All,
             &vec![&context.depositor_keypair],

--- a/bridge/src/transactions/peg_in_refund.rs
+++ b/bridge/src/transactions/peg_in_refund.rs
@@ -98,7 +98,6 @@ impl PegInRefundTransaction {
     fn sign_input_0(&mut self, context: &DepositorContext, connector_z: &ConnectorZ) {
         pre_sign_taproot_input_default(
             self,
-            context,
             0,
             TapSighashType::All,
             connector_z.generate_taproot_spend_info(),

--- a/bridge/src/transactions/peg_out.rs
+++ b/bridge/src/transactions/peg_out.rs
@@ -91,7 +91,6 @@ impl PegOutTransaction {
         let input_index = 0;
         pre_sign_p2wsh_input(
             self,
-            context,
             input_index,
             EcdsaSighashType::All,
             &vec![&context.operator_keypair],

--- a/bridge/src/transactions/peg_out_confirm.rs
+++ b/bridge/src/transactions/peg_out_confirm.rs
@@ -83,7 +83,6 @@ impl PegOutConfirmTransaction {
         let input_index = 0;
         pre_sign_p2wsh_input(
             self,
-            context,
             input_index,
             EcdsaSighashType::All,
             &vec![&context.operator_keypair],

--- a/bridge/src/transactions/pre_signed.rs
+++ b/bridge/src/transactions/pre_signed.rs
@@ -59,7 +59,6 @@ pub fn pre_sign_p2wpkh_input<T: PreSignedTransaction>(
 
 pub fn pre_sign_taproot_input_default<T: PreSignedTransaction>(
     tx: &mut T,
-    context: &dyn BaseContext,
     input_index: usize,
     sighash_type: TapSighashType,
     taproot_spend_info: TaprootSpendInfo,
@@ -69,7 +68,6 @@ pub fn pre_sign_taproot_input_default<T: PreSignedTransaction>(
     let script = &tx.prev_scripts()[input_index].clone();
 
     populate_taproot_input_witness_default(
-        context,
         tx.tx_mut(),
         prev_outs,
         input_index,

--- a/bridge/src/transactions/pre_signed.rs
+++ b/bridge/src/transactions/pre_signed.rs
@@ -19,7 +19,6 @@ pub trait PreSignedTransaction {
 
 pub fn pre_sign_p2wsh_input<T: PreSignedTransaction>(
     tx: &mut T,
-    context: &dyn BaseContext,
     input_index: usize,
     sighash_type: EcdsaSighashType,
     keypairs: &Vec<&Keypair>,
@@ -28,7 +27,6 @@ pub fn pre_sign_p2wsh_input<T: PreSignedTransaction>(
     let value = tx.prev_outs()[input_index].value;
 
     populate_p2wsh_witness(
-        context,
         tx.tx_mut(),
         input_index,
         sighash_type,

--- a/bridge/src/transactions/pre_signed_musig2.rs
+++ b/bridge/src/transactions/pre_signed_musig2.rs
@@ -8,7 +8,6 @@ use musig2::{
     secp256k1::{schnorr::Signature, Message},
     BinaryEncoding, PartialSignature, PubNonce, SecNonce,
 };
-use secp256k1::SECP256K1;
 use std::collections::HashMap;
 
 use super::{
@@ -80,10 +79,9 @@ pub trait PreSignedMusig2Transaction: PreSignedTransaction {
             musig2_nonce_signatures.insert(input_index, HashMap::new());
         }
 
-        let nonce_signature = SECP256K1.sign_schnorr(
-            &get_nonce_message(&secret_nonce.public_nonce()),
-            &context.verifier_keypair,
-        );
+        let nonce_signature = context
+            .verifier_keypair
+            .sign_schnorr(get_nonce_message(&secret_nonce.public_nonce()));
 
         musig2_nonce_signatures
             .get_mut(&input_index)
@@ -100,7 +98,7 @@ pub fn get_nonce_message(nonce: &PubNonce) -> Message {
 }
 
 fn verify_schnorr_signature(sig: &Signature, msg: &Message, pubkey: &XOnlyPublicKey) -> bool {
-    match SECP256K1.verify_schnorr(sig, msg, pubkey) {
+    match sig.verify(msg, pubkey) {
         Ok(()) => true,
         Err(e) => {
             eprintln!("verify_schnorr() failed with: {e}");

--- a/bridge/src/transactions/pre_signed_musig2.rs
+++ b/bridge/src/transactions/pre_signed_musig2.rs
@@ -1,6 +1,5 @@
 use bitcoin::{
     hashes::{sha256, Hash},
-    key::Secp256k1,
     taproot::TaprootSpendInfo,
     PublicKey, TapSighashType, XOnlyPublicKey,
 };
@@ -9,6 +8,7 @@ use musig2::{
     secp256k1::{schnorr::Signature, Message},
     BinaryEncoding, PartialSignature, PubNonce, SecNonce,
 };
+use secp256k1::SECP256K1;
 use std::collections::HashMap;
 
 use super::{
@@ -80,7 +80,7 @@ pub trait PreSignedMusig2Transaction: PreSignedTransaction {
             musig2_nonce_signatures.insert(input_index, HashMap::new());
         }
 
-        let nonce_signature = context.secp.sign_schnorr(
+        let nonce_signature = SECP256K1.sign_schnorr(
             &get_nonce_message(&secret_nonce.public_nonce()),
             &context.verifier_keypair,
         );
@@ -100,7 +100,7 @@ pub fn get_nonce_message(nonce: &PubNonce) -> Message {
 }
 
 fn verify_schnorr_signature(sig: &Signature, msg: &Message, pubkey: &XOnlyPublicKey) -> bool {
-    match Secp256k1::new().verify_schnorr(sig, msg, pubkey) {
+    match SECP256K1.verify_schnorr(sig, msg, pubkey) {
         Ok(()) => true,
         Err(e) => {
             eprintln!("verify_schnorr() failed with: {e}");

--- a/bridge/src/transactions/signing.rs
+++ b/bridge/src/transactions/signing.rs
@@ -24,7 +24,7 @@ pub fn generate_p2wsh_schnorr_signature(
         .p2wsh_signature_hash(input_index, script, value, sighash_type)
         .expect("Failed to construct sighash");
 
-    let signature = SECP256K1.sign_ecdsa(&Message::from(sighash), &keypair.secret_key());
+    let signature = keypair.secret_key().sign_ecdsa(Message::from(sighash));
 
     bitcoin::ecdsa::Signature {
         signature,
@@ -100,7 +100,7 @@ pub fn generate_p2wpkh_schnorr_signature(
         )
         .expect("Failed to construct sighash");
 
-    let signature = SECP256K1.sign_ecdsa(&Message::from(sighash), &keypair.secret_key());
+    let signature = keypair.secret_key().sign_ecdsa(Message::from(sighash));
 
     bitcoin::ecdsa::Signature {
         signature,
@@ -194,6 +194,8 @@ pub fn generate_taproot_leaf_schnorr_signature(
             .expect("Failed to construct sighash")
     };
 
+    // If secp256k1 is updated to 0.30.0, the following line can be replaced with
+    // let signature = keypair.sign_schnorr_no_aux_rand(&Message::from(sighash));
     let signature = SECP256K1.sign_schnorr_no_aux_rand(&Message::from(sighash), keypair);
 
     bitcoin::taproot::Signature {
@@ -328,6 +330,8 @@ fn generate_p2tr_key_spend_schnorr_signature(
 
     let tweak_keypair = keypair.tap_tweak(SECP256K1, taproot_spend_info.merkle_root());
 
+    // If secp256k1 is updated to 0.30.0, the following line can be replaced with
+    // let signature = keypair.sign_schnorr_no_aux_rand(&Message::from(sighash));
     let signature =
         SECP256K1.sign_schnorr_no_aux_rand(&Message::from(sighash), &tweak_keypair.to_inner());
 

--- a/bridge/src/transactions/signing.rs
+++ b/bridge/src/transactions/signing.rs
@@ -162,7 +162,6 @@ pub fn populate_p2wpkh_witness(
 }
 
 pub fn generate_taproot_leaf_schnorr_signature(
-    context: &dyn BaseContext,
     tx: &mut Transaction,
     prev_outs: &[TxOut],
     input_index: usize,
@@ -260,7 +259,6 @@ pub fn populate_taproot_input_witness(
 /// scripts containing only OP_CHECKSIG verification.
 #[allow(clippy::too_many_arguments)]
 pub fn populate_taproot_input_witness_default(
-    context: &dyn BaseContext,
     tx: &mut Transaction,
     prevouts: &[TxOut],
     input_index: usize,
@@ -272,7 +270,6 @@ pub fn populate_taproot_input_witness_default(
     let mut unlock_data: Vec<Vec<u8>> = Vec::new();
     for keypair in keypairs {
         let schnorr_signature = generate_taproot_leaf_schnorr_signature(
-            context,
             tx,
             prevouts,
             input_index,
@@ -304,7 +301,6 @@ pub fn populate_taproot_input_witness_with_signature(
 }
 
 fn generate_p2tr_key_spend_schnorr_signature(
-    context: &dyn BaseContext,
     tx: &mut Transaction,
     input_index: usize,
     prev_outs: &Vec<TxOut>,
@@ -342,7 +338,6 @@ fn generate_p2tr_key_spend_schnorr_signature(
 }
 
 pub fn populate_p2tr_key_spend_witness(
-    context: &dyn BaseContext,
     tx: &mut Transaction,
     input_index: usize,
     prev_outs: &Vec<TxOut>,
@@ -351,7 +346,6 @@ pub fn populate_p2tr_key_spend_witness(
     keypair: &Keypair,
 ) {
     let signature = generate_p2tr_key_spend_schnorr_signature(
-        context,
         tx,
         input_index,
         prev_outs,

--- a/bridge/src/transactions/start_time.rs
+++ b/bridge/src/transactions/start_time.rs
@@ -15,7 +15,9 @@ use super::{
     signing::{generate_taproot_leaf_schnorr_signature, populate_taproot_input_witness},
 };
 
-use bitvm::signatures::signing_winternitz::{generate_winternitz_witness, WinternitzSecret, WinternitzSigningInputs};
+use bitvm::signatures::signing_winternitz::{
+    generate_winternitz_witness, WinternitzSecret, WinternitzSigningInputs,
+};
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct StartTimeTransaction {
@@ -123,7 +125,6 @@ impl StartTimeTransaction {
 
         // get schnorr signature
         let schnorr_signature = generate_taproot_leaf_schnorr_signature(
-            context,
             self.tx_mut(),
             prev_outs,
             input_index,

--- a/bridge/src/transactions/take_1.rs
+++ b/bridge/src/transactions/take_1.rs
@@ -206,7 +206,6 @@ impl Take1Transaction {
         let input_index = 1;
         pre_sign_taproot_input_default(
             self,
-            context,
             input_index,
             TapSighashType::All,
             connector_a.generate_taproot_spend_info(),

--- a/bridge/src/transactions/take_1.rs
+++ b/bridge/src/transactions/take_1.rs
@@ -218,7 +218,6 @@ impl Take1Transaction {
         let input_index = 2;
         pre_sign_p2wsh_input(
             self,
-            context,
             input_index,
             EcdsaSighashType::All,
             &vec![&context.operator_keypair],

--- a/bridge/src/transactions/take_2.rs
+++ b/bridge/src/transactions/take_2.rs
@@ -206,7 +206,6 @@ impl Take2Transaction {
         let input_index = 1;
         pre_sign_p2wsh_input(
             self,
-            context,
             input_index,
             EcdsaSighashType::All,
             &vec![&context.operator_keypair],

--- a/bridge/src/transactions/take_2.rs
+++ b/bridge/src/transactions/take_2.rs
@@ -250,7 +250,6 @@ impl Take2Transaction {
         let taproot_spend_info = connector_c.generate_taproot_spend_info();
 
         populate_p2tr_key_spend_witness(
-            context,
             self.tx_mut(),
             input_index,
             prev_outs,

--- a/bridge/tests/bridge/base/merge.rs
+++ b/bridge/tests/bridge/base/merge.rs
@@ -42,7 +42,6 @@ async fn test_merge_add_new_input_and_output() {
     let input_script =
         generate_pay_to_pubkey_script(&config.depositor_context.depositor_public_key);
     source_challenge_tx.add_inputs_and_output(
-        &config.operator_context,
         &vec![InputWithScript {
             outpoint,
             amount: amount * 2,

--- a/bridge/tests/bridge/challenge/challenge.rs
+++ b/bridge/tests/bridge/challenge/challenge.rs
@@ -67,7 +67,6 @@ async fn test_challenge_tx() {
     );
 
     challenge_tx.add_inputs_and_output(
-        &config.depositor_context,
         &vec![
             InputWithScript {
                 outpoint: crowdfunding_outpoints[0],

--- a/bridge/tests/bridge/disprove/disprove.rs
+++ b/bridge/tests/bridge/disprove/disprove.rs
@@ -143,11 +143,10 @@ async fn test_disprove_tx_with_verifier_added_to_output_success() {
 
     let mut tx = disprove_tx.finalize();
 
-    let secp = SECP256K1;
     let verifier_secret: &str = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234";
-    let verifier_keypair = Keypair::from_seckey_str(&secp, verifier_secret).unwrap();
+    let verifier_keypair = Keypair::from_seckey_str_global(verifier_secret).unwrap();
     let verifier_private_key = PrivateKey::new(verifier_keypair.secret_key(), Network::Testnet);
-    let verifier_pubkey = PublicKey::from_private_key(&secp, &verifier_private_key);
+    let verifier_pubkey = PublicKey::from_private_key(SECP256K1, &verifier_private_key);
 
     let verifier_output = TxOut {
         value: Amount::from_sat(0),

--- a/bridge/tests/bridge/disprove/disprove.rs
+++ b/bridge/tests/bridge/disprove/disprove.rs
@@ -12,6 +12,7 @@ use bridge::{
         pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
+use secp256k1::SECP256K1;
 
 use crate::bridge::faucet::{Faucet, FaucetType};
 
@@ -142,7 +143,7 @@ async fn test_disprove_tx_with_verifier_added_to_output_success() {
 
     let mut tx = disprove_tx.finalize();
 
-    let secp = config.verifier_0_context.secp;
+    let secp = SECP256K1;
     let verifier_secret: &str = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234";
     let verifier_keypair = Keypair::from_seckey_str(&secp, verifier_secret).unwrap();
     let verifier_private_key = PrivateKey::new(verifier_keypair.secret_key(), Network::Testnet);

--- a/bridge/tests/bridge/disprove_chain/disprove_chain.rs
+++ b/bridge/tests/bridge/disprove_chain/disprove_chain.rs
@@ -12,6 +12,7 @@ use bridge::{
         pre_signed_musig2::PreSignedMusig2Transaction,
     },
 };
+use secp256k1::SECP256K1;
 
 use crate::bridge::faucet::{Faucet, FaucetType};
 
@@ -119,7 +120,7 @@ async fn test_disprove_chain_tx_with_verifier_added_to_output_success() {
 
     let mut tx = disprove_chain_tx.finalize();
 
-    let secp = config.verifier_0_context.secp;
+    let secp = SECP256K1;
     let verifier_secret: &str = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234";
     let verifier_keypair = Keypair::from_seckey_str(&secp, verifier_secret).unwrap();
     let verifier_private_key = PrivateKey::new(

--- a/bridge/tests/bridge/disprove_chain/disprove_chain.rs
+++ b/bridge/tests/bridge/disprove_chain/disprove_chain.rs
@@ -120,14 +120,13 @@ async fn test_disprove_chain_tx_with_verifier_added_to_output_success() {
 
     let mut tx = disprove_chain_tx.finalize();
 
-    let secp = SECP256K1;
     let verifier_secret: &str = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234";
-    let verifier_keypair = Keypair::from_seckey_str(&secp, verifier_secret).unwrap();
+    let verifier_keypair = Keypair::from_seckey_str_global(verifier_secret).unwrap();
     let verifier_private_key = PrivateKey::new(
         verifier_keypair.secret_key(),
         config.verifier_0_context.network,
     );
-    let verifier_pubkey = PublicKey::from_private_key(&secp, &verifier_private_key);
+    let verifier_pubkey = PublicKey::from_private_key(SECP256K1, &verifier_private_key);
 
     let verifier_output = TxOut {
         value: (Amount::from_sat(INITIAL_AMOUNT) - Amount::from_sat(FEE_AMOUNT)) * 5 / 100,

--- a/bridge/tests/bridge/integration/peg_out/challenge.rs
+++ b/bridge/tests/bridge/integration/peg_out/challenge.rs
@@ -87,7 +87,6 @@ async fn test_challenge_success() {
         challenge_input_amount,
     );
     challenge.add_inputs_and_output(
-        &config.depositor_context,
         &vec![challenge_crowdfunding_input],
         &config.depositor_context.depositor_keypair,
         generate_pay_to_pubkey_script(&config.depositor_context.depositor_public_key),

--- a/bridge/tests/bridge/integration/peg_out/disprove.rs
+++ b/bridge/tests/bridge/integration/peg_out/disprove.rs
@@ -9,9 +9,9 @@ use bridge::{
     scripts::generate_pay_to_pubkey_script_address,
     transactions::{
         assert_transactions::{
-            assert_commit_1::AssertCommit1Transaction,
-            assert_commit_2::AssertCommit2Transaction, assert_final::AssertFinalTransaction,
-            assert_initial::AssertInitialTransaction, utils::sign_assert_tx_with_groth16_proof,
+            assert_commit_1::AssertCommit1Transaction, assert_commit_2::AssertCommit2Transaction,
+            assert_final::AssertFinalTransaction, assert_initial::AssertInitialTransaction,
+            utils::sign_assert_tx_with_groth16_proof,
         },
         base::{BaseTransaction, Input},
         disprove::DisproveTransaction,
@@ -124,7 +124,6 @@ async fn test_disprove_success() {
     // assert commit 1
     let mut vout_base = 1; // connector E
     let mut assert_commit_1 = AssertCommit1Transaction::new(
-        &config.operator_context,
         &config.assert_commit_connectors_e_1,
         &config.assert_commit_connectors_f.connector_f_1,
         (0..config.assert_commit_connectors_e_1.connectors_num())
@@ -138,7 +137,6 @@ async fn test_disprove_success() {
             .collect(),
     );
     assert_commit_1.sign(
-        &config.operator_context,
         &config.assert_commit_connectors_e_1,
         witness_for_commit1.clone(),
     );
@@ -167,7 +165,6 @@ async fn test_disprove_success() {
         amount: assert_initial_tx.output[vout as usize].value,
     };
     let mut assert_commit_2 = AssertCommit2Transaction::new(
-        &config.operator_context,
         &config.assert_commit_connectors_e_2,
         &config.assert_commit_connectors_f.connector_f_2,
         (0..config.assert_commit_connectors_e_2.connectors_num())
@@ -181,7 +178,6 @@ async fn test_disprove_success() {
             .collect(),
     );
     assert_commit_2.sign(
-        &config.operator_context,
         &config.assert_commit_connectors_e_2,
         witness_for_commit2.clone(),
     );

--- a/bridge/tests/bridge/setup.rs
+++ b/bridge/tests/bridge/setup.rs
@@ -4,8 +4,8 @@ use bitcoin::{Network, PublicKey};
 
 use bitvm::{
     chunker::assigner::BridgeAssigner,
-    signatures::winternitz::Parameters,
     signatures::signing_winternitz::{WinternitzPublicKey, WinternitzSecret},
+    signatures::winternitz::Parameters,
 };
 
 use bridge::{
@@ -22,8 +22,8 @@ use bridge::{
         START_TIME_MESSAGE_LENGTH,
     },
     contexts::{
-        base::generate_keys_from_secret, depositor::DepositorContext,
-        operator::OperatorContext, verifier::VerifierContext, withdrawer::WithdrawerContext,
+        base::generate_keys_from_secret, depositor::DepositorContext, operator::OperatorContext,
+        verifier::VerifierContext, withdrawer::WithdrawerContext,
     },
     graphs::{
         base::{
@@ -73,10 +73,8 @@ pub async fn setup_test() -> SetupConfig {
 
     let commitment_secrets = get_test_commitment_secrets();
 
-    let (_, _, verifier_0_public_key) =
-        generate_keys_from_secret(source_network, VERIFIER_0_SECRET);
-    let (_, _, verifier_1_public_key) =
-        generate_keys_from_secret(source_network, VERIFIER_1_SECRET);
+    let (_, verifier_0_public_key) = generate_keys_from_secret(source_network, VERIFIER_0_SECRET);
+    let (_, verifier_1_public_key) = generate_keys_from_secret(source_network, VERIFIER_1_SECRET);
     let mut n_of_n_public_keys: Vec<PublicKey> = Vec::new();
     n_of_n_public_keys.push(verifier_0_public_key);
     n_of_n_public_keys.push(verifier_1_public_key);


### PR DESCRIPTION
Creating Secp256k1 context everytime causes precomputed values to be calculated for each signature verification, causing big memory allocations and unnecessary elliptic curve arithmetic.

Used global context provided by the secp256k1 library instead.

Verifier, operator, base context already had their own secp instances which mitigates this problem, however, by using the global instance we simplify and unify the code.