### PR TITLE
Add public graph accessor methods to BitVMClient

### DIFF
--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -222,6 +222,16 @@ impl BitVMClient {
         &mut self.data
     }
 
+    /// Get a mutable reference to a PegInGraph by its ID
+    pub fn get_peg_in_graph_mut(&mut self, id: &str) -> Option<&mut PegInGraph> {
+        self.data.peg_in_graphs.iter_mut().find(|graph| graph.id() == id)
+    }
+
+    /// Get a mutable reference to a PegOutGraph by its ID
+    pub fn get_peg_out_graph_mut(&mut self, id: &str) -> Option<&mut PegOutGraph> {
+        self.data.peg_out_graphs.iter_mut().find(|graph| graph.id() == id)
+    }
+
     // TODO: This should be private. Currently used in the fees test. See if it can be refactored.
     pub fn private_data(&self) -> &BitVMClientPrivateData {
         &self.private_data
@@ -1337,18 +1347,6 @@ impl BitVMClient {
                 peg_in_graph_id.clone(),
             )))
     }
-
-    // TODO: consider refactor client as static, and use it in graph struct directly
-    //       so we can have this method instead of find_peg_in_or_fail
-    // fn get_peg_in_graph_mut(&mut self, peg_in_graph_id: &String) -> Result<&mut PegInGraph, Error> {
-    //     self.data_mut_ref()
-    //         .peg_in_graphs
-    //         .iter_mut()
-    //         .find(|peg_in_graph| peg_in_graph.id().eq(peg_in_graph_id))
-    //         .ok_or(Error::Client(ClientError::PegInGraphNotFound(
-    //             peg_in_graph_id.clone(),
-    //         )))
-    // }
 
     fn find_peg_in_or_fail<'a>(
         data: &'a mut BitVMClientPublicData,

--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -224,12 +224,18 @@ impl BitVMClient {
 
     /// Get a mutable reference to a PegInGraph by its ID
     pub fn get_peg_in_graph_mut(&mut self, id: &str) -> Option<&mut PegInGraph> {
-        self.data.peg_in_graphs.iter_mut().find(|graph| graph.id() == id)
+        self.data
+            .peg_in_graphs
+            .iter_mut()
+            .find(|graph| graph.id() == id)
     }
 
     /// Get a mutable reference to a PegOutGraph by its ID
     pub fn get_peg_out_graph_mut(&mut self, id: &str) -> Option<&mut PegOutGraph> {
-        self.data.peg_out_graphs.iter_mut().find(|graph| graph.id() == id)
+        self.data
+            .peg_out_graphs
+            .iter_mut()
+            .find(|graph| graph.id() == id)
     }
 
     // TODO: This should be private. Currently used in the fees test. See if it can be refactored.

--- a/bridge/tests/bridge/client/fee.rs
+++ b/bridge/tests/bridge/client/fee.rs
@@ -544,22 +544,10 @@ async fn test_peg_out_fees() {
     check_tx_output_sum(reward_amount - DUST_AMOUNT * 4, &disprove_tx);
 }
 
-// TODO: consider making the graph getter in client public after refactor
 fn get_peg_in_graph_mut(client: &mut BitVMClient, id: String) -> &mut PegInGraph {
-    client
-        .data_mut()
-        .peg_in_graphs
-        .iter_mut()
-        .find(|graph| graph.id().eq(&id))
-        .unwrap()
+    client.get_peg_in_graph_mut(&id).unwrap()
 }
 
-// TODO: consider making the graph getter in client public after refactor
 fn get_peg_out_graph_mut(client: &mut BitVMClient, id: String) -> &mut PegOutGraph {
-    client
-        .data_mut()
-        .peg_out_graphs
-        .iter_mut()
-        .find(|graph| graph.id().eq(&id))
-        .unwrap()
+    client.get_peg_out_graph_mut(&id).unwrap()
 }

--- a/bridge/tests/bridge/client/fee.rs
+++ b/bridge/tests/bridge/client/fee.rs
@@ -9,7 +9,7 @@ use bridge::{
     },
     commitments::CommitmentMessageId,
     graphs::{
-        base::{max, BaseGraph, DUST_AMOUNT, MIN_RELAY_FEE_ASSERT_SET, PEG_IN_FEE, PEG_OUT_FEE},
+        base::{max, DUST_AMOUNT, MIN_RELAY_FEE_ASSERT_SET, PEG_IN_FEE, PEG_OUT_FEE},
         peg_in::PegInGraph,
         peg_out::PegOutGraph,
     },


### PR DESCRIPTION

## Description
This PR adds two new public methods to the BitVMClient class that provide a cleaner way to access graph data:

- `get_peg_in_graph_mut`: Returns a mutable reference to a PegInGraph by its ID
- `get_peg_out_graph_mut`: Returns a mutable reference to a PegOutGraph by its ID

These methods simplify access to graph objects in tests and remove the need for helper functions to directly access the internal data structure. The test helpers in fee.rs have been updated to use these new methods, removing duplication and making the code more maintainable.

Closes TODO item: "Consider making the graph getter in client public after refactor"
