### PR TITLE
fix: replace wildcard dependency version with specific version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 ark-std = { version = "0.5.0", default-features = false, features = ["print-trace"] }
 ark-crypto-primitives = { version = "0.5.0", features = ["snark", "sponge"] }
 ark-relations = "0.5.0"
-serial_test = "*"
+serial_test = "3.0"
 tqdm = "0.7"
 secp256k1 = { version = "0.29.1", features = ["global-context"]}
 derive_more = "2.0"


### PR DESCRIPTION
Replace serial_test = "*" with serial_test = "3.0" in workspace Cargo.toml. Wildcard versions can cause unpredictable build failures and violate  reproducible build principles. This change ensures consistent builds across all environments and follows Cargo best practices