### PR TITLE
Refactor blake3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,7 +1965,10 @@ name = "bitvm-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "bitcoin",
+ "bitcoin-script-stack",
  "bitvm",
+ "blake3",
  "libfuzzer-sys",
 ]
 

--- a/bitvm/src/chunk/wrap_hasher.rs
+++ b/bitvm/src/chunk/wrap_hasher.rs
@@ -1,6 +1,6 @@
 use crate::{
     bn254::{fp254impl::Fp254Impl, fq::Fq},
-    hash::blake3::blake3,
+    hash::blake3::blake3_compute_script,
     signatures::wots_api,
     treepp::*,
 };
@@ -25,10 +25,8 @@ fn wrap_scr(scr: Script) -> Script {
 }
 
 // create Script instance from stack-tracker and pad output with zeros to appropriate hash size
-pub(crate) fn hash_n_bytes<const N: u32>() -> Script {
-    let mut stack = StackTracker::new();
-    blake3(&mut stack, N, true, true);
-    wrap_scr(stack.get_script())
+pub(crate) fn hash_n_bytes<const N: usize>() -> Script {
+    wrap_scr(blake3_compute_script(N))
 }
 
 // helpers to directly hash data structures that we work with

--- a/bitvm/src/hash/blake3_utils.rs
+++ b/bitvm/src/hash/blake3_utils.rs
@@ -200,11 +200,11 @@ fn xor_and_rotate_right_by_7(
 /// Variables in `to_move` are consumed from the stack.
 fn u4_add_direct(
     stack: &mut StackTracker,
-    nibble_count: u32,
     to_copy: Vec<StackVariable>,
     mut to_move: Vec<&mut StackVariable>,
     tables: &TablesVars,
 ) {
+    let nibble_count = 8;
     let number_count = to_copy.len() + to_move.len();
 
     for i in (0..nibble_count).rev() {
@@ -263,9 +263,9 @@ fn g(
     let mut va = var_map.get_mut(&a).unwrap();
 
     if last_round {
-        u4_add_direct(stack, 8, vec![vb], vec![&mut va, &mut m_two_i], tables);
+        u4_add_direct(stack, vec![vb], vec![&mut va, &mut m_two_i], tables);
     } else {
-        u4_add_direct(stack, 8, vec![vb, m_two_i], vec![&mut va], tables);
+        u4_add_direct(stack, vec![vb, m_two_i], vec![&mut va], tables);
     }
 
     //stores the results in a
@@ -279,7 +279,7 @@ fn g(
 
     let vd = var_map[&d];
     let mut vc = var_map.get_mut(&c).unwrap();
-    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], tables);
+    u4_add_direct(stack, vec![vd], vec![&mut vc], tables);
     *vc = stack.from_altstack_joined(8, &format!("state_{}", c));
 
     let ret =
@@ -291,13 +291,12 @@ fn g(
     if last_round {
         u4_add_direct(
             stack,
-            8,
             vec![vb],
             vec![&mut va, &mut m_two_i_plus_one],
             tables,
         );
     } else {
-        u4_add_direct(stack, 8, vec![vb, m_two_i_plus_one], vec![&mut va], tables);
+        u4_add_direct(stack, vec![vb, m_two_i_plus_one], vec![&mut va], tables);
     }
 
     *va = stack.from_altstack_joined(8, &format!("state_{}", a));
@@ -309,7 +308,7 @@ fn g(
 
     let vd = var_map[&d];
     let mut vc = var_map.get_mut(&c).unwrap();
-    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], tables);
+    u4_add_direct(stack, vec![vd], vec![&mut vc], tables);
     *vc = stack.from_altstack_joined(8, &format!("state_{}", c));
 
     let ret = xor_and_rotate_right_by_7(stack, var_map, b, c, tables);

--- a/bitvm/src/hash/blake3_utils.rs
+++ b/bitvm/src/hash/blake3_utils.rs
@@ -194,32 +194,18 @@ fn xor_and_rotate_right_by_7(
     stack.join_count(&mut w0, 7)
 }
 
-/// Adds the given constant numbers and u32 variables. to_copy and to_move specify which of these variables are to be consumed and left
+/// Adds the given constant numbers and u32 variables.
+///
+/// Variables in `to_copy` are copied and the original remains on the stack.
+/// Variables in `to_move` are consumed from the stack.
 fn u4_add_direct(
     stack: &mut StackTracker,
     nibble_count: u32,
     to_copy: Vec<StackVariable>,
     mut to_move: Vec<&mut StackVariable>,
-    mut constants: Vec<u32>,
     tables: &TablesVars,
 ) {
-    // add all the constants together
-    if constants.len() > 1 {
-        let mut sum: u32 = 0;
-        for c in constants.iter() {
-            sum = sum.wrapping_add(*c);
-        }
-        constants = vec![sum];
-    }
-
-    //split the parts of the constant (still one element)
-    let mut constant_parts: Vec<Vec<u32>> = Vec::new();
-    for n in constants {
-        let parts = (0..8).rev().map(|i| (n >> (i * 4)) & 0xF).collect();
-        constant_parts.push(parts);
-    }
-
-    let number_count = to_copy.len() + to_move.len() + constant_parts.len();
+    let number_count = to_copy.len() + to_move.len();
 
     for i in (0..nibble_count).rev() {
         for x in to_copy.iter() {
@@ -228,10 +214,6 @@ fn u4_add_direct(
 
         for x in to_move.iter_mut() {
             stack.move_var_sub_n(x, i);
-        }
-
-        for parts in constant_parts.iter() {
-            stack.number(parts[i as usize]);
         }
 
         //add the numbers
@@ -281,16 +263,9 @@ fn g(
     let mut va = var_map.get_mut(&a).unwrap();
 
     if last_round {
-        u4_add_direct(
-            stack,
-            8,
-            vec![vb],
-            vec![&mut va, &mut m_two_i],
-            vec![],
-            tables,
-        );
+        u4_add_direct(stack, 8, vec![vb], vec![&mut va, &mut m_two_i], tables);
     } else {
-        u4_add_direct(stack, 8, vec![vb, m_two_i], vec![&mut va], vec![], tables);
+        u4_add_direct(stack, 8, vec![vb, m_two_i], vec![&mut va], tables);
     }
 
     //stores the results in a
@@ -304,7 +279,7 @@ fn g(
 
     let vd = var_map[&d];
     let mut vc = var_map.get_mut(&c).unwrap();
-    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], vec![], tables);
+    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], tables);
     *vc = stack.from_altstack_joined(8, &format!("state_{}", c));
 
     let ret =
@@ -319,18 +294,10 @@ fn g(
             8,
             vec![vb],
             vec![&mut va, &mut m_two_i_plus_one],
-            vec![],
             tables,
         );
     } else {
-        u4_add_direct(
-            stack,
-            8,
-            vec![vb, m_two_i_plus_one],
-            vec![&mut va],
-            vec![],
-            tables,
-        );
+        u4_add_direct(stack, 8, vec![vb, m_two_i_plus_one], vec![&mut va], tables);
     }
 
     *va = stack.from_altstack_joined(8, &format!("state_{}", a));
@@ -342,7 +309,7 @@ fn g(
 
     let vd = var_map[&d];
     let mut vc = var_map.get_mut(&c).unwrap();
-    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], vec![], tables);
+    u4_add_direct(stack, 8, vec![vd], vec![&mut vc], tables);
     *vc = stack.from_altstack_joined(8, &format!("state_{}", c));
 
     let ret = xor_and_rotate_right_by_7(stack, var_map, b, c, tables);

--- a/bitvm/src/lib.rs
+++ b/bitvm/src/lib.rs
@@ -117,6 +117,10 @@ impl fmt::Display for ExecuteInfo {
 }
 
 pub fn execute_script(script: treepp::Script) -> ExecuteInfo {
+    execute_script_buf(script.compile())
+}
+
+pub fn execute_script_buf(script: bitcoin::ScriptBuf) -> ExecuteInfo {
     let mut exec = Exec::new(
         ExecCtx::Tapscript,
         Options::default(),
@@ -131,10 +135,10 @@ pub fn execute_script(script: treepp::Script) -> ExecuteInfo {
             input_idx: 0,
             taproot_annex_scriptleaf: Some((TapLeafHash::all_zeros(), None)),
         },
-        script.compile(),
+        script,
         vec![],
     )
-    .expect("error creating exec");
+        .expect("error creating exec");
 
     loop {
         if exec.exec_next().is_err() {

--- a/bitvm/src/lib.rs
+++ b/bitvm/src/lib.rs
@@ -138,7 +138,7 @@ pub fn execute_script_buf(script: bitcoin::ScriptBuf) -> ExecuteInfo {
         script,
         vec![],
     )
-        .expect("error creating exec");
+    .expect("error creating exec");
 
     loop {
         if exec.exec_next().is_err() {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = "1.4.1"
+arbitrary = { version = "1.4.1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 bitvm = { path = "../bitvm", features = ["fuzzing"] }
 blake3 = "=1.5.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,9 @@ cargo-fuzz = true
 arbitrary = "1.4.1"
 libfuzzer-sys = "0.4"
 bitvm = { path = "../bitvm", features = ["fuzzing"] }
+blake3 = "=1.5.1"
+bitcoin = { version = "0.32.5" }
+bitcoin-script-stack = { git = "https://github.com/BitVM/rust-bitcoin-script-stack" }
 
 [[bin]]
 name = "blake3"

--- a/fuzz/fuzz_targets/blake3.rs
+++ b/fuzz/fuzz_targets/blake3.rs
@@ -20,9 +20,5 @@ impl<'a> Arbitrary<'a> for LimitedBytes {
 }
 
 fuzz_target!(|data: LimitedBytes| {
-    // use full tables
-    test_blake3_givenbyteslice(&data.0, true);
-
-    // use half tables
-    test_blake3_givenbyteslice(&data.0, false);
+    test_blake3_givenbyteslice(&data.0);
 });

--- a/fuzz/fuzz_targets/blake3.rs
+++ b/fuzz/fuzz_targets/blake3.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Result, Unstructured};
 use libfuzzer_sys::fuzz_target;
 
-use bitvm::hash::blake3::test_blake3_givenbyteslice;
+use bitvm::hash::blake3::verify_blake_output;
 
 /// This struct will hold up to 1024 bytes of fuzz data.
 #[derive(Debug)]
@@ -20,5 +20,6 @@ impl<'a> Arbitrary<'a> for LimitedBytes {
 }
 
 fuzz_target!(|data: LimitedBytes| {
-    test_blake3_givenbyteslice(&data.0);
+    let expected_hash = blake3::hash(&message).as_bytes().clone();
+    verify_blake_output(&data.0, expected_hash);
 });

--- a/fuzz/fuzz_targets/blake3.rs
+++ b/fuzz/fuzz_targets/blake3.rs
@@ -1,28 +1,75 @@
 #![no_main]
 
+use std::iter::IntoIterator;
 use std::sync::LazyLock;
 
+use arbitrary::Arbitrary;
 use bitcoin::ScriptBuf;
 use bitcoin_script_stack::optimizer;
 use libfuzzer_sys::fuzz_target;
-
 use bitvm::execute_script_buf;
 use bitvm::hash::blake3::{
     blake3_compute_script, blake3_push_message_script, blake3_verify_output_script,
 };
 
-static BLAKE3_COMPUTE_SCRIPT: LazyLock<ScriptBuf> =
-    LazyLock::new(|| optimizer::optimize(blake3_compute_script(32).compile()));
+static BLAKE3_COMPUTE_SCRIPTS: LazyLock<[ScriptBuf; 4]> =
+    LazyLock::new(|| [64, 128, 192, 448]
+            .into_iter()
+            .map(|msg_len| blake3_compute_script(msg_len).compile())
+            .map(|script| optimizer::optimize(script))
+            .collect::<Vec<ScriptBuf>>()
+            .try_into().unwrap()
+    );
 
-fuzz_target!(|message: [u8; 32]| {
-    let expected_hash = blake3::hash(&message).as_bytes().clone();
+/// Cover all message sizes that are used inside BitVM.
+///
+/// Each message size is processed by a different BLAKE3 Bitcoin script.
+/// Computing and optimizing each of these scripts takes considerable time.
+/// Even when we cache the result, the fuzzer has to wait until all scripts are gennerated.
+///
+/// In order to get useful coverage while keeping computational effort low,
+/// we fuzz exactly the message sizes that are used inside BitVM.
+/// It turns out, there are only four different sizes.
+#[derive(Debug, Clone, Arbitrary)]
+enum MessageBytes {
+    U64([u8; 64]),
+    U128([u8; 128]),
+    U192([u8; 192]),
+    U448([u8; 448]),
+}
 
-    let mut bytes = blake3_push_message_script(&message).compile().to_bytes();
-    bytes.extend_from_slice(BLAKE3_COMPUTE_SCRIPT.as_bytes());
-    bytes.extend(
+impl AsRef<[u8]> for MessageBytes {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::U64(bytes) => bytes,
+            Self::U128(bytes) => bytes,
+            Self::U192(bytes) => bytes,
+            Self::U448(bytes) => bytes,
+        }
+    }
+}
+
+impl MessageBytes {
+    pub fn blake3_compute_script(&self) -> &'static ScriptBuf {
+        let index = match self {
+            Self::U64(..) => 0,
+            Self::U128(..) => 1,
+            Self::U192(..) => 2,
+            Self::U448(..) => 3,
+        };
+        &BLAKE3_COMPUTE_SCRIPTS[index]
+    }
+}
+
+fuzz_target!(|message: MessageBytes| {
+    let expected_hash = blake3::hash(message.as_ref()).as_bytes().clone();
+
+    let mut bytes = blake3_push_message_script(message.as_ref()).compile().to_bytes();
+    bytes.extend_from_slice(message.blake3_compute_script().as_bytes());
+    bytes.extend_from_slice(
         blake3_verify_output_script(expected_hash)
             .compile()
-            .to_bytes(),
+            .as_bytes(),
     );
     let script = ScriptBuf::from_bytes(bytes);
     assert!(execute_script_buf(script).success);


### PR DESCRIPTION
This PR further cleans up the BLAKE3 code. It adds functions for pushing a message input onto the stack, for computing BLAKE3 on that input, and for verifying that the resulting output matches the expected hash. The unit tests are rewritten using this logic. The fuzz test is rewritten to use a cached version of the BLAKE3 compute script in each iteration.

Fixes #254 

## Need for half tables?

This PR removes the option for half tables from the API. I argue that we should always use full tables (smaller script size, more stack use) and not burden the caller with deciding which table to use. As far as I can see, BLAKE3 [is always called with full tables in BitVM](https://github.com/BitVM/BitVM/blob/0c4d463c3e2dd79d3b27d6958f5ebff6e24b592f/bitvm/src/chunk/wrap_hasher.rs#L23).

~~If there is consensus that we don't need half tables, then I will go ahead and remove that code. I will keep this PR as a draft until we have resolved this question.~~
There seems to no one who needs half tables. With the given BLAKE3 implementation, the stack has to be empty except for the message. In this setting, the script has access to the maximum number of stack items. This nullifies the upside of half tables and makes full tables always better.