### PR TITLE
Fix print message in test of hinted check add

### DIFF
--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -739,7 +739,7 @@ mod test {
         let exec_result = execute_script(script);
         assert!(exec_result.success);
         println!(
-            "hinted_add_line: {} @ {} stack",
+            "hinted_check_add: {} @ {} stack",
             hinted_check_add.len(),
             exec_result.stats.max_nb_stack_items
         );


### PR DESCRIPTION
The tests in g1 curve operations usually print the benchmarks as well. In the test for the hinted check add, the print message mentions 'hinted add line' (which is the test just preceding hinted check add). The message printed to stdout to get the benchmarks for hinted check add was fixed.