### PR TITLE
perf(chunk): replace Script with ScriptBuf in batch operations

### DIFF
--- a/bitvm/src/chunk/api.rs
+++ b/bitvm/src/chunk/api.rs
@@ -391,7 +391,6 @@ mod test {
         use crate::chunk::api::NUM_PUBS;
         use crate::chunk::api::NUM_U256;
         use crate::chunk::wrap_hasher::BLAKE3_HASH_LENGTH;
-        use crate::treepp::*;
         use bitcoin::ScriptBuf;
         use std::collections::HashMap;
         use std::error::Error;
@@ -431,7 +430,10 @@ mod test {
             write_map_to_file(&buf, file).unwrap();
         }
 
-        pub fn write_scripts_to_separate_files(sig_cache: HashMap<u32, Vec<ScriptBuf>>, file: &str) {
+        pub fn write_scripts_to_separate_files(
+            sig_cache: HashMap<u32, Vec<ScriptBuf>>,
+            file: &str,
+        ) {
             let mut buf: HashMap<u32, Vec<Vec<u8>>> = HashMap::new();
             std::fs::create_dir_all("bridge_data/chunker_data")
                 .expect("Failed to create directory structure");
@@ -607,7 +609,9 @@ mod test {
         let (index, hint_script) = invalid_tap.unwrap();
         println!("STEP 4 EXECUTING DISPROVE SCRIPT at index {}", index);
 
-        let scr = hint_script.clone().push_script(disprove_scripts[index].clone());
+        let scr = hint_script
+            .clone()
+            .push_script(disprove_scripts[index].clone());
         let res = execute_script(scr);
         if res.final_stack.len() > 1 {
             println!("Stack ");
@@ -743,7 +747,9 @@ mod test {
         assert!(invalid_tap.is_some());
         let (index, hint_script) = invalid_tap.unwrap();
         println!("STEP 4 EXECUTING DISPROVE SCRIPT at index {}", index);
-        let scr = hint_script.clone().push_script(disprove_scripts[index].clone());
+        let scr = hint_script
+            .clone()
+            .push_script(disprove_scripts[index].clone());
         let res = execute_script(scr);
         if res.final_stack.len() > 1 {
             println!("Stack ");
@@ -1313,7 +1319,9 @@ mod test {
             if fault.is_some() {
                 let (index, hint_script) = fault.unwrap();
                 println!("taproot index {:?}", index);
-                let scr = hint_script.clone().push_script(verifier_scripts[index].clone());
+                let scr = hint_script
+                    .clone()
+                    .push_script(verifier_scripts[index].clone());
                 let res = execute_script(scr);
                 for i in 0..res.final_stack.len() {
                     println!("{i:} {:?}", res.final_stack.get(i));

--- a/bitvm/src/chunk/api_compiletime_utils.rs
+++ b/bitvm/src/chunk/api_compiletime_utils.rs
@@ -39,9 +39,7 @@ pub(crate) struct Vkey {
     pub(crate) vky0: ark_bn254::G1Affine,
 }
 
-pub(crate) fn generate_partial_script(
-    vk: &ark_groth16::VerifyingKey<Bn254>,
-) -> Vec<ScriptBuf> {
+pub(crate) fn generate_partial_script(vk: &ark_groth16::VerifyingKey<Bn254>) -> Vec<ScriptBuf> {
     println!("generate_partial_script");
     assert!(vk.gamma_abc_g1.len() == NUM_PUBS + 1);
 
@@ -256,10 +254,13 @@ pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<ScriptB
             let elem_types_str = serialize_element_types(&elem_types_to_hash);
             let hash_scr = hashing_script_cache.get(&elem_types_str).unwrap();
 
-            op_scripts.push(script! {
-                {script!().push_script(op_scr)}
-                {hash_scr.clone()}
-            }.compile());
+            op_scripts.push(
+                script! {
+                    {script!().push_script(op_scr)}
+                    {hash_scr.clone()}
+                }
+                .compile(),
+            );
         }
     }
     op_scripts

--- a/bitvm/src/chunk/api_compiletime_utils.rs
+++ b/bitvm/src/chunk/api_compiletime_utils.rs
@@ -12,6 +12,7 @@ use ark_bn254::Bn254;
 use ark_ec::bn::BnConfig;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::Field;
+use bitcoin::ScriptBuf;
 use bitcoin_script::script;
 use num_bigint::BigUint;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -40,7 +41,7 @@ pub(crate) struct Vkey {
 
 pub(crate) fn generate_partial_script(
     vk: &ark_groth16::VerifyingKey<Bn254>,
-) -> Vec<bitcoin_script::Script> {
+) -> Vec<ScriptBuf> {
     println!("generate_partial_script");
     assert!(vk.gamma_abc_g1.len() == NUM_PUBS + 1);
 
@@ -68,10 +69,9 @@ pub(crate) fn generate_partial_script(
     println!("generate_partial_script; generate_segments_using_mock_proof");
     let segments = generate_segments_using_mock_proof(vk, false);
     println!("generate_partial_script; partial_scripts_from_segments");
-    let op_scripts: Vec<Script> = partial_scripts_from_segments(&segments)
-        .into_iter()
-        .collect();
+    let op_scripts: Vec<ScriptBuf> = partial_scripts_from_segments(&segments);
     assert_eq!(op_scripts.len(), NUM_TAPS);
+
     op_scripts
 }
 
@@ -80,8 +80,8 @@ pub(crate) fn generate_partial_script(
 // we do not need values at the input or outputs of tapscript
 pub(crate) fn append_bitcom_locking_script_to_partial_scripts(
     inpubkeys: PublicKeys,
-    ops_scripts: Vec<bitcoin_script::Script>,
-) -> Vec<bitcoin_script::Script> {
+    ops_scripts: Vec<ScriptBuf>,
+) -> Vec<ScriptBuf> {
     println!("append_bitcom_locking_script_to_partial_scripts; generage_segments_using_mock_vk_and_mock_proof");
     // mock_vk can be used because generating locking_script doesn't depend upon values or partial scripts; it's only a function of pubkey and ordering of input/outputs
     let mock_segments = generate_segments_using_mock_vk_and_mock_proof();
@@ -93,17 +93,14 @@ pub(crate) fn append_bitcom_locking_script_to_partial_scripts(
             .filter(|f| !f.is_empty())
             .collect();
     assert_eq!(ops_scripts.len(), bitcom_scripts.len());
-    let res: Vec<treepp::Script> = ops_scripts
+    let res: Vec<ScriptBuf> = ops_scripts
         .into_iter()
         .zip(bitcom_scripts)
         .map(|(op_scr, bit_scr)| {
-            script! {
-                {bit_scr}
-                {op_scr}
-            }
+            let joint_scr = bit_scr.push_script(op_scr);
+            joint_scr.compile()
         })
         .collect();
-
     res
 }
 
@@ -195,7 +192,7 @@ pub(crate) fn generate_segments_using_mock_vk_and_mock_proof() -> Vec<Segment> {
     generate_segments_using_mock_proof(mock_vk, true)
 }
 
-pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<treepp::Script> {
+pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<ScriptBuf> {
     fn serialize_element_types(elems: &[ElementType]) -> String {
         // 1. Convert each variant to its string representation.
         let joined = elems
@@ -213,7 +210,7 @@ pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<treepp:
         format!("{}|{}", joined, unique_hash)
     }
 
-    let mut op_scripts: Vec<treepp::Script> = vec![];
+    let mut op_scripts: Vec<ScriptBuf> = vec![];
 
     // cache hashing script as it is repititive
     let mut hashing_script_cache: HashMap<String, Script> = HashMap::new();
@@ -260,9 +257,9 @@ pub(crate) fn partial_scripts_from_segments(segments: &[Segment]) -> Vec<treepp:
             let hash_scr = hashing_script_cache.get(&elem_types_str).unwrap();
 
             op_scripts.push(script! {
-                {op_scr}
+                {script!().push_script(op_scr)}
                 {hash_scr.clone()}
-            });
+            }.compile());
         }
     }
     op_scripts

--- a/bitvm/src/chunk/api_runtime_utils.rs
+++ b/bitvm/src/chunk/api_runtime_utils.rs
@@ -17,6 +17,7 @@ use ark_bn254::Bn254;
 use ark_ec::bn::Bn;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::Field;
+use bitcoin::ScriptBuf;
 use bitcoin_script::script;
 
 use crate::{bn254::utils::Hint, execute_script};
@@ -393,7 +394,7 @@ fn utils_execute_chunked_g16(
     aux_hints: Vec<Vec<Hint>>,
     bc_hints: Vec<Script>,
     segments: &[Segment],
-    disprove_scripts: &[Script; NUM_TAPS],
+    disprove_scripts: &[ScriptBuf; NUM_TAPS],
 ) -> Option<(usize, Script)> {
     let mut tap_script_index = 0;
     for i in 0..aux_hints.len() {
@@ -406,10 +407,7 @@ fn utils_execute_chunked_g16(
             }
             {bc_hints[i].clone()}
         };
-        let total_script = script! {
-            {hint_script.clone()}
-            {disprove_scripts[tap_script_index].clone()}
-        };
+        let total_script = hint_script.clone().push_script(disprove_scripts[tap_script_index].clone());
         let exec_result = execute_script(total_script);
         if exec_result.final_stack.len() > 1 {
             for i in 0..exec_result.final_stack.len() {
@@ -487,10 +485,10 @@ pub(crate) fn execute_script_from_assertion(
     }
 
     // collect partial scripts
-    let partial_scripts: Vec<Script> = partial_scripts_from_segments(segments)
+    let partial_scripts: Vec<ScriptBuf> = partial_scripts_from_segments(segments)
         .into_iter()
         .collect();
-    let partial_scripts: [Script; NUM_TAPS] = partial_scripts.try_into().unwrap();
+    let partial_scripts: [ScriptBuf; NUM_TAPS] = partial_scripts.try_into().unwrap();
     // collect witness
     let mul_hints = utils_collect_mul_hints_per_segment(segments);
     let bc_hints = collect_wots_msg_as_witness_per_segment(segments, assts);
@@ -502,7 +500,7 @@ pub(crate) fn execute_script_from_assertion(
 pub(crate) fn execute_script_from_signature(
     segments: &[Segment],
     signed_assts: Signatures,
-    disprove_scripts: &[Script; NUM_TAPS],
+    disprove_scripts: &[ScriptBuf; NUM_TAPS],
 ) -> Option<(usize, Script)> {
     // if there is a disprove script; with locking script; i can use bitcom witness
     // segments and signatures
@@ -601,6 +599,7 @@ pub(crate) fn get_pubkeys(secret_key: Vec<String>) -> PublicKeys {
 mod test {
     use crate::chunk::api_compiletime_utils::append_bitcom_locking_script_to_partial_scripts;
     use ark_serialize::CanonicalDeserialize;
+    use bitcoin::ScriptBuf;
 
     use super::*;
 
@@ -713,12 +712,10 @@ mod test {
             .collect::<Vec<String>>();
         let pubkeys = get_pubkeys(secrets);
         println!("execute_script_from_signature");
-        let partial_scripts: Vec<Script> = partial_scripts_from_segments(&segments)
-            .into_iter()
-            .collect();
+        let partial_scripts: Vec<ScriptBuf> = partial_scripts_from_segments(&segments);
         let disprove_scripts =
             append_bitcom_locking_script_to_partial_scripts(pubkeys, partial_scripts.to_vec());
-        let disprove_scripts: [Script; NUM_TAPS] = disprove_scripts.try_into().unwrap();
+        let disprove_scripts: [ScriptBuf; NUM_TAPS] = disprove_scripts.try_into().unwrap();
 
         let res = execute_script_from_signature(&segments, signed_assts, &disprove_scripts);
         assert!(res.is_none());

--- a/bitvm/src/chunk/api_runtime_utils.rs
+++ b/bitvm/src/chunk/api_runtime_utils.rs
@@ -407,7 +407,9 @@ fn utils_execute_chunked_g16(
             }
             {bc_hints[i].clone()}
         };
-        let total_script = hint_script.clone().push_script(disprove_scripts[tap_script_index].clone());
+        let total_script = hint_script
+            .clone()
+            .push_script(disprove_scripts[tap_script_index].clone());
         let exec_result = execute_script(total_script);
         if exec_result.final_stack.len() > 1 {
             for i in 0..exec_result.final_stack.len() {

--- a/bitvm/src/chunk/g16_runner_core.rs
+++ b/bitvm/src/chunk/g16_runner_core.rs
@@ -3,7 +3,7 @@ use crate::chunk::{
 };
 use ark_ec::CurveGroup;
 use ark_ff::{Field, PrimeField};
-use bitcoin_script::script;
+use bitcoin::ScriptBuf;
 
 use super::{
     api::NUM_PUBS,
@@ -371,7 +371,7 @@ fn raw_input_proof_to_segments(
             result: (DataType::U256Data(*f), ElementType::ScalarElem),
             hints: vec![],
             scr_type: ScriptType::NonDeterministic,
-            scr: script! {},
+            scr: ScriptBuf::new(),
         })
         .collect();
     all_output_hints.extend_from_slice(&pub_scalars);
@@ -391,7 +391,7 @@ fn raw_input_proof_to_segments(
         result: (DataType::U256Data(*f), ElementType::FieldElem),
         hints: vec![],
         scr_type: ScriptType::NonDeterministic,
-        scr: script! {},
+        scr: ScriptBuf::new(),
     })
     .collect();
     all_output_hints.extend_from_slice(&p4vec);
@@ -408,7 +408,7 @@ fn raw_input_proof_to_segments(
             result: (DataType::U256Data(*f), ElementType::FieldElem),
             hints: vec![],
             scr_type: ScriptType::NonDeterministic,
-            scr: script! {},
+            scr: ScriptBuf::new(),
         })
         .collect();
     all_output_hints.extend_from_slice(&gc);
@@ -428,7 +428,7 @@ fn raw_input_proof_to_segments(
         result: (DataType::U256Data(*f), ElementType::FieldElem),
         hints: vec![],
         scr_type: ScriptType::NonDeterministic,
-        scr: script! {},
+        scr: ScriptBuf::new(),
     })
     .collect();
     all_output_hints.extend_from_slice(&temp_q4);

--- a/bitvm/src/chunk/g16_runner_utils.rs
+++ b/bitvm/src/chunk/g16_runner_utils.rs
@@ -19,10 +19,10 @@ use super::{
     },
 };
 use ark_ff::Field;
+use bitcoin::ScriptBuf;
 use bitcoin_script::script;
 
 use super::taps_ext_miller::{chunk_final_verify, chunk_frob_fp12, chunk_hash_c, chunk_hash_c_inv};
-use crate::treepp::Script;
 
 pub type SegmentID = u32;
 
@@ -33,7 +33,7 @@ pub(crate) struct Segment {
     pub result: (DataType, ElementType),
     pub hints: Vec<Hint>,
     pub scr_type: ScriptType,
-    pub scr: Script,
+    pub scr: ScriptBuf,
     pub is_valid_input: bool,
 }
 
@@ -92,7 +92,7 @@ pub(crate) fn wrap_hint_squaring(skip: bool, segment_id: usize, in_a: &Segment) 
         result: (DataType::Fp6Data(sq), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::MillerSquaring,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -130,7 +130,7 @@ pub(crate) fn wrap_hint_init_t4(
         result: (DataType::G2EvalData(tmpt4), ElementType::G2EvalPoint),
         hints: op_hints,
         scr_type: ScriptType::PreMillerInitT4,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -160,7 +160,7 @@ pub(crate) fn wrap_hints_dense_dense_mul(
         result: (DataType::Fp6Data(dmul0), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::FoldedFp12Multiply,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -188,7 +188,7 @@ pub(crate) fn wrap_hints_frob_fp12(
         result: (DataType::Fp6Data(cp), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::PostMillerFrobFp12(power as u8),
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -254,7 +254,7 @@ pub(crate) fn wrap_chunk_point_ops_and_multiply_line_evals_step_1(
         result: (DataType::G2EvalData(dbladd), ElementType::G2Eval),
         hints: op_hints,
         scr_type: ScriptType::MillerPointOpsStep1(is_dbl, ate_bit, is_frob),
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -282,7 +282,7 @@ pub(crate) fn wrap_chunk_point_ops_and_multiply_line_evals_step_2(
         result: (DataType::Fp6Data(cp), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::MillerPointOpsStep2,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -323,7 +323,7 @@ pub(crate) fn wrap_hint_msm(
                 result: (DataType::G1Data(hout_msm), ElementType::G1),
                 hints: op_hints,
                 scr_type: ScriptType::MSM(msm_chunk_index as u32),
-                scr,
+                scr: scr.compile(),
             });
         }
     } else {
@@ -344,7 +344,7 @@ pub(crate) fn wrap_hint_msm(
                 result: (DataType::G1Data(hout_msm), ElementType::G1),
                 hints: vec![],
                 scr_type: ScriptType::MSM(msm_chunk_index),
-                scr: script! {},
+                scr: ScriptBuf::new(),
             });
         }
     }
@@ -373,7 +373,7 @@ pub(crate) fn wrap_hint_hash_p(
         result: (DataType::G1Data(p3), ElementType::G1),
         hints: op_hints,
         scr_type: ScriptType::PreMillerHashP,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -404,7 +404,7 @@ pub(crate) fn wrap_hints_precompute_p(
         result: (DataType::G1Data(p3d), ElementType::G1),
         hints: op_hints,
         scr_type: ScriptType::PreMillerPrecomputeP,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -429,7 +429,7 @@ pub(crate) fn wrap_hints_precompute_p_from_hash(
         result: (DataType::G1Data(p3d), ElementType::G1),
         hints: op_hints,
         scr_type: ScriptType::PreMillerPrecomputePFromHash,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -457,7 +457,7 @@ pub(crate) fn wrap_hint_hash_c(skip: bool, segment_id: usize, in_c: Vec<Segment>
         result: (DataType::Fp6Data(c), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::PreMillerHashC,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -485,7 +485,7 @@ pub(crate) fn wrap_hint_hash_c_inv(skip: bool, segment_id: usize, in_c: Vec<Segm
         result: (DataType::Fp6Data(c), ElementType::Fp6),
         hints: op_hints,
         scr_type: ScriptType::PreMillerHashCInv,
-        scr,
+        scr: scr.compile(),
     }
 }
 
@@ -534,6 +534,6 @@ pub(crate) fn wrap_chunk_final_verify(
         result: (DataType::U256Data(is_valid_fq), ElementType::FieldElem),
         hints: op_hints,
         scr_type: ScriptType::PostMillerFinalVerify,
-        scr,
+        scr: scr.compile(),
     }
 }

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -124,9 +124,7 @@ impl ConnectorC {
         let locs: Vec<ScriptBuf> = self
             .lock_scripts_bytes()
             .into_iter()
-            .map(|f| {
-                ScriptBuf::from_bytes(f)
-            })
+            .map(|f| ScriptBuf::from_bytes(f))
             .collect();
         let locs = locs.try_into().unwrap();
         let exec_res = validate_assertions(vk, sigs, pubs, &locs);
@@ -330,11 +328,8 @@ fn generate_assert_leaves(
     let default_proof = RawProof::default(); // mock a default proof to generate scripts
     let partial_scripts = api_generate_partial_script(&default_proof.vk);
     let pks: PublicKeys = utils_typed_pubkey_from_raw(sorted_pks);
-    let locks =  api_generate_full_tapscripts(pks, &partial_scripts);
-    let locks = locks
-        .into_iter()
-        .map(|f| f.into_bytes())
-        .collect();
+    let locks = api_generate_full_tapscripts(pks, &partial_scripts);
+    let locks = locks.into_iter().map(|f| f.into_bytes()).collect();
     locks
 }
 

--- a/bridge/src/connectors/connector_c.rs
+++ b/bridge/src/connectors/connector_c.rs
@@ -121,12 +121,11 @@ impl ConnectorC {
 
         let sigs = utils_signatures_from_raw_witnesses(&commit_witness);
         let pubs = utils_typed_pubkey_from_raw(sorted_pks);
-        let locs: Vec<bitcoin_script::builder::StructuredScript> = self
+        let locs: Vec<ScriptBuf> = self
             .lock_scripts_bytes()
             .into_iter()
             .map(|f| {
-                bitcoin_script::builder::StructuredScript::new("")
-                    .push_script(ScriptBuf::from_bytes(f))
+                ScriptBuf::from_bytes(f)
             })
             .collect();
         let locs = locs.try_into().unwrap();
@@ -331,10 +330,10 @@ fn generate_assert_leaves(
     let default_proof = RawProof::default(); // mock a default proof to generate scripts
     let partial_scripts = api_generate_partial_script(&default_proof.vk);
     let pks: PublicKeys = utils_typed_pubkey_from_raw(sorted_pks);
-    let locks = api_generate_full_tapscripts(pks, &partial_scripts);
+    let locks =  api_generate_full_tapscripts(pks, &partial_scripts);
     let locks = locks
         .into_iter()
-        .map(|f| f.compile().into_bytes())
+        .map(|f| f.into_bytes())
         .collect();
     locks
 }


### PR DESCRIPTION
This PR  replaces use of Vec<Script> with use of Vec\<ScriptBuf>

Reason:
chunk module's APIs accept, works with or return array of Script.

For example, while generating chunked scripts in the presigning stage, one of the functions you'd call is
`pub fn api_generate_partial_script(vk: &ark_groth16::VerifyingKey<Bn254>) -> Vec<Script>`

Holding data as Script in memory seems really costly compared to holding its equivalent form in ScriptBuf.
This is especially true when you're working with large batch of scripts like the function above.
From benchmarks, it seems Vec<Script> consumes around 10 times as much memory (RAM) compared to its serialized form Vec\<ScriptBuf>.

Changes are limited to type conversion only but has been done on public APIs.