### PR TITLE
chore: fix array out-of-bounds error with index validation

### DIFF
--- a/header-chain/src/mmr_guest.rs
+++ b/header-chain/src/mmr_guest.rs
@@ -47,10 +47,6 @@ impl MMRGuest {
         }
         println!("GUEST: calculated subroot: {:?}", current_hash);
         println!("GUEST: subroots: {:?}", self.subroots);
-        if mmr_proof.subroot_idx < self.subroots.len() {
-            self.subroots[mmr_proof.subroot_idx] == current_hash
-        } else {
-            false
-        }
+        self.subroots.get(mmr_proof.subroot_idx) == Some(current_hash)
     }
 }

--- a/header-chain/src/mmr_guest.rs
+++ b/header-chain/src/mmr_guest.rs
@@ -47,6 +47,6 @@ impl MMRGuest {
         }
         println!("GUEST: calculated subroot: {:?}", current_hash);
         println!("GUEST: subroots: {:?}", self.subroots);
-        self.subroots.get(mmr_proof.subroot_idx) == Some(current_hash)
+        self.subroots.get(mmr_proof.subroot_idx) == Some(&current_hash)
     }
 }

--- a/header-chain/src/mmr_guest.rs
+++ b/header-chain/src/mmr_guest.rs
@@ -47,6 +47,10 @@ impl MMRGuest {
         }
         println!("GUEST: calculated subroot: {:?}", current_hash);
         println!("GUEST: subroots: {:?}", self.subroots);
-        self.subroots[mmr_proof.subroot_idx] == current_hash
+        if mmr_proof.subroot_idx < self.subroots.len() {
+            self.subroots[mmr_proof.subroot_idx] == current_hash
+        } else {
+            false
+        }
     }
 }


### PR DESCRIPTION
added a validation check to prevent array out-of-bounds errors. now, if the index is incorrect, the code won't panic and will handle it more gracefully.

p.s.this should improve stability and avoid unexpected crashes.