### PR TITLE
Remove `Chuncker` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,6 @@ Below is a list of the components and their purpose.
   Groth16 uses BN254 to verify proof, the script is currently around 1 GB.
   Some hints are precomputed in this part, which is related to the paper "On Proving Pairings".
 
-- [**Chunker**](bitvm/src/chunker/):
-  Splits Groth16 into chunks.
-  These chunks make sure two principles:
-
-  1. Any chunks shouldn't be success with a right proof.
-  2. There are always some successful chunks with a wrong proof.
-
 - [**Signatures**](bitvm/src/signatures/):
   Bit commitment using
   [Winternitz signature](https://en.wikipedia.org/wiki/Lamport_signature#Short_keys_and_signature).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Below is a list of the components and their purpose.
   Groth16 uses BN254 to verify proof, the script is currently around 1 GB.
   Some hints are precomputed in this part, which is related to the paper "On Proving Pairings".
 
+- [**Chunk**](bitvm/src/chunk/):
+  Splits Groth16 into chunks.
+  These chunks make sure two principles:
+
+  1. Any chunks shouldn't be success with a right proof.
+  2. There are always some successful chunks with a wrong proof.
+
 - [**Signatures**](bitvm/src/signatures/):
   Bit commitment using
   [Winternitz signature](https://en.wikipedia.org/wiki/Lamport_signature#Short_keys_and_signature).


### PR DESCRIPTION
Hi! I removed the documentation about the `Chunker` component from the README since it appears to no longer exist in the codebase.

ref: https://github.com/BitVM/BitVM/pull/235/commits/77c29dfc03e971423791dfc410f18c44bbb2eb49