### PR TITLE
fix: typos in documentation files

### DIFF
--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -961,7 +961,7 @@ mod test {
             {U876::transform_limbsize(19, 27)}
             {U876::transform_limbsize(27, 14)}
 
-           //push the same input in reverse and verfify
+           //push the same input in reverse and verify
             for _ in 0..62{
                 {0b00000000000000}
                 OP_EQUALVERIFY

--- a/bitvm/src/chunker/elements.rs
+++ b/bitvm/src/chunker/elements.rs
@@ -10,7 +10,7 @@ use crate::{chunker::assigner::BCAssigner, execute_script_with_inputs};
 use std::any::Any;
 use std::fmt::Debug;
 
-/// FqElements are used in the chunker, representing muliple Fq.
+/// FqElements are used in the chunker, representing multiple Fq.
 #[derive(Debug, Clone)]
 pub struct FqElement {
     pub identity: String,

--- a/bitvm/src/chunker/segment.rs
+++ b/bitvm/src/chunker/segment.rs
@@ -233,7 +233,7 @@ mod tests {
         );
 
         let res = execute_script_with_inputs(script, witness);
-        println!("res.successs {}", res.success);
+        println!("res.success {}", res.success);
         println!("res.stack len {}", res.final_stack.len());
         println!("rse.remaining: {}", res.remaining_script);
         println!("res: {:1000}", res);
@@ -270,7 +270,7 @@ mod tests {
         );
 
         let res = execute_script_with_inputs(script, witness);
-        println!("res.successs {}", res.success);
+        println!("res.success {}", res.success);
         println!("res.stack len {}", res.final_stack.len());
         println!("rse.remaining: {}", res.remaining_script);
         println!("res: {:1000}", res);

--- a/bitvm/src/hash/blake3_u4_compact.rs
+++ b/bitvm/src/hash/blake3_u4_compact.rs
@@ -345,7 +345,7 @@ mod tests {
             input_byte_arr.extend_from_slice(&array);
         }
 
-        //processing the string to corrrect for endianess when pushing into stack
+        //processing the string to correct for endianess when pushing into stack
         let input_str_processed = hex::encode(input_byte_arr.clone());
 
         // compute the hash using the official implementation


### PR DESCRIPTION
**Description correction:**
Corrected `verfify` to `verify`
Corrected `muliple` to `multiple`
Corrected `successs` to `success`
Corrected `corrrect` to `correct`