### PR TITLE
Speed up build times via defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ members = [
     "prover",
 ]
 
+default-members = [
+    "bitvm",
+    "bridge",
+    "fuzz",
+]
+
 [workspace.dependencies]
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoin = { version = "0.32.5", features = ["rand-std"] }


### PR DESCRIPTION
Work elsewhere in #250 by @ozankaymak speeds up build times using workspace defaults. This is currently part of a draft PR that includes a test update. This PR isolates the build time fix in order to get it out faster and improve PR atomicity.