### PR TITLE
WOTS data format refactor

### DIFF
--- a/bitvm/src/bigint/bits.rs
+++ b/bitvm/src/bigint/bits.rs
@@ -47,7 +47,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
     }
 
     pub fn limb_from_bytes() -> Script {
-        let bytes_per_limb = (LIMB_SIZE + 7) / 8;
+        let bytes_per_limb = LIMB_SIZE.div_ceil(8);
 
         assert!(LIMB_SIZE > 0, "LIMB_SIZE must not be 0");
         assert!(LIMB_SIZE < 33, "LIMB_SIZE must be less than 33");

--- a/bitvm/src/hash/blake3.rs
+++ b/bitvm/src/hash/blake3.rs
@@ -214,7 +214,7 @@ fn chunk_message(message_bytes: &[u8]) -> Vec<[u8; 64]> {
     message_bytes
         .iter()
         .copied()
-        .chain(std::iter::repeat(0u8).take(needed_padding_bytes))
+        .chain(std::iter::repeat_n(0u8, needed_padding_bytes))
         .chunks(4) // reverse 4-byte chunks
         .into_iter()
         .flat_map(|chunk| chunk.collect::<Vec<u8>>().into_iter().rev())

--- a/bitvm/src/signatures/signing_winternitz.rs
+++ b/bitvm/src/signatures/signing_winternitz.rs
@@ -135,11 +135,7 @@ pub fn winternitz_message_checksig_verify(
 mod tests {
     use super::*;
     use super::{WinternitzPublicKey, WinternitzSecret};
-    use crate::{
-        bn254::g1::G1Affine,
-        execute_script,
-        signatures::{utils::digits_to_number, winternitz::generate_public_key},
-    };
+    use crate::{bn254::g1::G1Affine, execute_script, signatures::utils};
     use crate::{execute_script_with_inputs, ExecuteInfo};
     use ark_ff::UniformRand as _;
     use ark_std::test_rng;
@@ -199,7 +195,7 @@ mod tests {
           },
           ).to_vec() }
           { winternitz_message_checksig(&public_key) }
-          { digits_to_number::<{ 4 * 2}, { LOG_D as usize }>() }
+          { utils::digits_to_number::<{ 4 * 2}, { LOG_D as usize }>() }
           { start_time_block_number }
           OP_EQUAL
         };

--- a/bitvm/src/signatures/signing_winternitz.rs
+++ b/bitvm/src/signatures/signing_winternitz.rs
@@ -18,7 +18,7 @@ pub struct WinternitzSecret {
     parameters: Parameters,
 }
 
-// Bits per digit (block)
+/// Bits per digit.
 pub const LOG_D: u32 = 4;
 
 impl WinternitzSecret {
@@ -40,7 +40,7 @@ impl WinternitzSecret {
     pub fn from_string(secret: &str, parameters: &Parameters) -> Self {
         WinternitzSecret {
             secret_key: secret.as_bytes().to_lower_hex_string().into(),
-            parameters: parameters.clone(),
+            parameters: *parameters,
         }
     }
 }
@@ -55,7 +55,7 @@ impl From<&WinternitzSecret> for WinternitzPublicKey {
     fn from(secret: &WinternitzSecret) -> Self {
         WinternitzPublicKey {
             public_key: generate_public_key(&secret.parameters, &secret.secret_key),
-            parameters: secret.parameters.clone(),
+            parameters: secret.parameters,
         }
     }
 }
@@ -223,7 +223,7 @@ mod tests {
         let public_key = WinternitzPublicKey::from(&secret);
         let reference_public_key = generate_public_key(&secret.parameters, &secret.secret_key);
 
-        for i in 0..secret.parameters.total_length() {
+        for i in 0..secret.parameters.total_digit_len() {
             assert_eq!(
                 public_key.public_key[i as usize],
                 reference_public_key[i as usize]
@@ -238,9 +238,9 @@ mod tests {
 
         assert_eq!(
             public_key.public_key.len(),
-            public_key.parameters.total_length() as usize
+            public_key.parameters.total_digit_len() as usize
         );
-        for i in 0..public_key.parameters.total_length() {
+        for i in 0..public_key.parameters.total_digit_len() {
             assert_eq!(
                 public_key.public_key[i as usize].len(),
                 20,

--- a/bitvm/src/signatures/utils.rs
+++ b/bitvm/src/signatures/utils.rs
@@ -16,7 +16,7 @@ pub(super) const fn log_base_ceil(n: u32, base: u32) -> u32 {
 /// ## Output format
 ///
 /// - sequence of `n_digits` many digits
-/// - each digit a `u32` value in range `0..2.pow(log2_base)`
+/// - each digit a `u32` value in range `0..base`
 /// - checksum converted into BE bytes, in turn converted into digits
 pub(super) fn checksum_to_digits(mut checksum: u32, base: u32, n_digits: u32) -> Vec<u32> {
     debug_assert!((16..=256).contains(&base));

--- a/bitvm/src/signatures/winternitz.rs
+++ b/bitvm/src/signatures/winternitz.rs
@@ -41,19 +41,8 @@ impl Parameters {
 
     /// Creates parameters with given message_length (number of bits in the message) and block length (number of bits in one block, in the closed range 4, 8)
     pub const fn new_by_bit_length(number_of_bits: u32, block_length: u32) -> Self {
-        assert!(
-            4 <= block_length && block_length <= 8,
-            "You can only choose block lengths in the range [4, 8]"
-        );
         let message_block_count = number_of_bits.div_ceil(block_length);
-        Parameters {
-            message_length: message_block_count,
-            block_length,
-            checksum_length: log_base_ceil(
-                ((1 << block_length) - 1) * message_block_count,
-                1 << block_length,
-            ) + 1,
-        }
+        Self::new(message_block_count, block_length)
     }
 
     /// Maximum value of a digit

--- a/bitvm/src/signatures/winternitz.rs
+++ b/bitvm/src/signatures/winternitz.rs
@@ -63,7 +63,7 @@ impl Parameters {
 
     /// Number of bytes that can be represented at maximum with the parameters
     pub const fn byte_message_length(&self) -> u32 {
-        (self.message_length * self.block_length + 7) / 8
+        (self.message_length * self.block_length).div_ceil(8)
     }
 
     /// Total number of blocks, i.e. sum of the number of blocks in the actual message and the checksum
@@ -251,13 +251,13 @@ impl Verifier for ListpickVerifier {
                 OP_MIN
                 OP_DUP
                 OP_TOALTSTACK
-                { (ps.d() + 1) / 2 }
+                { ps.d().div_ceil(2) }
                 OP_2DUP
                 OP_LESSTHAN
                 OP_IF
                     OP_DROP
                     OP_TOALTSTACK
-                    for _ in 0..(ps.d() + 1) / 2  {
+                    for _ in 0..ps.d().div_ceil(2)  {
                         OP_HASH160
                     }
                 OP_ELSE

--- a/bitvm/src/signatures/winternitz_hash.rs
+++ b/bitvm/src/signatures/winternitz_hash.rs
@@ -4,23 +4,23 @@ use blake3::hash;
 
 const MESSAGE_HASH_LEN: u32 = 20;
 /// Winternitz parameters for the 20 byte blake3 variant with the block length 4
-pub static WINTERNITZ_HASH_PARAMETERS: Parameters =
+pub const WINTERNITZ_HASH_PARAMETERS: Parameters =
     Parameters::new_by_bit_length(MESSAGE_HASH_LEN * 8, 4);
 
 /// Winternitz verifier for the 20 byte blake3 variant (can be used with other parameters), returns the message in bytes
-pub static WINTERNITZ_HASH_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
+pub const WINTERNITZ_HASH_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
     Winternitz::new();
 
 /// Winternitz verifier, returns the message in blocks
-pub static WINTERNITZ_MESSAGE_VERIFIER: Winternitz<ListpickVerifier, VoidConverter> =
+pub const WINTERNITZ_MESSAGE_VERIFIER: Winternitz<ListpickVerifier, VoidConverter> =
     Winternitz::new();
 
 /// Winternitz verifier, returns the message in in bytes
-pub static WINTERNITZ_VARIABLE_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
+pub const WINTERNITZ_VARIABLE_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
     Winternitz::new();
 
 /// Winternitz verifier for compact signature representation, returns the message in in bytes
-pub static WINTERNITZ_MESSAGE_COMPACT_VERIFIER: Winternitz<BruteforceVerifier, VoidConverter> =
+pub const WINTERNITZ_MESSAGE_COMPACT_VERIFIER: Winternitz<BruteforceVerifier, VoidConverter> =
     Winternitz::new();
 
 /// Create a Winternitz signature for the blake3 hash of a given message

--- a/bitvm/src/signatures/winternitz_hash.rs
+++ b/bitvm/src/signatures/winternitz_hash.rs
@@ -3,7 +3,8 @@ use bitcoin::Witness;
 use blake3::hash;
 
 const MESSAGE_HASH_LEN: u32 = 20;
-/// Winternitz parameters for the 20 byte blake3 variant with the block length 4
+
+/// Winternitz parameters for the 20 byte blake3 variant
 pub const WINTERNITZ_HASH_PARAMETERS: Parameters =
     Parameters::new_by_bit_length(MESSAGE_HASH_LEN * 8, 4);
 
@@ -11,15 +12,15 @@ pub const WINTERNITZ_HASH_PARAMETERS: Parameters =
 pub const WINTERNITZ_HASH_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
     Winternitz::new();
 
-/// Winternitz verifier, returns the message in blocks
+/// Winternitz verifier, returns the message in digits
 pub const WINTERNITZ_MESSAGE_VERIFIER: Winternitz<ListpickVerifier, VoidConverter> =
     Winternitz::new();
 
-/// Winternitz verifier, returns the message in in bytes
+/// Winternitz verifier, returns the message in bytes
 pub const WINTERNITZ_VARIABLE_VERIFIER: Winternitz<ListpickVerifier, ToBytesConverter> =
     Winternitz::new();
 
-/// Winternitz verifier for compact signature representation, returns the message in in bytes
+/// Winternitz verifier for compact signature representation, returns the message in bytes
 pub const WINTERNITZ_MESSAGE_COMPACT_VERIFIER: Winternitz<BruteforceVerifier, VoidConverter> =
     Winternitz::new();
 

--- a/bitvm/src/signatures/wots_api.rs
+++ b/bitvm/src/signatures/wots_api.rs
@@ -5,7 +5,6 @@ use crate::signatures::{
 };
 use crate::treepp::Script;
 use bitcoin::Witness;
-use paste::paste;
 
 /// Trait for converting a signature into a Script.
 pub trait SignatureImpl {
@@ -19,64 +18,124 @@ pub trait SignatureImpl {
 /// - For 256-bit WOTS, use 32 bytes.
 macro_rules! impl_wots {
     ($mod_name:ident, $MSG_LEN:expr) => {
-        paste! {
-            pub mod $mod_name {
-                use super::*;
-                use bitcoin_script::script;
-                use bitcoin::hex::FromHex;
+        pub mod $mod_name {
+            use super::*;
+            use bitcoin::hex::FromHex;
+            use bitcoin_script::script;
 
-                /// Message length in bytes.
-                pub const MSG_LEN: u32 = $MSG_LEN;
-                /// Necessary parameters for the algorithm
-                pub const PS: winternitz::Parameters = winternitz::Parameters::new_by_bit_length(MSG_LEN * 8, 4);
-                /// Total number of "digits" in the signature.
-                pub const N_DIGITS: u32 = PS.total_length();
+            /// Message length in bytes.
+            pub const MSG_LEN: u32 = $MSG_LEN;
+            /// Necessary parameters for the algorithm
+            pub const PS: winternitz::Parameters =
+                winternitz::Parameters::new_by_bit_length(MSG_LEN * 8, 4);
+            /// Total number of "digits" in the signature.
+            pub const N_DIGITS: u32 = PS.total_length();
 
-                /// Public key is an array of 20-byte arrays.
-                pub type PublicKey = [[u8; 20]; N_DIGITS as usize];
-                /// Signature consists of pairs: (20-byte preimage, 1-byte digit).
-                pub type Signature = [([u8; 20], u8); N_DIGITS as usize];
+            /// Public key is an array of 20-byte arrays.
+            pub type PublicKey = [[u8; 20]; N_DIGITS as usize];
+            /// Signature consists of pairs: (20-byte preimage, 1-byte digit).
+            pub type Signature = [([u8; 20], u8); N_DIGITS as usize];
 
-                impl SignatureImpl for Signature {
-                    fn to_script(self) -> Script {
-                        script! {
-                            for (preimage, digit) in self {
-                                { preimage.to_vec() }
-                                { digit }
-                            }
-                        }
-                    }
-
-                    fn to_compact_script(self) -> Script {
-                        script! {
-                            for (preimage, _) in self {
-                                { preimage.to_vec() }
-                            }
+            impl SignatureImpl for Signature {
+                fn to_script(self) -> Script {
+                    script! {
+                        for (preimage, digit) in self {
+                            { preimage.to_vec() }
+                            { digit }
                         }
                     }
                 }
 
-                /// Create a verification script for a WOTS public key.
+                fn to_compact_script(self) -> Script {
+                    script! {
+                        for (preimage, _) in self {
+                            { preimage.to_vec() }
+                        }
+                    }
+                }
+            }
+
+            /// Create a verification script for a WOTS public key.
+            pub fn checksig_verify(public_key: PublicKey) -> Script {
+                WINTERNITZ_MESSAGE_VERIFIER.checksig_verify(&PS, &public_key.to_vec())
+            }
+
+            /// Changes the format of the signature, from bitcoin witness to array
+            pub fn raw_witness_to_signature(sigs: &Witness) -> Signature {
+                // Iterate over the signature pieces two at a time.
+                let mut sigs_vec: Vec<([u8; 20], u8)> = Vec::new();
+                for i in (0..sigs.len()).step_by(2) {
+                    let preimage: [u8; 20] = if sigs[i].len() == 0 {
+                        [0; 20]
+                    } else {
+                        sigs[i].try_into().unwrap()
+                    };
+                    let digit_arr: [u8; 1] = if sigs[i + 1].len() == 0 {
+                        [0]
+                    } else {
+                        sigs[i + 1].try_into().unwrap()
+                    };
+                    sigs_vec.push((preimage, digit_arr[0]));
+                }
+                sigs_vec.try_into().unwrap()
+            }
+
+            /// Changes the format of the signature, from array to bitcoin witness
+            pub fn signature_to_raw_witness(sigs: &Signature) -> Witness {
+                let mut w = Witness::new();
+                for (h, digit) in sigs.iter() {
+                    w.push(h.to_vec());
+                    w.push(u32_to_le_bytes_minimal(*digit as u32));
+                }
+                w
+            }
+
+            /// Generate a signature for a message using the provided secret.
+            pub fn get_signature(secret: &str, msg_bytes: &[u8]) -> Signature {
+                let secret_key = match Vec::<u8>::from_hex(secret) {
+                    Ok(bytes) => bytes,
+                    Err(_) => panic!("Invalid hex string for secret"),
+                };
+
+                let sigs = WINTERNITZ_MESSAGE_VERIFIER.sign(&PS, &secret_key, &msg_bytes.to_vec());
+                assert_eq!(sigs.len(), 2 * N_DIGITS as usize);
+                raw_witness_to_signature(&sigs)
+            }
+
+            /// Generate a WOTS public key using the provided secret.
+            pub fn generate_public_key(secret: &str) -> PublicKey {
+                let secret_key = match Vec::<u8>::from_hex(secret) {
+                    Ok(bytes) => bytes,
+                    Err(_) => panic!("Invalid hex string for secret"),
+                };
+                let pubkey_vec = winternitz::generate_public_key(&PS, &secret_key);
+                pubkey_vec.try_into().unwrap()
+            }
+
+            /// A sub-module for the compact signature variant.
+            pub mod compact {
+                use super::*;
+
+                /// The compact signature is just the 20-byte preimages.
+                pub type Signature = [[u8; 20]; N_DIGITS as usize];
+
+                /// Create a verification script for the compact WOTS public key.
                 pub fn checksig_verify(public_key: PublicKey) -> Script {
-                    WINTERNITZ_MESSAGE_VERIFIER.checksig_verify(&PS, &public_key.to_vec())
+                    WINTERNITZ_MESSAGE_COMPACT_VERIFIER.checksig_verify(&PS, &public_key.to_vec())
                 }
 
                 /// Changes the format of the signature, from bitcoin witness to array
                 pub fn raw_witness_to_signature(sigs: &Witness) -> Signature {
                     // Iterate over the signature pieces two at a time.
-                    let mut sigs_vec: Vec<([u8; 20], u8)> = Vec::new();
-                    for i in (0..sigs.len()).step_by(2) {
+                    let mut sigs_vec: Vec<[u8; 20]> = Vec::new();
+                    // Iterate over the signature pieces using step_by.
+                    for i in 0..sigs.len() {
                         let preimage: [u8; 20] = if sigs[i].len() == 0 {
                             [0; 20]
                         } else {
                             sigs[i].try_into().unwrap()
                         };
-                        let digit_arr: [u8; 1] = if sigs[i + 1].len() == 0 {
-                            [0]
-                        } else {
-                            sigs[i + 1].try_into().unwrap()
-                        };
-                        sigs_vec.push((preimage, digit_arr[0]));
+                        sigs_vec.push(preimage);
                     }
                     sigs_vec.try_into().unwrap()
                 }
@@ -84,91 +143,26 @@ macro_rules! impl_wots {
                 /// Changes the format of the signature, from array to bitcoin witness
                 pub fn signature_to_raw_witness(sigs: &Signature) -> Witness {
                     let mut w = Witness::new();
-                    for (h, digit) in sigs.iter() {
+                    for h in sigs.iter() {
                         w.push(h.to_vec());
-                        w.push(u32_to_le_bytes_minimal(*digit as u32));
                     }
                     w
                 }
 
-                /// Generate a signature for a message using the provided secret.
+                /// Generate a compact signature for a message.
                 pub fn get_signature(secret: &str, msg_bytes: &[u8]) -> Signature {
                     let secret_key = match Vec::<u8>::from_hex(secret) {
                         Ok(bytes) => bytes,
                         Err(_) => panic!("Invalid hex string for secret"),
                     };
 
-                    let sigs = WINTERNITZ_MESSAGE_VERIFIER.sign(
+                    let sigs = WINTERNITZ_MESSAGE_COMPACT_VERIFIER.sign(
                         &PS,
                         &secret_key,
                         &msg_bytes.to_vec(),
                     );
-                    assert_eq!(sigs.len(), 2 * N_DIGITS as usize);
+                    assert_eq!(sigs.len(), N_DIGITS as usize);
                     raw_witness_to_signature(&sigs)
-                }
-
-                /// Generate a WOTS public key using the provided secret.
-                pub fn generate_public_key(secret: &str) -> PublicKey {
-                    let secret_key = match Vec::<u8>::from_hex(secret) {
-                        Ok(bytes) => bytes,
-                        Err(_) => panic!("Invalid hex string for secret"),
-                    };
-                    let pubkey_vec = winternitz::generate_public_key(&PS, &secret_key);
-                    pubkey_vec.try_into().unwrap()
-                }
-
-                /// A sub-module for the compact signature variant.
-                pub mod compact {
-                    use super::*;
-
-                    /// The compact signature is just the 20-byte preimages.
-                    pub type Signature = [[u8; 20]; N_DIGITS as usize];
-
-                    /// Create a verification script for the compact WOTS public key.
-                    pub fn checksig_verify(public_key: PublicKey) -> Script {
-                        WINTERNITZ_MESSAGE_COMPACT_VERIFIER.checksig_verify(&PS, &public_key.to_vec())
-                    }
-
-                    /// Changes the format of the signature, from bitcoin witness to array
-                    pub fn raw_witness_to_signature(sigs: &Witness) -> Signature {
-                        // Iterate over the signature pieces two at a time.
-                        let mut sigs_vec: Vec<[u8; 20]> = Vec::new();
-                        // Iterate over the signature pieces using step_by.
-                        for i in 0..sigs.len() {
-                            let preimage: [u8; 20] = if sigs[i].len() == 0 {
-                                [0; 20]
-                            } else {
-                                sigs[i].try_into().unwrap()
-                            };
-                            sigs_vec.push(preimage);
-                        }
-                        sigs_vec.try_into().unwrap()
-                    }
-
-                    /// Changes the format of the signature, from array to bitcoin witness
-                    pub fn signature_to_raw_witness(sigs: &Signature) -> Witness {
-                        let mut w = Witness::new();
-                        for h in sigs.iter() {
-                            w.push(h.to_vec());
-                        }
-                        w
-                    }
-
-                    /// Generate a compact signature for a message.
-                    pub fn get_signature(secret: &str, msg_bytes: &[u8]) -> Signature {
-                        let secret_key = match Vec::<u8>::from_hex(secret) {
-                            Ok(bytes) => bytes,
-                            Err(_) => panic!("Invalid hex string for secret"),
-                        };
-
-                        let sigs = WINTERNITZ_MESSAGE_COMPACT_VERIFIER.sign(
-                            &PS,
-                            &secret_key,
-                            &msg_bytes.to_vec(),
-                        );
-                        assert_eq!(sigs.len(), N_DIGITS as usize);
-                        raw_witness_to_signature(&sigs)
-                    }
                 }
             }
         }

--- a/bitvm/src/signatures/wots_api.rs
+++ b/bitvm/src/signatures/wots_api.rs
@@ -29,7 +29,7 @@ macro_rules! impl_wots {
             pub const PS: winternitz::Parameters =
                 winternitz::Parameters::new_by_bit_length(MSG_LEN * 8, 4);
             /// Total number of "digits" in the signature.
-            pub const N_DIGITS: u32 = PS.total_length();
+            pub const N_DIGITS: u32 = PS.total_digit_len();
 
             /// Public key is an array of 20-byte arrays.
             pub type PublicKey = [[u8; 20]; N_DIGITS as usize];


### PR DESCRIPTION
This PR documents the data formats used in the WOTS code. I also do some cheap refactors while I'm at it.

##  From messages to digits

In WOTS, we sign messages of bytes. These bytes are converted into digits, which reverses the byte order. Each byte is split into two nibbles (digits).

A message of the form `[0x12, 0x34, 0x56, 0x78, ... ]` is converted into digits `[..., 7, 8, 5, 6, 3, 4, 1, 2]`.

A checksum is appended to the end of the digit sequence.

This data format might raise some eyebrows, but a lot of code depends on it. In particular, many Bitcoin scripts expect this exact format. For now, it seems best to keep it and document as best as possible.

## From digits to signatures

A WOTS signature are the hashes of each digit, plus optionally the digit itself. The precise format is documented in the code.