### PR TITLE
Feat/transform bigint limbsize

### DIFF
--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -468,11 +468,11 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         // ensure that source and target limb sizes are between 0 and 31 inclusive
         assert!(
             source_limb_size < 32 && source_limb_size > 0,
-            "source limb size must lie between 0 and 31 inclusive"
+            "source limb size must lie between 1 and 31 inclusive"
         );
         assert!(
             target_limb_size < 32 && target_limb_size > 0,
-            "target limb size must lie between 0 and 31 inclusive"
+            "target limb size must lie between 1 and 31 inclusive"
         );
 
         //ensure that source and target limb size aren't greater than N_BITS
@@ -922,5 +922,37 @@ mod test {
         );
         let res = crate::execute_script(script.clone());
         assert!(res.success);
+    }
+
+    #[test]
+    #[should_panic(expected = "source limb size must lie between 0 and 31 inclusive")]
+    fn test_source_limbsize_too_high() {
+        script!(
+            {U254::transform_limbsize(32, 3)}
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "source limb size must lie between 0 and 31 inclusive")]
+    fn test_source_limbsize_too_low() {
+        script!(
+            {U254::transform_limbsize(0, 29)}
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "target limb size must lie between 0 and 31 inclusive")]
+    fn test_target_limbsize_too_high() {
+        script!(
+            {U254::transform_limbsize(29, 32)}
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "target limb size must lie between 0 and 31 inclusive")]
+    fn test_target_limbsize_too_low() {
+        script!(
+            {U254::transform_limbsize(29, 0)}
+        );
     }
 }

--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -975,25 +975,25 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "source limb size must lie between 0 and 31 inclusive")]
+    #[should_panic(expected = "source limb size must lie between 1 and 31 inclusive")]
     fn test_source_limbsize_too_high() {
         script!({ U254::transform_limbsize(32, 3) });
     }
 
     #[test]
-    #[should_panic(expected = "source limb size must lie between 0 and 31 inclusive")]
+    #[should_panic(expected = "source limb size must lie between 1 and 31 inclusive")]
     fn test_source_limbsize_too_low() {
         script!({ U254::transform_limbsize(0, 29) });
     }
 
     #[test]
-    #[should_panic(expected = "target limb size must lie between 0 and 31 inclusive")]
+    #[should_panic(expected = "target limb size must lie between 1 and 31 inclusive")]
     fn test_target_limbsize_too_high() {
         script!({ U254::transform_limbsize(29, 32) });
     }
 
     #[test]
-    #[should_panic(expected = "target limb size must lie between 0 and 31 inclusive")]
+    #[should_panic(expected = "target limb size must lie between 1 and 31 inclusive")]
     fn test_target_limbsize_too_low() {
         script!({ U254::transform_limbsize(29, 0) });
     }

--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -344,10 +344,6 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     /// Doesn't do input validation
     /// All the bits before start_index must be 0 for the extract to work properly
     /// doesnot work when start_index is 32
-    /// Properties to test for Property based testing:
-    /// - if window == start_index, the entire thing should be copied.
-    ///
-    ///
     pub fn extract_digits(start_index: u32, window: u32) -> Script {
         // doesnot work if start_index is 32
         assert!(start_index != 32, "start_index mustn't be 32");

--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -11,7 +11,7 @@ use crate::treepp::*;
 /// Struct to store the information of each step in `transform_limbsize` function.
 #[derive(Debug)]
 struct TransformStep {
-    current_limb_index: u32,
+    current_limb_remaining_bits: u32,
     extract_window: u32,
     drop_currentlimb: bool,
     initiate_targetlimb: bool,
@@ -404,7 +404,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                 match source_limb_remaining_bits.cmp(&target_limb_remaining_bits) {
                     Ordering::Less => {
                         transform_steps.push(TransformStep {
-                            current_limb_index: source_limb_remaining_bits.clone(),
+                            current_limb_remaining_bits: source_limb_remaining_bits.clone(),
                             extract_window: source_limb_remaining_bits.clone(),
                             drop_currentlimb: true,
                             initiate_targetlimb: first_iter_flag,
@@ -414,7 +414,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     }
                     Ordering::Equal => {
                         transform_steps.push(TransformStep {
-                            current_limb_index: source_limb_remaining_bits.clone(),
+                            current_limb_remaining_bits: source_limb_remaining_bits.clone(),
                             extract_window: target_limb_remaining_bits,
                             drop_currentlimb: true,
                             initiate_targetlimb: first_iter_flag,
@@ -424,7 +424,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
                     }
                     Ordering::Greater => {
                         transform_steps.push(TransformStep {
-                            current_limb_index: source_limb_remaining_bits.clone(),
+                            current_limb_remaining_bits: source_limb_remaining_bits.clone(),
                             extract_window: target_limb_remaining_bits,
                             drop_currentlimb: false,
                             initiate_targetlimb: first_iter_flag,
@@ -464,7 +464,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             "source limb size must lie between 0 and 31 inclusive"
         );
         assert!(
-            target_limb_size < 32 && source_limb_size > 0,
+            target_limb_size < 32 && target_limb_size > 0,
             "target limb size must lie between 0 and 31 inclusive"
         );
 
@@ -490,7 +490,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             for _ in 0..(source_n_limbs - 1){OP_TOALTSTACK}
 
             for step in steps{
-                    {Self::extract_digits(step.current_limb_index, step.extract_window)}
+                    {Self::extract_digits(step.current_limb_remaining_bits, step.extract_window)}
 
                     if !step.initiate_targetlimb{
                         OP_ROT


### PR DESCRIPTION
Function to transform one limbsize representation of BigInt to another. Useful in optimizing some implementations especially blake3. 

More tests need to be added. 