### PR TITLE
fix G1Affine::hinted_check_add has a soundness issue (Mohit 2 11.06)

### DIFF
--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -160,6 +160,7 @@ impl G1Affine {
     pub fn hinted_check_add(t: ark_bn254::G1Affine, q: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
         let mut hints = vec![];
 
+        assert_ne!{t.x, q.x};
         let (alpha, bias) = if !t.is_zero() && !q.is_zero() {
             let alpha = (t.y - q.y) / (t.x - q.x);
             let bias = t.y - alpha * t.x;


### PR DESCRIPTION
assert_ne!{t.x, q.x}; // add a judge: t and q are not equal. If they are equal, then call hinted_check_double().