### PR TITLE
chore: optimized script initialization and enum handling

### DIFF
--- a/fuzz/fuzz_targets/blake3.rs
+++ b/fuzz/fuzz_targets/blake3.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-use std::iter::IntoIterator;
 use std::sync::LazyLock;
+use std::array;
 
 use arbitrary::Arbitrary;
 use bitcoin::ScriptBuf;
@@ -12,32 +12,28 @@ use bitvm::hash::blake3::{
 };
 use libfuzzer_sys::fuzz_target;
 
+/// Optimized LazyLock initialization to avoid unnecessary Vec allocation.
 static BLAKE3_COMPUTE_SCRIPTS: LazyLock<[ScriptBuf; 4]> = LazyLock::new(|| {
-    [64, 128, 192, 448]
-        .into_iter()
-        .map(|msg_len| blake3_compute_script(msg_len).compile())
-        .map(optimizer::optimize)
-        .collect::<Vec<ScriptBuf>>()
-        .try_into()
-        .unwrap()
+    array::from_fn(|i| optimizer::optimize(blake3_compute_script([64, 128, 192, 448][i]).compile()))
 });
 
 /// Cover all message sizes that are used inside BitVM.
 ///
 /// Each message size is processed by a different BLAKE3 Bitcoin script.
 /// Computing and optimizing each of these scripts takes considerable time.
-/// Even when we cache the result, the fuzzer has to wait until all scripts are gennerated.
+/// Even when we cache the result, the fuzzer has to wait until all scripts are generated.
 ///
 /// In order to get useful coverage while keeping computational effort low,
 /// we fuzz exactly the message sizes that are used inside BitVM.
 /// It turns out, there are only four different sizes.
 #[derive(Debug, Clone, Arbitrary)]
+#[repr(usize)]  // Ensure the enum can be directly cast to usize
 #[allow(clippy::large_enum_variant)]
 enum MessageBytes {
-    U64([u8; 64]),
-    U128([u8; 128]),
-    U192([u8; 192]),
-    U448([u8; 448]),
+    U64([u8; 64]) = 0,
+    U128([u8; 128]) = 1,
+    U192([u8; 192]) = 2,
+    U448([u8; 448]) = 3,
 }
 
 impl AsRef<[u8]> for MessageBytes {
@@ -52,14 +48,9 @@ impl AsRef<[u8]> for MessageBytes {
 }
 
 impl MessageBytes {
+    /// Optimized to use enum indexing instead of match.
     pub fn blake3_compute_script(&self) -> &'static ScriptBuf {
-        let index = match self {
-            Self::U64(..) => 0,
-            Self::U128(..) => 1,
-            Self::U192(..) => 2,
-            Self::U448(..) => 3,
-        };
-        &BLAKE3_COMPUTE_SCRIPTS[index]
+        &BLAKE3_COMPUTE_SCRIPTS[*self as usize]
     }
 }
 
@@ -69,12 +60,13 @@ fuzz_target!(|message: MessageBytes| {
     let mut bytes = blake3_push_message_script_with_limb(message.as_ref(), 29)
         .compile()
         .to_bytes();
-    bytes.extend_from_slice(message.blake3_compute_script().as_bytes());
-    bytes.extend_from_slice(
-        blake3_verify_output_script(expected_hash)
-            .compile()
-            .as_bytes(),
-    );
+    
+    // Optimized by reducing multiple extend_from_slice calls
+    bytes.extend([
+        message.blake3_compute_script().as_bytes(),
+        blake3_verify_output_script(expected_hash).compile().as_bytes(),
+    ].concat());
+    
     let script = ScriptBuf::from_bytes(bytes);
     assert!(execute_script_buf(script).success);
 });


### PR DESCRIPTION
I’ve made a few optimizations to improve performance and readability:  

- **Removed unnecessary Vec allocation**: Replaced `collect::<Vec<_>>().try_into().unwrap()` with `array::from_fn()` in `LazyLock`, avoiding temporary allocations.  
- **Optimized `MessageBytes::blake3_compute_script()`**: Used `#[repr(usize)]` to enable direct indexing, eliminating the need for a `match` statement.  
- **Reduced redundant `extend_from_slice` calls**: Combined them using `concat()` to minimize operations on `bytes`.  
