### PR TITLE
Fix error handling in flush() to prevent transaction broadcasting after storage failure

### DIFF
--- a/bridge/src/client/cli/client_command.rs
+++ b/bridge/src/client/cli/client_command.rs
@@ -202,7 +202,10 @@ impl ClientCommand {
         };
         let peg_in_id = self.client.create_peg_in_graph(input, evm_address).await;
 
-        self.client.flush().await;
+        if let Err(e) = self.client.flush().await {
+            eprintln!("Failed to save data to remote storage: {e}");
+            return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+        }
 
         println!("Created peg-in graph with ID: {peg_in_id}");
         println!("Broadcasting deposit...");
@@ -251,7 +254,10 @@ impl ClientCommand {
             CommitmentMessageId::generate_commitment_secrets(),
         );
 
-        self.client.flush().await;
+        if let Err(e) = self.client.flush().await {
+            eprintln!("Failed to save data to remote storage: {e}");
+            return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+        }
 
         println!("Created peg-out with ID: {peg_out_id}");
         Ok(())
@@ -270,7 +276,10 @@ impl ClientCommand {
 
         self.client.sync().await;
         self.client.push_verifier_nonces(graph_id);
-        self.client.flush().await;
+        if let Err(e) = self.client.flush().await {
+            eprintln!("Failed to save data to remote storage: {e}");
+            return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+        }
 
         Ok(())
     }
@@ -291,7 +300,10 @@ impl ClientCommand {
 
         self.client.sync().await;
         self.client.push_verifier_signature(graph_id);
-        self.client.flush().await;
+        if let Err(e) = self.client.flush().await {
+            eprintln!("Failed to save data to remote storage: {e}");
+            return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+        }
 
         Ok(())
     }
@@ -322,7 +334,10 @@ impl ClientCommand {
             let mock_chain_service = get_mock_chain_service(outpoint, operator_public_key);
             self.client.set_chain_service(mock_chain_service);
             self.client.sync_l2().await;
-            self.client.flush().await;
+            if let Err(e) = self.client.flush().await {
+                eprintln!("Failed to save data to remote storage: {e}");
+                return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+            }
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -350,7 +365,10 @@ impl ClientCommand {
 
             // A bit inefficient, but fine for now: only flush if data changed
             if self.client.data() != &old_data {
-                self.client.flush().await;
+                if let Err(e) = self.client.flush().await {
+                    eprintln!("Failed to save data to remote storage: {e}");
+                    return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+                }
             } else {
                 sleep(Duration::from_millis(250)).await;
             }
@@ -425,7 +443,10 @@ impl ClientCommand {
                     amount: tx.output[outpoint.vout as usize].value,
                 };
                 let result = self.client.broadcast_peg_out(graph_id, input).await;
-                self.client.flush().await;
+                if let Err(e) = self.client.flush().await {
+                    eprintln!("Failed to save data to remote storage: {e}");
+                    return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+                }
                 result
             }
             Some(("peg_out_confirm", _)) => self.client.broadcast_peg_out_confirm(graph_id).await,

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -244,8 +244,8 @@ impl BitVMClient {
         self.read_from_l2().await;
     }
 
-    pub async fn flush(&mut self) {
-        self.save_to_data_store().await;
+    pub async fn flush(&mut self) -> Result<(), String> {
+        self.save_to_data_store().await
     }
 
     /*
@@ -491,7 +491,7 @@ impl BitVMClient {
         (None, 0, 0)
     }
 
-    async fn save_to_data_store(&mut self) {
+    async fn save_to_data_store(&mut self) -> Result<(), String> {
         // read newly created data before pushing
         let latest_file_names_result = Self::get_latest_file_names(
             &self.data_store,
@@ -525,8 +525,12 @@ impl BitVMClient {
                 );
                 save_local_public_file(&self.local_file_path, &file_name, &contents);
                 self.latest_processed_file_name = Some(file_name);
+                Ok(())
             }
-            Err(err) => println!("Failed to push: {}", err),
+            Err(err) => {
+                println!("Failed to push: {}", err);
+                Err(format!("Failed to save data to remote storage: {}", err))
+            }
         }
     }
 


### PR DESCRIPTION
This is a PR addressing [issue 267](https://github.com/BitVM/BitVM/issues/267)
##Problem
I noticed that when the flush() method in BitVMClient encounters an error while saving data to remote storage, the execution continues and attempts to broadcast transactions. This could lead to inconsistent state. 

I've made the following changes:
Modified flush() in client.rs to return a Result<(), String> instead of ()
Updated save_to_data_store() to properly propagate error messages
Changed the error handling in handle_initiate_peg_in_command() to stop execution if flush() fails
