### PR TITLE
[Zellic Audit] tmul: check hints are valid bigints

### DIFF
--- a/bitvm/src/bigint/add.rs
+++ b/bitvm/src/bigint/add.rs
@@ -172,6 +172,32 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         }
     }
 
+    pub fn double_prevent_overflow_keep_element(n: u32) -> Script {
+        script! {
+            for _ in 0..Self::N_LIMBS {
+                { n + Self::N_LIMBS - 1 } OP_PICK
+            }
+            { 1 << LIMB_SIZE }
+
+            // Double the limb, take the result to the alt stack, and add initial carry
+            OP_SWAP limb_double_without_carry OP_TOALTSTACK
+
+
+            for _ in 0..Self::N_LIMBS - 2 {
+                OP_ROT limb_double_with_carry OP_TOALTSTACK
+            }
+
+            // When we got {limb} {base} {carry} on the stack, we drop the base
+            OP_NIP // {limb} {carry}
+            { limb_double_with_carry_prevent_overflow(Self::HEAD_OFFSET) }
+
+            // Take all limbs from the alt stack to the main stack
+            for _ in 0..Self::N_LIMBS - 1 {
+                OP_FROMALTSTACK
+            }
+        }
+    }
+
     /// Left shift the BigInt on top of the stack by `bits`
     ///
     /// # Note

--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -307,6 +307,24 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         }
     }
 
+    /// checks if the element on top of the stack is a valid bigint, needed for hints
+    /// - head limb in the range [0..HEAD_OFFSET-1]
+    /// - other limbs in the range [0..2^LIMB_SIZE-1]
+    pub fn check_validity() -> Script {
+        script! {                            // a0 a1 ... an
+            { 1 << LIMB_SIZE }               // a0 a1 ... an x
+            for _ in 0..Self::N_LIMBS-2 {    // a x
+                OP_TUCK                      // x a x
+                0 OP_SWAP                    // x a 0 x
+                OP_WITHIN OP_VERIFY          // x
+            }                                // a0 a1 x
+            0 OP_SWAP                        // a0 a1 0 x
+            OP_WITHIN OP_VERIFY              // a0
+            0 { Self::HEAD_OFFSET }          // a0 0 y
+            OP_WITHIN OP_VERIFY
+        }
+    }
+
     /// Resize positive numbers
     ///
     /// # Note

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -577,9 +577,10 @@ pub trait Fp254Impl {
         let y = BigInt::from_str(&b.to_string()).unwrap();
         let modulus = &Fq::modulus_as_bigint();
         let q = (x * y) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_1().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -599,9 +600,10 @@ pub trait Fp254Impl {
         let y = BigInt::from_str(&constant.to_string()).unwrap();
         let modulus = &Fq::modulus_as_bigint();
         let q = (x * y) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_1().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -631,9 +633,10 @@ pub trait Fp254Impl {
         let y = BigInt::from_str(&b.to_string()).unwrap();
         let modulus = &Fq::modulus_as_bigint();
         let q = (x * y) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_1().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -669,9 +672,10 @@ pub trait Fp254Impl {
         let w = BigInt::from_str(&d.to_string()).unwrap();
 
         let q = (x * z + y * w) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_2().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -712,9 +716,10 @@ pub trait Fp254Impl {
         let w = BigInt::from_str(&d.to_string()).unwrap();
 
         let q = (x * z + y * w) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_2_w4().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -724,7 +729,7 @@ pub trait Fp254Impl {
             { Fq::roll(d_depth + 4) }
             { Fq::tmul_lc2_w4() }
         };
-        hints.push(Hint::BigIntegerTmulLC2(q));
+        hints.push(Hint::BigIntegerTmulLC2W4(q));
 
         (script, hints)
     }
@@ -774,9 +779,10 @@ pub trait Fp254Impl {
         let w2 = BigInt::from_str(&h.to_string()).unwrap();
 
         let q = (x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_4().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { fq_push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -818,9 +824,10 @@ pub trait Fp254Impl {
         let w = BigInt::from_str(&d.to_string()).unwrap();
 
         let q = (x * z + y * w) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_2().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -859,9 +866,10 @@ pub trait Fp254Impl {
         let w = BigInt::from_str(&d.to_string()).unwrap();
 
         let q = (x * z + y * w) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_2_w4().2;
 
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -871,7 +879,7 @@ pub trait Fp254Impl {
             { Fq::copy(d_depth + 4) }
             { Fq::tmul_lc2_w4() }
         };
-        hints.push(Hint::BigIntegerTmulLC2(q));
+        hints.push(Hint::BigIntegerTmulLC2W4(q));
 
         (script, hints)
     }
@@ -882,8 +890,10 @@ pub trait Fp254Impl {
         let x = &BigInt::from_str(&a.to_string()).unwrap();
         let modulus = &Fq::modulus_as_bigint();
         let q = (x * x) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_1().2;
+
         let script = script! {
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -902,11 +912,13 @@ pub trait Fp254Impl {
         let modulus = &Fq::modulus_as_bigint();
         let y = &x.modinv(modulus).unwrap();
         let q = (x * y) / modulus;
+        const T_N_LIMBS: u32 = Fq::bigint_tmul_lc_1().2;
+
         let script = script! {
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
-            for _ in 0..Self::N_LIMBS {
+            for _ in 0..T_N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hints
             }
             // { Fq::push(ark_bn254::Fq::from_str(&y.to_string()).unwrap()) }

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -132,7 +132,7 @@ macro_rules! fp_lc_mul {
             impl [<Fp254 $NAME>] for Fq {
 
                 type U = BigIntImpl<{ Self::N_BITS }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
-                type W = BigIntImpl<{ Self::N_BITS + $VAR_WIDTH}, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
+                type W = BigIntImpl<{ Self::N_BITS + <Self as [<Fp254 $NAME>]>::LC_BITS + 1 }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
                 type T = BigIntImpl<{ Self::N_BITS + $VAR_WIDTH + <Self as [<Fp254 $NAME>]>::LC_BITS + 1 }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
 
                 fn tmul() -> Script {

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -431,11 +431,11 @@ mod test {
     use ark_ff::Field;
     use ark_std::UniformRand;
     use core::ops::{Add, Mul, Rem, Sub};
-    use std::str::FromStr;
     use num_bigint::{BigInt, BigUint, RandBigInt, RandomBits};
     use num_traits::{Num, Signed};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
+    use std::str::FromStr;
 
     fn extract_witness_from_stack(res: ExecuteInfo) -> Vec<Vec<u8>> {
         res.final_stack.0.iter_str().fold(vec![], |mut vector, x| {
@@ -1048,8 +1048,14 @@ mod test {
         type U = <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::U;
         type T = <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::T;
 
-        println!("LCS = {:?}", <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::LCS);
-        println!("LC_BITS = {}", <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::LC_BITS);
+        println!(
+            "LCS = {:?}",
+            <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::LCS
+        );
+        println!(
+            "LC_BITS = {}",
+            <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::LC_BITS
+        );
         println!("T::N_BITS = {}", T::N_BITS);
 
         let lcs = <Fq as Fp254ZellicMulNonPowerTwoLCSLength>::LCS;
@@ -1088,6 +1094,5 @@ mod test {
         };
         let res = execute_script(script);
         assert!(res.success);
-
     }
 }

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -323,9 +323,10 @@ macro_rules! fp_lc_mul {
                             { U::lessthan(1, 0) } OP_VERIFY                                // {q} {x0} {x1} {y0} {y1}
                             { U::toaltstack() }                                            // {q} {x0} {x1} {y0} -> {y1}
                         }                                                                  // {q} -> {x0} {x1} {y0} {y1}
+                        // ensure q is a valid bigint
+                        { T::copy(0) } { T::check_validity() }
                         // Pre-compute lookup tables
-                        { T::push_zero() }                   // {q} {0} -> {x0} {x1} {y0} {y1}
-                        { T::sub(0, 1) }                     // {-q} -> {x0} {x1} {y0} {y1}
+                        { T::neg() }                         // {-q} -> {x0} {x1} {y0} {y1}
                         { init_table(MOD_WIDTH) }            // {-q_table} -> {x0} {x1} {y0} {y1}
                         for i in 0..N_LC {
                             { U::fromaltstack() }            // {-q_table} {x0} -> {x1} {y0} {y1}

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -338,6 +338,7 @@ macro_rules! fp_lc_mul {
                         }                                                                  // {q} -> {x0} {x1} {y0} {y1}
                         // ensure q is a valid bigint
                         { W::copy(0) } { W::check_validity() }
+                        { W::resize::<{ T::N_BITS }>() }
                         // Pre-compute lookup tables
                         { T::neg() }                         // {-q} -> {x0} {x1} {y0} {y1}
                         { init_table(MOD_WIDTH) }            // {-q_table} -> {x0} {x1} {y0} {y1}

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -334,7 +334,7 @@ macro_rules! fp_lc_mul {
                             { U::toaltstack() }                                            // {q} {x0} {x1} {y0} -> {y1}
                         }                                                                  // {q} -> {x0} {x1} {y0} {y1}
                         // ensure q is a valid bigint
-                        { T::copy(0) } { T::check_validity() }
+                        { T::copy(0) } { U::check_validity() }
                         // Pre-compute lookup tables
                         { T::neg() }                         // {-q} -> {x0} {x1} {y0} {y1}
                         { init_table(MOD_WIDTH) }            // {-q_table} -> {x0} {x1} {y0} {y1}

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -64,30 +64,30 @@ impl Fq {
     }
 
     pub const fn bigint_tmul_lc_1() -> (u32, u32, u32) {
-        const X: u32 = <Fq as Fp254Mul>::W::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul>::W::LIMB_SIZE;
-        const Z: u32 = <Fq as Fp254Mul>::W::N_LIMBS;
+        const X: u32 = <Fq as Fp254Mul>::T::N_BITS;
+        const Y: u32 = <Fq as Fp254Mul>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul>::T::N_LIMBS;
         (X, Y, Z)
     }
 
     pub const fn bigint_tmul_lc_2() -> (u32, u32, u32) {
-        const X: u32 = <Fq as Fp254Mul2LC>::W::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul2LC>::W::LIMB_SIZE;
-        const Z: u32 = <Fq as Fp254Mul2LC>::W::N_LIMBS;
+        const X: u32 = <Fq as Fp254Mul2LC>::T::N_BITS;
+        const Y: u32 = <Fq as Fp254Mul2LC>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul2LC>::T::N_LIMBS;
         (X, Y, Z)
     }
 
     pub const fn bigint_tmul_lc_2_w4() -> (u32, u32, u32) {
-        const X: u32 = <Fq as Fp254Mul2LCW4>::W::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul2LCW4>::W::LIMB_SIZE;
-        const Z: u32 = <Fq as Fp254Mul2LCW4>::W::N_LIMBS;
+        const X: u32 = <Fq as Fp254Mul2LCW4>::T::N_BITS;
+        const Y: u32 = <Fq as Fp254Mul2LCW4>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul2LCW4>::T::N_LIMBS;
         (X, Y, Z)
     }
 
     pub const fn bigint_tmul_lc_4() -> (u32, u32, u32) {
-        const X: u32 = <Fq as Fp254Mul4LC>::W::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul4LC>::W::LIMB_SIZE;
-        const Z: u32 = <Fq as Fp254Mul4LC>::W::N_LIMBS;
+        const X: u32 = <Fq as Fp254Mul4LC>::T::N_BITS;
+        const Y: u32 = <Fq as Fp254Mul4LC>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul4LC>::T::N_LIMBS;
         (X, Y, Z)
     }
 
@@ -124,7 +124,6 @@ macro_rules! fp_lc_mul {
                 const LCS: [bool; $LCS.len()] = $LCS;
                 const LC_BITS: u32 = usize::BITS - ($LCS.len() - 1).leading_zeros();
                 type U;
-                type W;
                 type T;
                 fn tmul() -> Script;
             }
@@ -132,7 +131,6 @@ macro_rules! fp_lc_mul {
             impl [<Fp254 $NAME>] for Fq {
 
                 type U = BigIntImpl<{ Self::N_BITS }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
-                type W = BigIntImpl<{ Self::N_BITS + <Self as [<Fp254 $NAME>]>::LC_BITS + 1 }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
                 type T = BigIntImpl<{ Self::N_BITS + $VAR_WIDTH + <Self as [<Fp254 $NAME>]>::LC_BITS + 1 }, { <Self as [<Fp254 $NAME>]>::LIMB_SIZE }>;
 
                 fn tmul() -> Script {
@@ -147,7 +145,6 @@ macro_rules! fp_lc_mul {
                     let lc_signs = <Fq as [<Fp254 $NAME>]>::LCS;
 
                     type U = <Fq as [<Fp254 $NAME>]>::U;
-                    type W = <Fq as [<Fp254 $NAME>]>::W;
                     type T = <Fq as [<Fp254 $NAME>]>::T;
 
                     // N_BITS for the extended number used during intermediate computation
@@ -337,9 +334,8 @@ macro_rules! fp_lc_mul {
                             { U::toaltstack() }                                            // {q} {x0} {x1} {y0} -> {y1}
                         }                                                                  // {q} -> {x0} {x1} {y0} {y1}
                         // ensure q is a valid bigint
-                        { W::copy(0) } { W::check_validity() }
-                        { W::resize::<{ T::N_BITS }>() }
-                        // Pre-compute lookup tables
+                        { T::copy(0) } { T::check_validity() }
+                        // Pre-compute lookup tables (q can not be 2^T::N_BITS-1 when tmul is correctly used, so neg() gives correct result)
                         { T::neg() }                         // {-q} -> {x0} {x1} {y0} {y1}
                         { init_table(MOD_WIDTH) }            // {-q_table} -> {x0} {x1} {y0} {y1}
                         for i in 0..N_LC {

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -63,22 +63,32 @@ impl Fq {
         }
     }
 
-    pub const fn bigint_tmul_lc_1() -> (u32, u32) {
+    pub const fn bigint_tmul_lc_1() -> (u32, u32, u32) {
         const X: u32 = <Fq as Fp254Mul>::T::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul>::LIMB_SIZE;
-        (X, Y)
+        const Y: u32 = <Fq as Fp254Mul>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul>::T::N_LIMBS;
+        (X, Y, Z)
     }
 
-    pub const fn bigint_tmul_lc_2() -> (u32, u32) {
+    pub const fn bigint_tmul_lc_2() -> (u32, u32, u32) {
         const X: u32 = <Fq as Fp254Mul2LC>::T::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul2LC>::LIMB_SIZE;
-        (X, Y)
+        const Y: u32 = <Fq as Fp254Mul2LC>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul2LC>::T::N_LIMBS;
+        (X, Y, Z)
     }
 
-    pub const fn bigint_tmul_lc_4() -> (u32, u32) {
+    pub const fn bigint_tmul_lc_2_w4() -> (u32, u32, u32) {
+        const X: u32 = <Fq as Fp254Mul2LCW4>::T::N_BITS;
+        const Y: u32 = <Fq as Fp254Mul2LCW4>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul2LCW4>::T::N_LIMBS;
+        (X, Y, Z)
+    }
+
+    pub const fn bigint_tmul_lc_4() -> (u32, u32, u32) {
         const X: u32 = <Fq as Fp254Mul4LC>::T::N_BITS;
-        const Y: u32 = <Fq as Fp254Mul4LC>::LIMB_SIZE;
-        (X, Y)
+        const Y: u32 = <Fq as Fp254Mul4LC>::T::LIMB_SIZE;
+        const Z: u32 = <Fq as Fp254Mul4LC>::T::N_LIMBS;
+        (X, Y, Z)
     }
 
     #[inline]
@@ -359,12 +369,12 @@ macro_rules! fp_lc_mul {
                                         OP_SWAP
                                         OP_SUB
                                         if i + j == MAIN_LOOP_START && j == 0 {
-                                            for _ in 0..Self::N_LIMBS {
+                                            for _ in 0..T::N_LIMBS {
                                                 OP_NIP
                                             }
-                                            { NMUL(Self::N_LIMBS) }
+                                            { NMUL(T::N_LIMBS) }
                                             OP_DUP OP_PICK
-                                            for _ in 0..Self::N_LIMBS-1 {
+                                            for _ in 0..T::N_LIMBS-1 {
                                                 OP_SWAP
                                                 OP_DUP OP_PICK
                                             }

--- a/bitvm/src/bn254/utils.rs
+++ b/bitvm/src/bn254/utils.rs
@@ -14,16 +14,19 @@ pub enum Hint {
     U256(num_bigint::BigInt),
     BigIntegerTmulLC1(num_bigint::BigInt),
     BigIntegerTmulLC2(num_bigint::BigInt),
+    BigIntegerTmulLC2W4(num_bigint::BigInt),
     BigIntegerTmulLC4(num_bigint::BigInt),
 }
 
 impl Hint {
     pub fn push(&self) -> Script {
-        const K1: (u32, u32) = Fq::bigint_tmul_lc_1();
-        const K2: (u32, u32) = Fq::bigint_tmul_lc_2();
-        const K4: (u32, u32) = Fq::bigint_tmul_lc_4();
+        const K1: (u32, u32, u32) = Fq::bigint_tmul_lc_1();
+        const K2: (u32, u32, u32) = Fq::bigint_tmul_lc_2();
+        const K3: (u32, u32, u32) = Fq::bigint_tmul_lc_2_w4();
+        const K4: (u32, u32, u32) = Fq::bigint_tmul_lc_4();
         pub type T1 = BigIntImpl<{ K1.0 }, { K1.1 }>;
         pub type T2 = BigIntImpl<{ K2.0 }, { K2.1 }>;
+        pub type T3 = BigIntImpl<{ K3.0 }, { K3.1 }>;
         pub type T4 = BigIntImpl<{ K4.0 }, { K4.1 }>;
         match self {
             Hint::Fq(fq) => script! {
@@ -45,6 +48,9 @@ impl Hint {
             },
             Hint::BigIntegerTmulLC2(a) => script! {
                 { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T2::N_BITS)) }
+            },
+            Hint::BigIntegerTmulLC2W4(a) => script! {
+                { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T3::N_BITS)) }
             },
             Hint::BigIntegerTmulLC4(a) => script! {
                 { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T4::N_BITS)) }

--- a/bitvm/src/bn254/utils.rs
+++ b/bitvm/src/bn254/utils.rs
@@ -24,10 +24,10 @@ impl Hint {
         const K2: (u32, u32, u32) = Fq::bigint_tmul_lc_2();
         const K3: (u32, u32, u32) = Fq::bigint_tmul_lc_2_w4();
         const K4: (u32, u32, u32) = Fq::bigint_tmul_lc_4();
-        pub type T1 = BigIntImpl<{ K1.0 }, { K1.1 }>;
-        pub type T2 = BigIntImpl<{ K2.0 }, { K2.1 }>;
-        pub type T3 = BigIntImpl<{ K3.0 }, { K3.1 }>;
-        pub type T4 = BigIntImpl<{ K4.0 }, { K4.1 }>;
+        pub type W1 = BigIntImpl<{ K1.0 }, { K1.1 }>;
+        pub type W2 = BigIntImpl<{ K2.0 }, { K2.1 }>;
+        pub type W3 = BigIntImpl<{ K3.0 }, { K3.1 }>;
+        pub type W4 = BigIntImpl<{ K4.0 }, { K4.1 }>;
         match self {
             Hint::Fq(fq) => script! {
                 { Fq::push(*fq) }
@@ -44,16 +44,16 @@ impl Hint {
                 { U256::push_u32_le(&bigint_to_u32_limbs(num.clone(), 256)) }
             },
             Hint::BigIntegerTmulLC1(a) => script! {
-                { T1::push_u32_le(&bigint_to_u32_limbs(a.clone(), T1::N_BITS)) }
+                { W1::push_u32_le(&bigint_to_u32_limbs(a.clone(), W1::N_BITS)) }
             },
             Hint::BigIntegerTmulLC2(a) => script! {
-                { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T2::N_BITS)) }
+                { W2::push_u32_le(&bigint_to_u32_limbs(a.clone(), W2::N_BITS)) }
             },
             Hint::BigIntegerTmulLC2W4(a) => script! {
-                { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T3::N_BITS)) }
+                { W2::push_u32_le(&bigint_to_u32_limbs(a.clone(), W3::N_BITS)) }
             },
             Hint::BigIntegerTmulLC4(a) => script! {
-                { T2::push_u32_le(&bigint_to_u32_limbs(a.clone(), T4::N_BITS)) }
+                { W2::push_u32_le(&bigint_to_u32_limbs(a.clone(), W4::N_BITS)) }
             },
         }
     }


### PR DESCRIPTION
This PR adds check_validity() function BigIntImpl which checks every limb is in correct interval. This function is then used in tmul to check the given hint is a well-formed bigint. This adds +70 bytes of script to Fq::hinted_mul (67820 -> 67890). 

To reduce this, I also noticed a small optimization while fixing this. It is to replace `T::push_zero() + T::sub()` with `T::neg()`. neg function doesnt exist, so I created it, it basically first performs `(2^N_BITS-1)-x`, and then adds 1. This takes Fq::hinted_mul from 67890 to 67837. 

Closes #304 and closes #305 (followup). (edit: also closes #307 ) (edit: also closes #311 ) (edit: also closes #310 )