### PR TITLE
chore: cache hashing scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "bitcoin-script-stack",
  "bitcoin-scriptexec",
  "blake3",
+ "cached",
  "colored",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -2142,6 +2143,39 @@ dependencies = [
  "once_cell",
  "serde",
 ]
+
+[[package]]
+name = "cached"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown 0.14.5",
+ "once_cell",
+ "thiserror 2.0.12",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "camino"
@@ -2562,6 +2596,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3436,6 +3505,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3867,6 +3940,12 @@ dependencies = [
  "quote",
  "syn 2.0.99",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/bitvm/Cargo.toml
+++ b/bitvm/Cargo.toml
@@ -30,6 +30,7 @@ ark-crypto-primitives.workspace = true
 ark-relations.workspace = true
 tqdm.workspace = true
 regex.workspace = true
+cached = "0.55.1"
 
 [features]
 fuzzing = []

--- a/bitvm/src/chunk/wrap_hasher.rs
+++ b/bitvm/src/chunk/wrap_hasher.rs
@@ -37,9 +37,11 @@ pub(crate) mod hash_utils {
         treepp::Script,
     };
     use bitcoin_script::script;
+    use cached::proc_macro::cached;
 
     /// Compute hash of top two field elements on stack: [a00, a01]
     /// Output is {BLAKE3_HASH_LENGTH} byte output represented in limb-form
+    #[cached]
     pub(crate) fn hash_fp2() -> Script {
         script! {
             // [a00, a01]
@@ -51,6 +53,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of top four field elements on stack: [a00, a01, a10, a11]
     /// Output is {BLAKE3_HASH_LENGTH} byte output represented in limb-form
+    #[cached]
     pub(crate) fn hash_fp4() -> Script {
         script! {
             // [a00, a01, a10, a11]
@@ -65,6 +68,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of top six field elements on stack: [a00, a01, a10, a11, a20, a21]
     /// Output is {BLAKE3_HASH_LENGTH} byte output represented in limb-form
+    #[cached]
     pub(crate) fn hash_fp6() -> Script {
         script! {
             // [a00, a01, a10, a11, a20, a21]
@@ -79,6 +83,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of top six field elements on stack: [a00, a01,.., a60, a61]
     /// Output is {BLAKE3_HASH_LENGTH} byte output represented in limb-form
+    #[cached]
     pub(crate) fn hash_fp14() -> Script {
         script! {
             // [a00, a01,... ,a60, a61]
@@ -93,6 +98,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of G2 Point Accumulator (i.e. [t(4), partial_product(14)]) where Hash(partial_product) has been passed as auxiliary input on stack.
     /// Stack: [t(4), Hash_partial_product(1)]
+    #[cached]
     pub(crate) fn hash_g2acc_with_hashed_le() -> Script {
         script! {
             // [t, Hash_partial_product]
@@ -108,6 +114,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of G2 Point Accumulator (i.e. [t(4), partial_product(14)]) where all elements are passed as raw value on stack
     /// Stack: [t(4), partial_product(14)]
+    #[cached]
     pub(crate) fn hash_g2acc() -> Script {
         script! {
             // [t, partial_product]
@@ -136,6 +143,7 @@ pub(crate) mod hash_utils {
 
     /// Compute hash of G2 Point Accumulator (i.e. [t(4), partial_product(14)]) where Hash(t) has been passed as auxiliary input on stack.
     /// Stack: [Hash_partial_priduct(14), Hash_t(1)]
+    #[cached]
     pub(crate) fn hash_g2acc_with_hash_t() -> Script {
         script! {
             // [partial_product, Hash_t]


### PR DESCRIPTION
Added some caching on the functions that create the hashing scripts to make running the tests a little bit more bearable. This reduces `generate_segments_using_mock_proof` execution time on my machine from 270s to 90s, a 4x improvement. The downside is increased memory usage, which I think is probably fine, but if there are objections we could make the caching conditional on a feature flag