### PR TITLE
[Zellic Audit] Fix limb_add_with_carry_prevent_overflow and limb_double_with_carry_prevent_overflow issues

### DIFF
--- a/bitvm/src/bigint/add.rs
+++ b/bitvm/src/bigint/add.rs
@@ -234,7 +234,7 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
 
             OP_NIP
             { b_depth + 1 } OP_PICK
-            OP_ROT
+            OP_SWAP
             { limb_add_with_carry_prevent_overflow(Self::HEAD_OFFSET) }
 
             for _ in 0..Self::N_LIMBS - 1 {
@@ -361,7 +361,7 @@ fn limb_add_with_carry_prevent_overflow(head_offset: u32) -> Script {
         OP_2SWAP                                             // {a+b+c_nlo} {x} {a} {sign_b} {a+b+c_nlo} {x}
         OP_GREATERTHANOREQUAL                                // {a+b+c_nlo} {x} {a} {sign_b} {I:0/1}
         OP_2SWAP                                             // {a+b+c_nlo} {sign_b} {I:0/1} {x} {a}
-        OP_GREATERTHANOREQUAL                                // {a+b+c_nlo} {sign_b} {I:0/1} {sign_a}
+        OP_GREATERTHAN                                       // {a+b+c_nlo} {sign_b} {I:0/1} {sign_a}
         OP_ADD OP_ADD 1 3 OP_WITHIN OP_VERIFY                // verify (sign_a, sign_b, I) is not (0, 0, 0) or (1, 1, 1) which would mean overflow
     }
 }
@@ -417,7 +417,7 @@ fn limb_double_with_carry_prevent_overflow(head_offset: u32) -> Script {
         OP_TUCK OP_DUP OP_ADD                            // {a} {x} {2a+c} {2x}
         OP_2DUP OP_GREATERTHANOREQUAL                    // {a} {x} {2a+c} {2x} {L:0/1}
         OP_NOTIF OP_NOT OP_ENDIF OP_SUB                  // {a} {x} {2a+c_nlo}
-        OP_2DUP OP_LESSTHAN                              // {a} {x} {2a+c_nlo} {I:0/1}
+        OP_2DUP OP_LESSTHANOREQUAL                       // {a} {x} {2a+c_nlo} {I:0/1}
         OP_2SWAP                                         // {2a+c_nlo} {I:0/1} {a} {x}
         OP_LESSTHAN                                      // {2a+c_nlo} {I:0/1} {sign_a}
 


### PR DESCRIPTION
This PR fixes findings (Malte 2), (Malte 3), (Mohit 11) in the list.

### Malte 2
Finding: `limb_add_with_carry_prevent_overflow` behaves incorrectly regarding signed overflows if the first summand is the smallest negative number

This finding is about the function `limb_add_with_carry_prevent_overflow` in `bitvm/src/bigint/add.rs`.

This function expects three values a, b, and c on the stack. Furthermore, the argument head_offset is assumed to be of the form 2^w, with w < 31. The value c is assumed to be only a bit, and a and b both at most w bits wide, with all three being nonnegative integers as interpreted by Bitcoin Script. The three values are however conceptualized by this script as signed integers using two's complement with a bit width of w bits. In our notation, we are going to use a_u for a interpreted as an unsigned integer, and a_s for a interpreted as a signed integer, and similarly for b. For example, a_u = 2^(w-1) + 1 corresponds to a_s = -2^(w-1)+1 We emphasize that with respect to instructions such as OP_GREATERTHANOREQUAL, the values on the stack are assumed nonnegative, it is only at the level of how limb_add_with_carry_prevent_overflow conceptualizes their meaning that the signed interpretation comes into play. The purpose of the script is then to pop these three values off the stack and push the twos-complement encoding of a_s + b_s + c as long as this is representable in w bits, and fail otherwise.

Note that the unsigned integer corresponding to a signed integer can be obtained by reduction modulo 2^w. Thus, if -2^(w-1) ≤ a_s + b_s + c < 2^(w-1), the script should push (a_u + b_u + s) % 2^w, and otherwise fail.

The script begins by computing this value and placing it on the stack. The remaining logic is then supposed to check that -2^(w-1) ≤ a_s + b_s + c < 2^(w-1) and make the script fail otherwise. For this, three boolean values are obtained, as follows:
```
sign_a  =  a_u ≤ 2^(w-1)
sign_b  =  b_u < 2^(w-1)
I       =  ((a_u + b_u + c) % 2^w) ≥ 2^(w-1)
```

The script then fails if sign_a + sign_b + I is either 0 or 3.

Note that while sign_b is true if and only if b is interpreted as a nonnegative number, sign_a is true if and only if a is interpreted as a nonnegative number or -2^(w-1), which suggests a surprising assymmetry. Correspondingly, the script misbehaves in the case that a_u = 2^(w-1) (equivalentely, a_s = -2^(w-1)).

If one were to replace the definition of sign_a with the symmetrical sign_a = a_u < 2^(w-1), then one can check that sign_a + sign_b + I will be 1 or 2 if and only if -2^(w-1) ≤ a_s + b_s + c < 2^(w-1), so that the script correctly enforces that no signed overflow occured.

As the actual implementation matches the variant we just mentioned except possibly in the case a_u = 2^(w-1), where the correct variant would have sign_a=0, while the implementation has sign_a=1, we can conclude that in all cases with a_u ≠ 2^(w-1), the criteria under which the script fails is correct.

We now discuss this remaining edge case.

Case b_s < 0

In this case, we will have sign_a + sign_b = 1 + 0 = 1, and no matter what I is, the script will succeed. However, we will have that a_s + b_s < -2^(w-1). Thus we can conclude that the script will succeed even though the result is incorrect due to signed arithmetic underflow in all cases where b_s < -1 (independently of c) as well as in the case of b_s = -1 when c=0.

Case `b_s ≥ 0`

In this case, we will have a_s + b_s + c ≥ -2^(w-1) + 0 + 0 = -2^(w-1) and a_s + b_s + c ≤ -2^(w-1) + 2^(w-1) - 1 + 1 = 0, and hence the script should succeed. However, if I=1, then we will have sign_a+sign_b+I=3 and the script will fail. By definition, this happens when ((a_u + b_u + c) % 2^w) ≥ 2^(w-1). If a_u + b_u + c takes any value from -2^(w-1) to -1 (inclusive), this will be the case. In all those cases, the script will thus fail even though it should not. The one case where the script correctly succeeds is when a_u + b_u + c = 0, which happens only if b_u = 2^(w-1)-1 and c=1.

Impact
There is thus essentially a soundness and a completeness issue.

The soundness issue arises whenever a_s = -2^(w-1) and b_s+c < 0. In this case, the script will succeed with an incorrect result. This will break assumptions made by calling scripts. Should the input to some instance of limb_add_with_carry_prevent_overflow be attacker-controlled, an impact of soundness on the top level proof checker can not be ruled out.

The completeness issue arises in legitimate calls with a_s = -2^(w-1) and b_s≥ 0 with b_s+c < 2^(w-1). In this case, the script will fail. Depending on the precise use by calling scripts, a top level completeness issue can again not be ruled out.

The following two tests demonstrate this issue via the function BigIntImpl<254, 29>::add_ref_with_top.

This first test demonstrates the soundness variant. It should fail no matter whether change is 1<<200 or 1<<250, but only fails in the latter case. In the former case, it succeeds even though a signed overflow happens due to the discussed bug in limb_add_with_carry_prevent_overflow

```
    #[test]
    fn zellic_test_add_ref_with_top_soundness() {
        type T = crate::bigint::BigIntImpl<254, 29>;
        let mut a : BigUint = BigUint::one().shl(253);
        let mut b : BigUint = BigUint::one().shl(254) - BigUint::one();
        let c : BigUint = BigUint::one().shl(253) - BigUint::one();

        let change : BigUint = BigUint::one().shl(200);
        a += change.clone();
        b -= change;

        let script = script! {
            { T::push_u32_le(&a.to_u32_digits()) }
            { T::push_u32_le(&b.to_u32_digits()) }
            { T::add_ref_with_top(1) }
            { T::push_u32_le(&c.to_u32_digits()) }
            { T::equalverify(1, 0) }
            { T::drop() }
            { T::drop() }
            OP_TRUE
        };
        run(script);
    }
```

In contrast, the following test demonstrating completeness should succeed, but does not due to the discussed bug.
```
    #[test]
    fn zellic_test_add_ref_with_top_completeness() {
        type T = crate::bigint::BigIntImpl<254, 29>;
        let mut a : BigUint = BigUint::one().shl(253); // `-2^254`
        let mut b : BigUint = BigUint::one(); // `1`
        let c : BigUint = a.clone() + b.clone();

        let script = script! {
            { T::push_u32_le(&a.to_u32_digits()) }
            { T::push_u32_le(&b.to_u32_digits()) }
            { T::add_ref_with_top(1) }
            { T::push_u32_le(&c.to_u32_digits()) }
            { T::equalverify(1, 0) }
            { T::drop() }
            { T::drop() }
            OP_TRUE
        };
        run(script);
    }
```

Recommendation

The last OP_GREATERTHANOREQUAL needs to be OP_GREATERTHAN instead. With this change, the script will replace sign_a by the correct definition.

### Malte 3
Finding: Function `add_ref` deals incorrectly with the potential of signed overflows and underflows

The following function in bitvm/src/bigint/add.rs is intended to add two bigint values that are interpreted as signed integers, while preventing signed overflows, making the script fail if a signed overflow would have happend:
```
    /// Add BigInt on top of the stack to a BigInt at `b` depth in the stack
    ///
    /// # Note
    ///
    /// This function consumes the BigInt on top of the stack while not consuming
    /// the referenced BigInt
    pub fn add_ref(b: u32) -> Script {
        let b_depth = b * Self::N_LIMBS;
        assert_ne!(b, 0);
        script! {
            { b_depth } OP_PICK
            OP_ADD

            // OP_DEPTH OP_1SUB OP_PICK
            { 1 << LIMB_SIZE }
            OP_SWAP

            { limb_add_create_carry() }
            OP_TOALTSTACK

            for _ in 0..Self::N_LIMBS - 2 {
                OP_ROT
                { b_depth + 2 } OP_PICK
                OP_ADD
                OP_ADD { limb_add_create_carry() } OP_TOALTSTACK
            }

            OP_NIP
            { b_depth + 1 } OP_PICK
            OP_ROT
            { limb_add_with_carry_prevent_overflow(Self::HEAD_OFFSET) }

            for _ in 0..Self::N_LIMBS - 1 {
                OP_FROMALTSTACK
            }
        }
    }
```

After the last iteration of the first loop, the top of the stack will look as follows, with the topmost item on the right:
... y_{N_LIMBS-1} (1<<LIMB_SIZE) carry_{N_LIMBS - 2}
The OP_NIP instruction drops the (1<<LIMB_SIZE) in the middle, and then { b_depth + 1 } OP_PICK copies the last limb from the other summand to the top:
y_{N_LIMBS-1} carry_{N_LIMBS - 2} x_{N_LIMBS - 1}
The OP_ROT instruction then moves y_{N_LIMBS-1} to the top, so that we are left with the top three items on the stack in the following order before the limb_add_with_carry_prevent_overflow script:
carry_{N_LIMBS - 2} x_{N_LIMBS - 1} y_{N_LIMBS-1}

However, limb_add_with_carry_prevent_overflow expects the stack to be in the order a b carry, with the carry on top and the two limbs below. Note that while limb_add_with_carry_prevent_overflow calculates the sum a + b + carry modulo Self::HEAD_OFFSET, for which the order of the three items would not matter, it also checks that no signed arithmetic overflow or underflow occurs, making the script fail if it would. See my discussion on Tuesday (update 2) for more details on the specification and intended behavior of limb_add_with_carry_prevent_overflow. What is relevant for this finding is that limb_add_with_carry_prevent_overflow relies on 0 <= a, b < Self::HEAD_OFFSET as well as 0 <= carry <= 1 for the overflow check to be accurate.

In this case, we will have a = carry_{N_LIMBS - 2}, b = x_{N_LIMBS - 1}, and carry = y_{N_LIMBS-1}. While the assumption limb_add_with_carry_prevent_overflow makes on a and b are satisfied, they are not satisfied for carry.

I will use the same notation as in the update on Tuesday. So what should be enforced is -2^{w-1} ≤ a_s + b_s + c < 2^{w-1}$, where Self::HEAD_OFFSET is equal to 2^w. As a_u is either zero or one in this case, we will have sign_a = 1. The script will then fail if and only if b_u < 2^{w-1} and 2^{w-1} ≤ ((a_u + b_u + c) % 2^w). In other words, the script will fail if and only if the signed value represented by x_{N_LIMBS - 1} is nonnegative, and the signed value obtained as the sum is negative.

This has both soundness and completeness implications. Regarding soundness, when x_{N_LIMBS - 1} as well as y_{N_LIMBS - 1} are negative, with their sum being smaller than -2^{w-1}, then a signed arithmetic underflow will occur, but the script will still succeed and produce an incorrect result.

Regarding completeness, if x_{N_LIMBS - 1} is nonnegative and y_{N_LIMBS - 1} is negative, with the full signed sum (including also the carry that is) being negative, then the script will fail even though no arithmetic overflow or underflow occurred.

The soundness variant is demonstrated by the following test, which should fail but succeeds:
```
    #[test]
    fn zellic_test_add_ref_soundness() {
        type T = crate::bigint::BigIntImpl<254, 29>;
        let mut a : BigUint = BigUint::one().shl(253); // `-2^253`
        let mut b : BigUint = BigUint::one().shl(254) - BigUint::one(); // `-1`
        let c : BigUint = BigUint::one().shl(253) - BigUint::one(); // `2^253 - 1`

        let script = script! {
            { T::push_u32_le(&a.to_u32_digits()) }
            { T::push_u32_le(&b.to_u32_digits()) }
            { T::add_ref(1) }
            { T::push_u32_le(&c.to_u32_digits()) }
            { T::equalverify(1, 0) }
            { T::drop() }
            OP_TRUE
        };
        run(script);
    }
```

This second tests demonstrates the completeness variant by failing:
```
    #[test]
    fn zellic_test_add_ref_completeness() {
        type T = crate::bigint::BigIntImpl<254, 29>;
        let mut a : BigUint = BigUint::ZERO; // `0`
        let mut b : BigUint = BigUint::one().shl(254) - BigUint::one(); // `-1`
        let c : BigUint = a.clone() + b.clone(); // `-1`

        let script = script! {
            { T::push_u32_le(&a.to_u32_digits()) }
            { T::push_u32_le(&b.to_u32_digits()) }
            { T::add_ref(1) }
            { T::push_u32_le(&c.to_u32_digits()) }
            { T::equalverify(1, 0) }
            { T::drop() }
            OP_TRUE
        };
        run(script);
    }
```

Recommendation

The OP_ROT instruction should have been a OP_SWAP instead. With this change, the stack
y_{N_LIMBS-1} carry_{N_LIMBS - 2} x_{N_LIMBS - 1}
would be transformed to
y_{N_LIMBS-1} x_{N_LIMBS - 1} carry_{N_LIMBS - 2}
with the carry value at the top, as expected by limb_add_with_carry_prevent_overflow.

### Mohit 11
Similar issue with (Malte 2) applies to function limb_double_with_carry_prevent_overflow as well. It is also fixed.