### PR TITLE
Fix clippy

### DIFF
--- a/bitvm/src/bigint/inv.rs
+++ b/bitvm/src/bigint/inv.rs
@@ -1,9 +1,5 @@
 use crate::bigint::BigIntImpl;
-use crate::pseudo::OP_NDUP;
 use crate::treepp::*;
-use core::ops::{Mul, Rem, Sub};
-use num_bigint::BigUint;
-use num_traits::Num;
 
 impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     pub fn div2() -> Script {

--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -38,8 +38,8 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             chunk_vec.resize(LIMB_SIZE as usize, false);
 
             let mut elem = 0u32;
-            for (i, chunk_i) in chunk_vec.iter().enumerate() {
-                if *chunk_i {
+            for (i, chunk_i) in chunk_vec.into_iter().enumerate() {
+                if chunk_i {
                     elem += 1 << i;
                 }
             }
@@ -79,8 +79,8 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             chunk_vec.resize(32, false);
 
             let mut elem = 0u32;
-            for i in 0..32_usize {
-                if chunk_vec[i] {
+            for (i, chunk_i) in chunk_vec.into_iter().enumerate() {
+                if chunk_i {
                     elem += 1 << i;
                 }
             }
@@ -343,7 +343,6 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     /// Generates a vector of TransformStep struct that encodes all the information needed to
     /// convert BigInt form one limbsize represention (source) to another (target).
     /// used as a helper function for `transform_limbsize`
-
     fn get_transform_steps(source_limb_size: u32, target_limb_size: u32) -> Vec<TransformStep> {
         //define an empty vector to store Transform steps
         let mut transform_steps: Vec<TransformStep> = Vec::new();
@@ -428,7 +427,6 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     /// - If the source or target limb size is greater than number of bits, fails with assertion error.
     /// - If the elements do not fit on the stack. (few satck elements are also used for intermediate computation).
     /// - The number of bits in the BigInt must be 32 or larger.
-
     pub fn transform_limbsize(source_limb_size: u32, target_limb_size: u32) -> Script {
         // ensure that source and target limb sizes are between 0 and 31 inclusive
         assert!(

--- a/bitvm/src/bn254/ell_coeffs.rs
+++ b/bitvm/src/bn254/ell_coeffs.rs
@@ -10,7 +10,6 @@ use ark_ec::short_weierstrass::SWCurveConfig;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::Field;
 use ark_ff::{AdditiveGroup, CyclotomicMultSubgroup};
-use ark_std::cfg_chunks_mut;
 use itertools::Itertools;
 use num_traits::One;
 
@@ -28,6 +27,7 @@ pub struct G2Prepared {
 pub type EllCoeff = (ark_bn254::Fq2, ark_bn254::Fq2, ark_bn254::Fq2);
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 struct G2HomProjective {
     x: ark_bn254::Fq2,
     y: ark_bn254::Fq2,
@@ -35,6 +35,7 @@ struct G2HomProjective {
 }
 
 impl G2HomProjective {
+    #[allow(dead_code)]
     fn double_in_place(&mut self, two_inv: &ark_bn254::Fq) -> EllCoeff {
         // Formula for line function when working with
         // homogeneous projective coordinates.
@@ -61,6 +62,7 @@ impl G2HomProjective {
         }
     }
 
+    #[allow(dead_code)]
     fn add_in_place(&mut self, q: &ark_bn254::G2Affine) -> EllCoeff {
         // Formula for line function when working with
         // homogeneous projective coordinates.
@@ -323,7 +325,8 @@ impl AffinePairing for BnAffinePairing {
             })
             .collect::<Vec<_>>();
 
-        let mut f = cfg_chunks_mut!(pairs, 4)
+        let mut f = pairs
+            .chunks_mut(4)
             .map(|pairs| {
                 let mut f = ark_bn254::Fq12::one();
                 for i in (1..Config::ATE_LOOP_COUNT.len()).rev() {

--- a/bitvm/src/chunk/api.rs
+++ b/bitvm/src/chunk/api.rs
@@ -86,31 +86,25 @@ pub mod type_conversion_utils {
         }
     }
 
-    pub fn utils_signatures_from_raw_witnesses(raw_wits: &Vec<RawWitness>) -> Signatures {
+    #[allow(clippy::needless_range_loop)]
+    pub fn utils_signatures_from_raw_witnesses(raw_wits: &[RawWitness]) -> Signatures {
         assert_eq!(raw_wits.len(), NUM_PUBS + NUM_U256 + NUM_HASH);
         let mut asigs = vec![];
         for i in 0..NUM_PUBS {
-            let a: wots256::Signature =
-                wots256::raw_witness_to_signature(&Witness::from_slice(&raw_wits[i]))
-                    .try_into()
-                    .unwrap();
+            let a = wots256::raw_witness_to_signature(&Witness::from_slice(&raw_wits[i]));
             asigs.push(a);
         }
         let mut bsigs = vec![];
         for i in 0..NUM_U256 {
-            let a: wots256::Signature =
-                wots256::raw_witness_to_signature(&Witness::from_slice(&raw_wits[i + NUM_PUBS]))
-                    .try_into()
-                    .unwrap();
+            let a =
+                wots256::raw_witness_to_signature(&Witness::from_slice(&raw_wits[i + NUM_PUBS]));
             bsigs.push(a);
         }
         let mut csigs = vec![];
         for i in 0..NUM_HASH {
-            let a: wots_hash::Signature = wots_hash::raw_witness_to_signature(
-                &Witness::from_slice(&raw_wits[i + NUM_PUBS + NUM_U256]),
-            )
-            .try_into()
-            .unwrap();
+            let a = wots_hash::raw_witness_to_signature(&Witness::from_slice(
+                &raw_wits[i + NUM_PUBS + NUM_U256],
+            ));
             csigs.push(a);
         }
         let asigs = asigs.try_into().unwrap();
@@ -155,8 +149,7 @@ pub mod type_conversion_utils {
         let mut apubs = vec![];
         let mut bpubs = vec![];
         let mut cpubs = vec![];
-        for idx in 0..commits_public_keys.len() {
-            let f = commits_public_keys[idx];
+        for (idx, f) in commits_public_keys.into_iter().enumerate() {
             if idx < NUM_PUBS {
                 let p: wots256::PublicKey = f.public_key.clone().try_into().unwrap();
                 apubs.push(p);
@@ -420,6 +413,7 @@ mod test {
             Ok(())
         }
 
+        #[allow(clippy::type_complexity)]
         pub(crate) fn read_map_from_file(
             filename: &str,
         ) -> Result<HashMap<u32, Vec<Vec<u8>>>, Box<dyn Error>> {
@@ -488,6 +482,7 @@ mod test {
             write_map_to_file(&obj, filename).unwrap();
         }
 
+        #[allow(clippy::needless_range_loop)]
         pub fn read_asserts_from_file(filename: &str) -> Assertions {
             let res = read_map_from_file(filename).unwrap();
             let proof_vec = res.get(&0).unwrap();
@@ -769,6 +764,8 @@ mod test {
         assert!(res.success);
         println!("DONE");
     }
+
+    #[allow(clippy::needless_range_loop)]
     fn sign_assertions(assn: Assertions) -> Signatures {
         let (ps, fs, hs) = (assn.0, assn.1, assn.2);
         let secret = MOCK_SECRET;
@@ -845,8 +842,8 @@ mod test {
         let partial_scripts = api_generate_partial_script(&mock_vk);
 
         let mut script_cache = HashMap::new();
-        for i in 0..partial_scripts.len() {
-            script_cache.insert(i as u32, vec![partial_scripts[i].clone()]);
+        for (i, script) in partial_scripts.into_iter().enumerate() {
+            script_cache.insert(i as u32, vec![script]);
         }
 
         write_scripts_to_separate_files(script_cache, "tapnode");

--- a/bitvm/src/chunk/api_compiletime_utils.rs
+++ b/bitvm/src/chunk/api_compiletime_utils.rs
@@ -195,7 +195,7 @@ pub(crate) fn generate_segments_using_mock_vk_and_mock_proof() -> Vec<Segment> {
     generate_segments_using_mock_proof(mock_vk, true)
 }
 
-pub(crate) fn partial_scripts_from_segments(segments: &Vec<Segment>) -> Vec<treepp::Script> {
+pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<treepp::Script> {
     fn serialize_element_types(elems: &[ElementType]) -> String {
         // 1. Convert each variant to its string representation.
         let joined = elems
@@ -236,8 +236,7 @@ pub(crate) fn partial_scripts_from_segments(segments: &Vec<Segment>) -> Vec<tree
             });
     }
 
-    for i in 0..segments.len() {
-        let seg = &segments[i];
+    for seg in segments {
         let scr_type = seg.scr_type.clone();
         if scr_type == ScriptType::NonDeterministic {
             continue;
@@ -270,7 +269,7 @@ pub(crate) fn partial_scripts_from_segments(segments: &Vec<Segment>) -> Vec<tree
 }
 
 pub(crate) fn bitcom_scripts_from_segments(
-    segments: &Vec<Segment>,
+    segments: &[Segment],
     wots_pubkeys: PublicKeys,
 ) -> Vec<treepp::Script> {
     let mut bitcom_scripts: Vec<treepp::Script> = vec![];

--- a/bitvm/src/chunk/elements.rs
+++ b/bitvm/src/chunk/elements.rs
@@ -15,6 +15,8 @@ use super::helpers::{extern_hash_fps, extern_nibbles_to_limbs};
 
 /// Data Structure to hold values passed around in pairing check
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+#[allow(clippy::large_enum_variant)]
 pub enum DataType {
     /// Fp6 elements
     Fp6Data(ark_bn254::Fq6),
@@ -116,6 +118,7 @@ pub enum CompressedStateObject {
 impl CompressedStateObject {
     // helper function to represent State as hint
     // used in tests to check the validity of checksig_verify()
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn as_hint_type(self) -> Hint {
         match self {
             CompressedStateObject::Hash(h) => Hint::Hash(extern_nibbles_to_limbs(h)),
@@ -215,6 +218,7 @@ impl DataType {
     }
 
     // hashing pre-image for the DataType
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_witness(&self, elem_type: ElementType) -> Vec<Hint> {
         match (elem_type, self) {
             (ElementType::G2EvalPoint, DataType::G2EvalData(g)) => {

--- a/bitvm/src/chunk/g16_runner_core.rs
+++ b/bitvm/src/chunk/g16_runner_core.rs
@@ -326,10 +326,10 @@ pub(crate) fn groth16_generate_segments(
     push_compare_or_return!(t4);
 
     // (t2, t3) = (le.t2, le.t3);
-    let tmp_q2f = frob_q_power(pubs.q2, -1);
-    t2 = (t2 + tmp_q2f).into_affine();
-    let tmp_q3f = frob_q_power(pubs.q3, -1);
-    t3 = (t3 + tmp_q3f).into_affine();
+    // let tmp_q2f = frob_q_power(pubs.q2, -1);
+    // t2 = (t2 + tmp_q2f).into_affine();
+    // let tmp_q3f = frob_q_power(pubs.q3, -1);
+    // t3 = (t3 + tmp_q3f).into_affine();
     let lev = wrap_chunk_point_ops_and_multiply_line_evals_step_2(
         skip_evaluation,
         all_output_hints.len(),
@@ -355,6 +355,7 @@ pub(crate) fn groth16_generate_segments(
     is_valid == ark_ff::BigInt::<4>::one()
 }
 
+#[allow(clippy::type_complexity)]
 fn raw_input_proof_to_segments(
     eval_ins: InputProofRaw,
     all_output_hints: &mut Vec<Segment>,
@@ -559,7 +560,7 @@ mod test {
         let f = pairing
             .multi_miller_loop_affine([p1, p2, p3, p4], [q1, q2, q3, q4])
             .0;
-        let (c, s) = compute_c_wi(f);
+        let (c, _s) = compute_c_wi(f);
         let eval_ins: InputProof = InputProof {
             p2,
             p4,
@@ -741,7 +742,7 @@ mod test {
         ps: Vec<ark_bn254::G1Affine>,
         qs: Vec<ark_bn254::G2Affine>,
         gc: ark_bn254::Fq12,
-        s: ark_bn254::Fq12,
+        _s: ark_bn254::Fq12,
         p1q1: ark_bn254::Fq6,
     ) {
         use crate::chunk::{
@@ -805,6 +806,7 @@ mod test {
         let num_pairings = ps.len();
 
         let mut total_script_size = 0;
+        #[allow(unused_assignments)] // clippy bug?
         let mut temp_scr = script! {};
 
         let (mut t4, _, scr, _) = chunk_init_t4([
@@ -1053,10 +1055,10 @@ mod test {
 
         println!("total script size {:?}", total_script_size);
 
-        let tmp_q2f = frob_q_power(qs[0], -1);
-        t2 = (t2 + tmp_q2f).into_affine();
-        let tmp_q3f = frob_q_power(qs[1], -1);
-        t3 = (t3 + tmp_q3f).into_affine();
+        // let tmp_q2f = frob_q_power(qs[0], -1);
+        // t2 = (t2 + tmp_q2f).into_affine();
+        // let tmp_q3f = frob_q_power(qs[1], -1);
+        // t3 = (t3 + tmp_q3f).into_affine();
         assert_eq!(g, f.c1);
 
         assert_eq!(g + p1q1, ark_bn254::Fq6::ZERO); // final check, f: (a+b == 0 => (1 + a) * (1 + b) == Fq12::ONE)

--- a/bitvm/src/chunk/g16_runner_core.rs
+++ b/bitvm/src/chunk/g16_runner_core.rs
@@ -292,7 +292,6 @@ pub(crate) fn groth16_generate_segments(
     );
     push_compare_or_return!(t4);
 
-    // (t2, t3) = (le.t2, le.t3);
     let tmp_q2f = frob_q_power(pubs.q2, 1);
     t2 = (t2 + tmp_q2f).into_affine();
     let tmp_q3f = frob_q_power(pubs.q3, 1);
@@ -325,11 +324,6 @@ pub(crate) fn groth16_generate_segments(
     );
     push_compare_or_return!(t4);
 
-    // (t2, t3) = (le.t2, le.t3);
-    // let tmp_q2f = frob_q_power(pubs.q2, -1);
-    // t2 = (t2 + tmp_q2f).into_affine();
-    // let tmp_q3f = frob_q_power(pubs.q3, -1);
-    // t3 = (t3 + tmp_q3f).into_affine();
     let lev = wrap_chunk_point_ops_and_multiply_line_evals_step_2(
         skip_evaluation,
         all_output_hints.len(),
@@ -673,9 +667,6 @@ mod test {
             f *= cq;
             f = ark_bn254::Fq12::new(ark_bn254::Fq6::ONE, f.c1 / f.c0);
         }
-
-        // f *= s;
-        // f = ark_bn254::Fq12::new(ark_bn254::Fq6::ONE, f.c1/f.c0);
 
         for i in 0..num_pairings {
             let mut q = qs[i];
@@ -1054,11 +1045,6 @@ mod test {
         total_script_size += temp_scr.len();
 
         println!("total script size {:?}", total_script_size);
-
-        // let tmp_q2f = frob_q_power(qs[0], -1);
-        // t2 = (t2 + tmp_q2f).into_affine();
-        // let tmp_q3f = frob_q_power(qs[1], -1);
-        // t3 = (t3 + tmp_q3f).into_affine();
         assert_eq!(g, f.c1);
 
         assert_eq!(g + p1q1, ark_bn254::Fq6::ZERO); // final check, f: (a+b == 0 => (1 + a) * (1 + b) == Fq12::ONE)

--- a/bitvm/src/chunk/g16_runner_utils.rs
+++ b/bitvm/src/chunk/g16_runner_utils.rs
@@ -18,7 +18,7 @@ use super::{
         chunk_point_ops_and_multiply_line_evals_step_2,
     },
 };
-use ark_ff::{AdditiveGroup, Field};
+use ark_ff::Field;
 use bitcoin_script::script;
 
 use super::taps_ext_miller::{chunk_final_verify, chunk_frob_fp12, chunk_hash_c, chunk_hash_c_inv};
@@ -193,6 +193,7 @@ pub(crate) fn wrap_hints_frob_fp12(
 }
 
 // ops
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn wrap_chunk_point_ops_and_multiply_line_evals_step_1(
     skip: bool,
     segment_id: usize,
@@ -300,8 +301,6 @@ pub(crate) fn wrap_hint_msm(
         .collect();
 
     let mut segments = vec![];
-    let mut prev_input =
-        ark_bn254::G1Affine::new_unchecked(ark_bn254::Fq::ZERO, ark_bn254::Fq::ZERO);
     if !skip {
         let houts = chunk_msm(hint_scalars, pub_vky.clone());
         assert_eq!(houts.len(), num_chunks_per_scalar as usize * scalars.len());
@@ -316,8 +315,6 @@ pub(crate) fn wrap_hint_msm(
 
             let sc = &scalars[msm_chunk_index / num_chunks_per_scalar as usize];
             input_segment_info.push((sc.id, ElementType::ScalarElem));
-
-            prev_input = hout_msm;
 
             segments.push(Segment {
                 id: (segment_id + msm_chunk_index) as u32,
@@ -360,8 +357,7 @@ pub(crate) fn wrap_hint_hash_p(
     in_t: &Segment,
     pub_vky0: ark_bn254::G1Affine,
 ) -> Segment {
-    let mut input_segment_info: Vec<(SegmentID, ElementType)> = vec![];
-    input_segment_info.push((in_t.id, ElementType::G1));
+    let input_segment_info = vec![(in_t.id, ElementType::G1)];
 
     let t = in_t.result.0.try_into().unwrap();
     let (mut p3, mut is_valid_input, mut scr, mut op_hints) =
@@ -387,9 +383,10 @@ pub(crate) fn wrap_hints_precompute_p(
     in_py: &Segment,
     in_px: &Segment,
 ) -> Segment {
-    let mut input_segment_info: Vec<(SegmentID, ElementType)> = vec![];
-    input_segment_info.push((in_py.id, ElementType::FieldElem));
-    input_segment_info.push((in_px.id, ElementType::FieldElem));
+    let input_segment_info: Vec<(SegmentID, ElementType)> = vec![
+        (in_py.id, ElementType::FieldElem),
+        (in_px.id, ElementType::FieldElem),
+    ];
 
     let (mut p3d, mut is_valid_input, mut scr, mut op_hints) =
         (ark_bn254::G1Affine::identity(), true, script! {}, vec![]);
@@ -416,8 +413,7 @@ pub(crate) fn wrap_hints_precompute_p_from_hash(
     segment_id: usize,
     in_p: &Segment,
 ) -> Segment {
-    let mut input_segment_info: Vec<(SegmentID, ElementType)> = vec![];
-    input_segment_info.push((in_p.id, ElementType::G1));
+    let input_segment_info = vec![(in_p.id, ElementType::G1)];
 
     let (mut p3d, mut is_valid_input, mut scr, mut op_hints) =
         (ark_bn254::G1Affine::identity(), true, script! {}, vec![]);

--- a/bitvm/src/chunk/helpers.rs
+++ b/bitvm/src/chunk/helpers.rs
@@ -173,6 +173,7 @@ mod test {
     };
 
     #[test]
+    #[allow(clippy::needless_range_loop)]
     fn test_emulate_fq_to_nibbles() {
         let mut prng = ChaCha20Rng::seed_from_u64(1777);
         let p = ark_bn254::Fq::rand(&mut prng);
@@ -199,6 +200,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::needless_range_loop)]
     fn test_emulate_external_hash() {
         fn emulate_extern_hash_fps_scripted(msgs: Vec<ark_bn254::Fq>) -> [u8; 64] {
             assert!(

--- a/bitvm/src/chunk/taps_msm.rs
+++ b/bitvm/src/chunk/taps_msm.rs
@@ -6,7 +6,7 @@ use crate::bn254::msm;
 use crate::bn254::utils::Hint;
 use crate::chunk::api::NUM_PUBS;
 use crate::{bn254::fp254impl::Fp254Impl, treepp::*};
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::CurveGroup;
 use ark_ff::{AdditiveGroup, Field, PrimeField};
 
 use super::elements::ElementType;
@@ -181,6 +181,7 @@ mod test {
             helpers::extern_hash_nibbles,
         },
     };
+    use ark_ec::AffineRepr;
     use ark_ff::{BigInt, Field, UniformRand};
 
     use rand::SeedableRng;

--- a/bitvm/src/chunk/taps_point_ops.rs
+++ b/bitvm/src/chunk/taps_point_ops.rs
@@ -402,6 +402,7 @@ fn utils_point_add_eval(
     (result, script, hints)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn point_ops_and_multiply_line_evals_step_1(
     is_dbl: bool,
     is_frob: Option<bool>,
@@ -609,6 +610,7 @@ fn point_ops_and_multiply_line_evals_step_1(
     (hout, input_is_valid, scr, hints)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn chunk_point_ops_and_multiply_line_evals_step_1(
     is_dbl: bool,
     is_frob: Option<bool>,

--- a/bitvm/src/chunk/wrap_wots.rs
+++ b/bitvm/src/chunk/wrap_wots.rs
@@ -41,10 +41,12 @@ pub(crate) fn checksig_verify_to_limbs(pub_key: &WOTSPubKey) -> Script {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn byte_array_to_wots_hash_sig(secret: &str, msg_bytes: &[u8]) -> wots_hash::Signature {
     wots_hash::get_signature(secret, msg_bytes)
 }
 
+#[allow(dead_code)]
 pub(crate) fn byte_array_to_wots256_sig(secret: &str, msg_bytes: &[u8]) -> wots256::Signature {
     wots256::get_signature(secret, msg_bytes)
 }
@@ -78,6 +80,7 @@ pub(crate) fn wots_hash_sig_to_byte_array(sig: wots_hash::Signature) -> Vec<u8> 
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum WOTSPubKey {
     PHash(wots_hash::PublicKey),
     P256(wots256::PublicKey),

--- a/bitvm/src/groth16/test.rs
+++ b/bitvm/src/groth16/test.rs
@@ -11,23 +11,12 @@ use ark_std::{end_timer, start_timer, test_rng, UniformRand};
 use bitcoin_script::script;
 use rand::{RngCore, SeedableRng};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct DummyCircuit<F: PrimeField> {
     pub a: Option<F>,
     pub b: Option<F>,
     pub num_variables: usize,
     pub num_constraints: usize,
-}
-
-impl<F: PrimeField> Clone for DummyCircuit<F> {
-    fn clone(&self) -> Self {
-        DummyCircuit {
-            a: self.a,
-            b: self.b,
-            num_variables: self.num_variables,
-            num_constraints: self.num_constraints,
-        }
-    }
 }
 
 impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {

--- a/bitvm/src/groth16/verifier.rs
+++ b/bitvm/src/groth16/verifier.rs
@@ -53,9 +53,9 @@ impl Verifier {
 
         // hint from arkworks
         let pairing = BnAffinePairing;
-        let f = pairing
-            .multi_miller_loop_affine([p1, p2, p3, p4], [q1, q2, q3, q4])
-            .0;
+        // let f = pairing
+        //     .multi_miller_loop_affine([p1, p2, p3, p4], [q1, q2, q3, q4])
+        //     .0;
         let f_without_3 = pairing
             .multi_miller_loop_affine([p1, p2, p4], [q1, q2, q4])
             .0;

--- a/bitvm/src/groth16/verifier.rs
+++ b/bitvm/src/groth16/verifier.rs
@@ -53,9 +53,6 @@ impl Verifier {
 
         // hint from arkworks
         let pairing = BnAffinePairing;
-        // let f = pairing
-        //     .multi_miller_loop_affine([p1, p2, p3, p4], [q1, q2, q3, q4])
-        //     .0;
         let f_without_3 = pairing
             .multi_miller_loop_affine([p1, p2, p4], [q1, q2, q4])
             .0;

--- a/bitvm/src/hash/blake3.rs
+++ b/bitvm/src/hash/blake3.rs
@@ -297,9 +297,9 @@ pub fn maximum_number_of_altstack_elements_using_blake3(message_len: usize, limb
 /// - The input message is in the form U256 where each message block is comprised of two U256, each represented with elements consisting of `limb_len` bits
 /// - The input message must unpack to a multiple of 128 nibbles, so pushing padding bytes is necessary
 /// - __BLAKE3 uses exactly [`MAX_BLAKE3_ELEMENT_COUNT`] = 644 elements at maximum, including the tables__ \
-///  With the max stack limit 1000, __you are allowed to have at most 356 elements including the message (excluding the first block of it) in stack (in total, of altstack and stack)__ \
-///  Note that smaller `limb_len`'s means more elements, hence more stack usage \
-///  For a more certain number, you can look into and use [`maximum_number_of_altstack_elements_using_blake3`]
+///   With the max stack limit 1000, __you are allowed to have at most 356 elements including the message (excluding the first block of it) in stack (in total, of altstack and stack)__ \
+///   Note that smaller `limb_len`'s means more elements, hence more stack usage \
+///   For a more certain number, you can look into and use [`maximum_number_of_altstack_elements_using_blake3`]
 /// - A message of `n` blocks is expected in the following format:
 ///
 /// ```text

--- a/bitvm/src/hash/blake3_utils.rs
+++ b/bitvm/src/hash/blake3_utils.rs
@@ -538,9 +538,7 @@ mod tests {
         let mut stack = StackTracker::new();
         let tables = TablesVars::new(&mut stack, true);
 
-        let mut ret = Vec::new();
-        ret.push(stack.number_u32(0xdeadbeaf));
-        ret.push(stack.number_u32(0x01020304));
+        let ret = [stack.number_u32(0xdeadbeaf), stack.number_u32(0x01020304)];
 
         let mut var_map: HashMap<u8, StackVariable> = HashMap::new();
         var_map.insert(0, ret[0]);

--- a/bitvm/src/hash/sha256_u4.rs
+++ b/bitvm/src/hash/sha256_u4.rs
@@ -471,6 +471,7 @@ mod tests {
 
     use crate::hash::sha256_u4::*;
     use crate::{execute_script, treepp::script};
+    use bitcoin::hex::DisplayHex;
     use sha2::{Digest, Sha256};
 
     #[test]
@@ -543,18 +544,10 @@ mod tests {
     #[test]
     fn test_sha256_strs() {
         let message = "Hello.";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex: String = message.as_bytes().to_lower_hex_string();
         test_sha256(&hex);
         let message = "This is a longer message that still fits in one block!";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex: String = message.as_bytes().to_lower_hex_string();
         test_sha256(&hex)
     }
 

--- a/bitvm/src/hash/sha256_u4_stack.rs
+++ b/bitvm/src/hash/sha256_u4_stack.rs
@@ -729,6 +729,7 @@ mod tests {
     use super::*;
     use crate::execute_script;
     use crate::u4::u4_std::u4_drop;
+    use bitcoin::hex::DisplayHex;
     use bitcoin_script::Script as StructuredScript;
     use bitcoin_script_stack::stack::{script, Script, StackTracker};
     use sha2::{Digest, Sha256};
@@ -855,18 +856,10 @@ mod tests {
     #[test]
     fn test_sha256_strs() {
         let message = "Hello.";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex: String = message.as_bytes().to_lower_hex_string();
         test_sha256(&hex, true, true);
         let message = "This is a longer message that still fits in one block!";
-        let hex: String = message
-            .as_bytes()
-            .iter()
-            .map(|&b| format!("{:02x}", b))
-            .collect();
+        let hex: String = message.as_bytes().to_lower_hex_string();
         test_sha256(&hex, true, true)
     }
 

--- a/bitvm/src/signatures/signing_winternitz.rs
+++ b/bitvm/src/signatures/signing_winternitz.rs
@@ -108,7 +108,7 @@ pub fn generate_winternitz_witness(signing_inputs: &WinternitzSigningInputs) -> 
     WINTERNITZ_MESSAGE_VERIFIER.sign(
         &signing_inputs.signing_key.parameters,
         &signing_inputs.signing_key.secret_key,
-        &signing_inputs.message.to_vec(),
+        signing_inputs.message,
     )
 }
 
@@ -265,7 +265,7 @@ mod tests {
         let random_g1_point = ark_bn254::G1Affine::rand(&mut rng);
 
         let res = execute_script(script! {
-            {G1Affine::push(random_g1_point.clone())}
+            {G1Affine::push(random_g1_point)}
         });
         let g1_to_bytes = u32_witness_to_bytes(extract_witness_from_stack(res));
         println!("g1_to_bytes: {:?}", g1_to_bytes);

--- a/bitvm/src/signatures/utils.rs
+++ b/bitvm/src/signatures/utils.rs
@@ -32,7 +32,7 @@ pub(super) fn to_digits(mut number: u32, base: u32, digit_count: i32) -> Vec<u32
 }
 
 /// Converts the given bytes to 'len' `u32`'s, each consisting of given number of bits
-pub(crate) fn bytes_to_u32s(len: u32, bits_per_item: u32, bytes: &Vec<u8>) -> Vec<u32> {
+pub(crate) fn bytes_to_u32s(len: u32, bits_per_item: u32, bytes: &[u8]) -> Vec<u32> {
     assert!(
         bytes.len() as u32 * 8 <= len * bits_per_item,
         "Message length is too large for the given length"

--- a/bitvm/src/signatures/winternitz_hash.rs
+++ b/bitvm/src/signatures/winternitz_hash.rs
@@ -27,9 +27,5 @@ pub static WINTERNITZ_MESSAGE_COMPACT_VERIFIER: Winternitz<BruteforceVerifier, V
 pub fn sign_hash(sec_key: &Vec<u8>, message: &[u8]) -> Witness {
     let message_hash = hash(message);
     let message_hash_bytes = &message_hash.as_bytes()[0..20];
-    WINTERNITZ_HASH_VERIFIER.sign(
-        &WINTERNITZ_HASH_PARAMETERS,
-        sec_key,
-        &message_hash_bytes.to_vec(),
-    )
+    WINTERNITZ_HASH_VERIFIER.sign(&WINTERNITZ_HASH_PARAMETERS, sec_key, message_hash_bytes)
 }

--- a/bitvm/src/u32/u32_std.rs
+++ b/bitvm/src/u32/u32_std.rs
@@ -5,17 +5,17 @@ use crate::treepp::*;
 pub fn u32_push(value: u32) -> Script {
     script! {
         //optimization
-        if (value >> 24 & 0xff) == (value >> 16 & 0xff) &&
-            (value >> 24 & 0xff) == (value >> 8 & 0xff) &&
-            (value >> 24 & 0xff) == (value & 0xff) {
+        if ((value >> 24) & 0xff) == ((value >> 16) & 0xff) &&
+            ((value >> 24) & 0xff) == ((value >> 8) & 0xff) &&
+            ((value >> 24) & 0xff) == (value & 0xff) {
 
-                { push_to_stack((value >> 24 & 0xff) as usize, 4) }
+                { push_to_stack(((value >> 24) & 0xff) as usize, 4) }
         }
         else{
 
-                {value >> 24 & 0xff}
-                {value >> 16 & 0xff}
-                {value >>  8 & 0xff}
+                {(value >> 24) & 0xff}
+                {(value >> 16) & 0xff}
+                {(value >>  8) & 0xff}
                 {value & 0xff}
         }
     }
@@ -221,7 +221,6 @@ pub fn u32_uncompress() -> Script {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::Rng;
 
     #[test]
     fn test_u32_push() {
@@ -239,15 +238,20 @@ mod test {
         run(script);
     }
 
+    // This unit test has really strange semantics.
+    // A number modulo 1 will always be 0.
+    // I commented out the broken lines and added lines with the current, real semantics.
+    // TODO: If someone knows the intended semantics, please update the unit.
     #[test]
     fn test_with_u32_compress() {
-        let mut rng = rand::thread_rng();
+        // let mut rng = rand::thread_rng();
         for _ in 0..30 {
-            let mut origin_value0: u32 = rng.gen();
-            origin_value0 = (origin_value0 % 1) << 31;
-            let mut origin_value1: u32 = rng.gen();
-            origin_value1 = (origin_value1 % 1) << 31;
-
+            // let mut origin_value0: u32 = rng.gen();
+            // origin_value0 = (origin_value0 % 1) << 31;
+            // let mut origin_value1: u32 = rng.gen();
+            // origin_value1 = (origin_value1 % 1) << 31;
+            let origin_value0 = 0u32;
+            let origin_value1 = 0u32;
             let v = origin_value0 + origin_value1;
 
             let script = script! {

--- a/bitvm/src/u4/u4_add.rs
+++ b/bitvm/src/u4/u4_add.rs
@@ -263,8 +263,7 @@ mod tests {
         for _ in 0..1000 {
             for len in 2..5 {
                 let vars: Vec<u32> = (0..len).map(|_| rng.gen()).collect();
-                let result =
-                    vars.iter().fold(0 as u64, |sum, &x| sum + x as u64) % ((1 as u64) << 32);
+                let result = vars.iter().fold(0_u64, |sum, &x| sum + x as u64) % (1_u64 << 32);
                 let script = script! {
                     for x in vars {
                         { u4_number_to_nibble(x) }
@@ -293,8 +292,7 @@ mod tests {
         for _ in 0..1000 {
             for len in 2..5 {
                 let vars: Vec<u32> = (0..len).map(|_| rng.gen()).collect();
-                let result =
-                    vars.iter().fold(0 as u64, |sum, &x| sum + x as u64) % ((1 as u64) << 32);
+                let result = vars.iter().fold(0_u64, |sum, &x| sum + x as u64) % (1_u64 << 32);
                 let script = script! {
                     { u4_push_add_tables() }
                     for x in vars {

--- a/fuzz/fuzz_targets/blake3.rs
+++ b/fuzz/fuzz_targets/blake3.rs
@@ -16,7 +16,7 @@ static BLAKE3_COMPUTE_SCRIPTS: LazyLock<[ScriptBuf; 4]> = LazyLock::new(|| {
     [64, 128, 192, 448]
         .into_iter()
         .map(|msg_len| blake3_compute_script(msg_len).compile())
-        .map(|script| optimizer::optimize(script))
+        .map(optimizer::optimize)
         .collect::<Vec<ScriptBuf>>()
         .try_into()
         .unwrap()
@@ -32,6 +32,7 @@ static BLAKE3_COMPUTE_SCRIPTS: LazyLock<[ScriptBuf; 4]> = LazyLock::new(|| {
 /// we fuzz exactly the message sizes that are used inside BitVM.
 /// It turns out, there are only four different sizes.
 #[derive(Debug, Clone, Arbitrary)]
+#[allow(clippy::large_enum_variant)]
 enum MessageBytes {
     U64([u8; 64]),
     U128([u8; 128]),


### PR DESCRIPTION
Progress towards #259. There are still many warnings outside of `bitvm/bitvm`.

There were a lot of clippy lints. Especially when running `cargo clippy --all-targets`. This PR resolves all of them.

I tried to be as conservative as possible, keeping the general function structure the same, not deleting any types, etc. At some places, I allowed the lint instead of resolving it. These lines are searchable via `git grep` and can be fixed in follow-up PRs.

The [manual_div_ceil lint explanation](https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil) might help reviewers.

There is also the usage of `cfg_chunks_mut!` from `ark_std` that caused problems due to the missing `parallel` feature. I replaced that line with [the non-parallel function call, as by the macro](https://github.com/arkworks-rs/std/blob/b0cbdeb097b42f61880b3bee19e8dd37258d23a5/src/lib.rs#L179-L192).

```
warning: unexpected `cfg` condition value: `parallel`
   --> bitvm/src/bn254/ell_coeffs.rs:329:21
    |
329 |         let mut f = cfg_chunks_mut!(pairs, 4)
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `fuzzing`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `cfg_chunks_mut` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_chunks_mut` may come from an old version of the `ark_std` crate, try updating your dependency with `cargo update -p ark_std`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
    = note: this warning originates in the macro `cfg_chunks_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
```