### PR TITLE
[Zellic Audit] Hash Bug (Mark 3 09.07)

### DIFF
--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -488,6 +488,81 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
             )
         }
     }
+
+    /// Validate that the BigInt on stack has valid limb values
+    ///
+    /// This function checks that each limb in the BigInt representation
+    /// does not exceed the maximum value allowed for the given LIMB_SIZE
+    /// and ensures no limb is negative.
+    ///
+    /// ## Stack Effects:
+    /// - Input: BigInt limbs (MSB first, LSB on top)
+    /// - Output: Same BigInt limbs + validation result (1 if valid, 0 if invalid)
+    ///
+    /// ## Validation Rules:
+    /// - Each limb must be >= 0 (no negative values)
+    /// - Each limb must be < (1 << LIMB_SIZE)
+    /// - The head limb must be < (1 << HEAD_OFFSET) where HEAD_OFFSET is the remaining bits
+    ///
+    /// ## Note:
+    /// This function is expensive in terms of script size and should be used carefully
+    pub fn is_valid_bigint_with_limb_size(limb_size: u32) -> Script {
+        let n_limbs = N_BITS.div_ceil(limb_size);
+        let head = N_BITS - (n_limbs - 1) * limb_size;
+        script! {
+            // Start with validation result = 1 (valid)
+            1
+
+            // Validate each regular limb (except the head)
+            for i in 0..n_limbs - 1 {
+                // Pick the limb from stack (limbs are ordered MSB first, LSB on top)
+                { i + 1 } OP_PICK
+
+                // Check if limb >= 0 (not negative)
+                OP_DUP
+                0 OP_GREATERTHANOREQUAL
+
+                // Check if limb < (1 << LIMB_SIZE)
+                OP_SWAP
+                { 1 << limb_size }
+                OP_LESSTHAN
+
+                // AND the boolean results
+                OP_BOOLAND OP_BOOLAND
+            }
+
+            // Validate the head limb (MSB) separately as it may have fewer bits
+            { n_limbs } OP_PICK
+
+            // Check if head limb >= 0 (not negative)
+            OP_DUP
+            0 OP_GREATERTHANOREQUAL
+
+            // Check if head limb < (1 << HEAD)
+            OP_SWAP
+            { 1 << head }
+            OP_LESSTHAN
+
+            // AND the boolean results
+            OP_BOOLAND OP_BOOLAND
+        }
+    }
+
+    /// Validate BigInt and fail script if invalid
+    pub fn verify_bigint_on_stack_with_limb_size(limb_size: u32) -> Script {
+        script! {
+            { Self::is_valid_bigint_with_limb_size(limb_size) }
+            OP_VERIFY
+        }
+    }
+
+    pub fn verify_bigint_on_stack() -> Script {
+        Self::verify_bigint_on_stack_with_limb_size(Self::LIMB_SIZE)
+    }
+
+    pub fn is_valid_bigint() -> Script {
+        Self::is_valid_bigint_with_limb_size(Self::LIMB_SIZE)
+    }
 }
 
 /// Extracts a window of bits from a u32 limb on top of stack
@@ -538,12 +613,48 @@ pub fn extract_digits(start_index: u32, window: u32) -> Script {
 #[cfg(test)]
 mod test {
     use crate::bigint::std::extract_digits;
+    use crate::bigint::U256;
     use crate::bigint::{BigIntImpl, U254};
-    use crate::run;
+    use crate::{execute_script, run};
 
     use bitcoin_script::script;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
+
+    #[test]
+    fn test_valid_bigint() {
+        let invalid_bigint = (
+            script! {
+                {0} {0} {0} {0} {0} {0} {0} {0} {-1}
+            },
+            false,
+        );
+
+        let invalid_bigint2 = (
+            script! {
+                {1 << U256::HEAD} {0} {0} {0} {0} {0} {0} {0} {0}
+            },
+            false,
+        );
+
+        let valid_bigint = (
+            script! {
+                {0x1234} {0x1234} {0x1234} {0x1234} {0x1234} {0x1234} {0x1234} {0x1234} {0x1234}
+            },
+            true,
+        );
+
+        for (bigint, expected) in [invalid_bigint, invalid_bigint2, valid_bigint] {
+            let res = execute_script(script! {
+                {bigint.clone()}
+                { U256::is_valid_bigint() }
+                OP_TOALTSTACK
+                for _ in 0..9 { OP_DROP }
+                OP_FROMALTSTACK
+            });
+            assert_eq!(res.success, expected);
+        }
+    }
 
     #[test]
     fn test_zip() {

--- a/bitvm/src/hash/blake3.rs
+++ b/bitvm/src/hash/blake3.rs
@@ -93,6 +93,7 @@ fn blake3(
         // unpack the compact form of message
         stack.custom(
             script!(
+                {U256::verify_bigint_on_stack_with_limb_size(limb_len as u32)}
                 {U256::transform_limbsize(limb_len as u32, 4)}
                 for _ in 0..64{
                     OP_TOALTSTACK
@@ -106,6 +107,7 @@ fn blake3(
 
         stack.custom(
             script!(
+                {U256::verify_bigint_on_stack_with_limb_size(limb_len as u32)}
                 {U256::transform_limbsize(limb_len as u32, 4)}
                 for _ in 0..64{
                     OP_FROMALTSTACK
@@ -374,6 +376,8 @@ pub fn blake3_verify_output_script(expected_output: [u8; 32]) -> Script {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bn254::fp254impl::Fp254Impl;
+    use crate::bn254::fq::Fq;
     use crate::{execute_script, execute_script_buf_without_stack_limit};
     use bitcoin::ScriptBuf;
     use bitcoin_script_stack::optimizer;
@@ -606,5 +610,35 @@ mod tests {
     #[ignore]
     fn test_maximum_alstack_element_calculation_with_all_limbs() {
         test_maximum_alstack_element_calculation_with_limbs(&ALL_POSSIBLE_LIMB_LENGTHS);
+    }
+
+    #[test]
+    fn test_hash_collision_on_invalid_input() {
+        let zero = script! {
+            {0} {0} {0} {0} {0} {0} {0} {0} {0}
+        };
+        let fake_zero = script! {
+            {0} {0} {0} {0} {0} {0} {0} {0} {-1}
+        };
+        let res = execute_script(script! {
+            // fake_zero has same hash as zero
+            {zero.clone()} {zero.clone()} {blake3_compute_script(64)}
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+            {zero.clone()} {fake_zero.clone()} {blake3_compute_script(64)}
+            for i in 0..64 {
+                OP_FROMALTSTACK
+                {64-i} OP_ROLL
+                OP_EQUALVERIFY
+            }
+            // fake_zero + (1: Fq) = (0: Fq)
+            {Fq::push(1.into())} {fake_zero.clone()} {Fq::add(1, 0)}
+            {Fq::push(0.into())} {Fq::equalverify(1, 0)}
+            {1}
+        });
+        println! {"{:?} {:?} {:?} {:?}", res.success, res.final_stack, res.stats, res.last_opcode};
+        assert_eq!(res.success, false);
+        assert_eq!(res.last_opcode, Some(bitcoin::opcodes::all::OP_VERIFY));
     }
 }

--- a/bitvm/src/hash/blake3.rs
+++ b/bitvm/src/hash/blake3.rs
@@ -613,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_collision_on_invalid_input() {
+    fn test_failure_on_invalid_input() {
         let zero = script! {
             {0} {0} {0} {0} {0} {0} {0} {0} {0}
         };
@@ -627,15 +627,6 @@ mod tests {
                 OP_TOALTSTACK
             }
             {zero.clone()} {fake_zero.clone()} {blake3_compute_script(64)}
-            for i in 0..64 {
-                OP_FROMALTSTACK
-                {64-i} OP_ROLL
-                OP_EQUALVERIFY
-            }
-            // fake_zero + (1: Fq) = (0: Fq)
-            {Fq::push(1.into())} {fake_zero.clone()} {Fq::add(1, 0)}
-            {Fq::push(0.into())} {Fq::equalverify(1, 0)}
-            {1}
         });
         println! {"{:?} {:?} {:?} {:?}", res.success, res.final_stack, res.stats, res.last_opcode};
         assert_eq!(res.success, false);


### PR DESCRIPTION
This PR targets https://github.com/BitVM/BitVM/issues/301

We convert a 29-limb bigint into a 4-limb by function `transform_limbsize` in the Blake3. The `transform_limbsize` extracts digits for the target limb by comparing the source limb with a 2-power positive integer. If there is a {-1} limb in an integer, then the extracted digits are all zeros, which is the same as the limb {0}. 

```
        let fake_zero = script! {
            {0} {0} {0} {0} {0} {0} {0} {0} {-1}
        };
        let zero = script! {
            {0} {0} {0} {0} {0} {0} {0} {0} {0}
        };
```

It turns out that there is no valid check when we try to use `transform_limbsize`. I add a function `verify_bigint_on_stack` to check if the data on the stack is a valid bigint. Now, the script of the Blake3 function will reject the invalid input by failing the script.
