### PR TITLE
Optimize small-constant uses of OP_ROLL in the bn254 module.

### DIFF
--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -4,7 +4,7 @@ use num_traits::{FromPrimitive, Num, ToPrimitive};
 
 use crate::bigint::BigIntImpl;
 use crate::bn254::fp254impl::Fp254Impl;
-use crate::pseudo::NMUL;
+use crate::pseudo::{NMUL, roll32};
 use crate::treepp::*;
 
 pub struct Fq;
@@ -285,8 +285,8 @@ macro_rules! fp_lc_mul {
                                         for _ in j+1..N_LC {
                                             OP_FROMALTSTACK
                                         }
-                                        { N_LC - j - 1 } OP_ROLL OP_TOALTSTACK // acc
-                                        { N_LC - j - 1 } OP_ROLL OP_TOALTSTACK // res
+                                        { roll32(N_LC - j - 1) } OP_TOALTSTACK // acc
+                                        { roll32(N_LC - j - 1) } OP_TOALTSTACK // res
                                         for _ in j+1..N_LC {
                                             OP_TOALTSTACK
                                         }
@@ -298,7 +298,7 @@ macro_rules! fp_lc_mul {
                                 OP_FROMALTSTACK
                             }
                             for j in (0..N_LC).rev() {
-                                if j != 0 { { 2*j } OP_ROLL }
+                                if j != 0 { { roll32(2*j) } }
                                 if iter == 1 { OP_DROP } else { OP_TOALTSTACK }
                             }
                         }

--- a/bitvm/src/bn254/fr.rs
+++ b/bitvm/src/bn254/fr.rs
@@ -5,7 +5,7 @@ use num_traits::{FromPrimitive, Num, ToPrimitive};
 
 use crate::bigint::BigIntImpl;
 use crate::bn254::fp254impl::Fp254Impl;
-use crate::pseudo::NMUL;
+use crate::pseudo::{NMUL, roll32};
 use crate::treepp::Script;
 
 pub struct Fr;
@@ -239,8 +239,8 @@ macro_rules! fr_lc_mul {
                                         for _ in j+1..N_LC {
                                             OP_FROMALTSTACK
                                         }
-                                        { N_LC - j - 1 } OP_ROLL OP_TOALTSTACK // acc
-                                        { N_LC - j - 1 } OP_ROLL OP_TOALTSTACK // res
+                                        { roll32(N_LC - j - 1) } OP_TOALTSTACK // acc
+                                        { roll32(N_LC - j - 1) } OP_TOALTSTACK // res
                                         for _ in j+1..N_LC {
                                             OP_TOALTSTACK
                                         }
@@ -252,7 +252,7 @@ macro_rules! fr_lc_mul {
                                 OP_FROMALTSTACK
                             }
                             for j in (0..N_LC).rev() {
-                                if j != 0 { { 2*j } OP_ROLL }
+                                if j != 0 { { roll32(2*j) } }
                                 if iter == 1 { OP_DROP } else { OP_TOALTSTACK }
                             }
                         }

--- a/bitvm/src/pseudo.rs
+++ b/bitvm/src/pseudo.rs
@@ -67,6 +67,21 @@ pub fn OP_4FROMALTSTACK() -> Script {
     }
 }
 
+/// Optimized OP_ROLL with a u32 immediate
+pub fn roll32(n: u32) -> Script {
+    roll(n as usize)
+}
+
+/// Optimized OP_ROLL with a usize immediate
+pub fn roll(n: usize) -> Script {
+    match n {
+        0 => script!(),
+        1 => script!(OP_SWAP),
+        2 => script!(OP_ROT),
+        _ => script!({n} OP_ROLL),
+    }
+}
+
 //
 // Multiplication by Powers of 2
 //


### PR DESCRIPTION
Optimizing `OP_ROLL` usage for fq/fr in the `bn254` implementation decreases the total Groth16 verifier size from 931617108 to 929649780 (as reported by `cargo test --release -- groth16::test::test_hinted_groth16_verifier --nocapture --exact` ), a 0.2% improvement.