### PR TITLE
Change network to bitvm signet

### DIFF
--- a/bridge/src/client/esplora.rs
+++ b/bridge/src/client/esplora.rs
@@ -3,11 +3,12 @@ use bitcoin::Network;
 const REGTEST_ESPLORA_URL: &str = "http://localhost:8094/regtest/api/";
 // This endpoint accepts non-standard transactions.
 const ALPEN_SIGNET_ESPLORA_URL: &str = "https://esplora-large.devnet-annapurna.stratabtc.org";
+const BITVM_SIGNET_ESPLORA_URL: &str = "https://esplora.bitvmnet.org";
 
 // TODO: Needs to be updated for production environment.
 pub fn get_esplora_url(network: Network) -> &'static str {
     match network {
         Network::Regtest => REGTEST_ESPLORA_URL,
-        _ => ALPEN_SIGNET_ESPLORA_URL,
+        _ => BITVM_SIGNET_ESPLORA_URL,
     }
 }


### PR DESCRIPTION
HI, We Bitlayer built an available BitVM signet for the e2e testing of BitVM repo and BitVM testnet. 

Mempool: https://mempool.bitvmnet.org/
Esplora API Endpoint: https://esplora.bitvmnet.org

By walking through the instructions in `DEMO_INSTRUCTIONS.md`, all test transactions of successful disprove scenario have been sent to BitVM Signet. Here is the list, and anyone can view them by https://mempool.bitvmnet.org/tx/{txid}.

- Peg in  : https://mempool.bitvmnet.org/tx/4dd5d195073af820875b5f19dc2ab30862798af2ea63fc37aecbe1051f1e8688
- Peg in confirm  : https://mempool.bitvmnet.org/tx/e9663b684cb15f255ef0a77fdcc5ffebcfa0ba06dc32b4650b3fab8d91da518f
- Peg out  : https://mempool.bitvmnet.org/tx/095c21cc45331da7fdb45f8f56e184c4d983cf86f539fd32ee39cc44543e71bd
- Peg out confirm  : https://mempool.bitvmnet.org/tx/1c74c2819717b3af854c2ab50b58001186e40f384fb8c1bd01791fce64cc7353
- Kickoff 1  : https://mempool.bitvmnet.org/tx/8d96aab47ef67279141ae0eeccf1b588ab9ad1d75fba1a6dd46a70845499006e
- Kickoff 2  : https://mempool.bitvmnet.org/tx/3c8d81f37e28f64b34a76e41b58788c94e1a7e7a0761c2d5a235aa956908243a
- Assert initial  : https://mempool.bitvmnet.org/tx/8d386719cc3bc461e07c261a14419fd87b8e56374283b79e357b05b9fb3fd45c
- Assert Commit 1  : https://mempool.bitvmnet.org/tx/bb29da2a87879faf46c22fbb19a3961b226c4a6075bad5226a6802472fbb0871
- Assert Commit 2  : https://mempool.bitvmnet.org/tx/93e951de5ce6335f588f344ff58d54e1d813fcecc192a186bf7e19d712556680
- Assert Final  : https://mempool.bitvmnet.org/tx/e7da86777532342521f80bbf2bfc477ebbab289866b6c2842673a006ec34512a
- Disprove  : https://mempool.bitvmnet.org/tx/ee29855315760b5b839ad20c9ce19a1e235c54afc2431b2a527b97458c0ab8e5