### PR TITLE
Zellic Audit G1 fixes

### DIFF
--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -147,7 +147,7 @@ impl G1Affine {
             witness[Fq::N_LIMBS as usize..2 * Fq::N_LIMBS as usize].to_vec(),
         ))
         .into();
-        let is_inf = x.is_zero() & y.is_zero();
+        let is_inf = x.is_zero() && y.is_zero();
         ark_bn254::G1Affine {
             x,
             y,

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -556,7 +556,6 @@ mod test {
     fn test_read_from_stack() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         let a = ark_bn254::G1Affine::rand(&mut prng);
-        //let a = ark_bn254::G1Affine::zero();
         let script = script! {
             {G1Affine::push(a)}
         };
@@ -567,14 +566,14 @@ mod test {
 
         assert_eq!(a, recovered_a);
 
-        let b = ark_bn254::G2Affine::rand(&mut prng);
+        let b = ark_bn254::G1Affine::identity();
         let script = script! {
-            {G2Affine::push(b)}
+            {G1Affine::push(b)}
         };
 
         let res = execute_script(script);
         let witness = extract_witness_from_stack(res);
-        let recovered_b = G2Affine::read_from_stack(witness);
+        let recovered_b = G1Affine::read_from_stack(witness);
 
         assert_eq!(b, recovered_b);
     }

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -144,7 +144,7 @@ impl G1Affine {
         let x = Fq::read_u32_le(witness[0..Fq::N_LIMBS as usize].to_vec());
         let y = Fq::read_u32_le(witness[Fq::N_LIMBS as usize..2 * Fq::N_LIMBS as usize].to_vec());
         let mut zero = Vec::new();
-        for _ in 0..8{
+        for _ in 0..8 {
             zero.push(0u32);
         }
         let is_inf = (x == zero) & (y == zero);

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -411,53 +411,6 @@ impl G1Affine {
 ///      tmul hints, p.y_inverse
 /// output on stack:
 ///      x' = -p.x / p.y
-pub fn hinted_x_from_eval_point(
-    p: ark_bn254::G1Affine,
-    py_inv: ark_bn254::Fq,
-) -> (Script, Vec<Hint>) {
-    let mut hints = Vec::new();
-
-    let (hinted_script1, hint1) = Fq::hinted_mul(1, p.y, 0, py_inv);
-    let (hinted_script2, hint2) = Fq::hinted_mul(1, py_inv, 0, -p.x);
-    let script = script! {   // Stack: [hints, pyd, px, py]
-        {Fq::copy(2)}                        // Stack: [hints, pyd, px, py, pyd]
-        {hinted_script1}
-        {Fq::push_one()}
-        {Fq::equalverify(1, 0)}              // Stack: [hints, pyd, px]
-        {Fq::neg(0)}                        // Stack: [hints, pyd, -px]
-        {hinted_script2}
-    };
-    hints.extend(hint1);
-    hints.extend(hint2);
-    (script, hints)
-}
-
-/// input of func (params):
-///      p.y
-/// Input Hints On Stack
-///      tmul hints, p.y_inverse
-/// output on stack:
-///      []
-pub fn hinted_y_from_eval_point(py: ark_bn254::Fq, py_inv: ark_bn254::Fq) -> (Script, Vec<Hint>) {
-    let mut hints = Vec::new();
-
-    let (hinted_script1, hint1) = Fq::hinted_mul(1, py_inv, 0, py);
-    let script = script! {// [hints,..., pyd_calc, py]
-        {hinted_script1}
-        {Fq::push_one()}
-        {Fq::equalverify(1,0)}
-    };
-    hints.extend(hint1);
-
-    (script, hints)
-}
-
-/// input of func (params):
-///      p.x, p.y
-/// Input Hints On Stack
-///      tmul hints, p.y_inverse
-/// output on stack:
-///      x' = -p.x / p.y
 ///      y' = 1 / p.y
 pub fn hinted_from_eval_point(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
     let mut hints = Vec::new();
@@ -491,9 +444,6 @@ pub fn hinted_from_eval_points(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
     let mut hints = Vec::new();
 
     let py_inv = p.y().unwrap().inverse().unwrap();
-
-    //let (hinted_script1, hint1) = hinted_y_from_eval_point(p.y, py_inv);
-    //let (hinted_script2, hint2) = hinted_x_from_eval_point(p, py_inv);
 
     let (hinted_script1, hint1) = Fq::hinted_mul(1, p.y, 0, py_inv);
     let (hinted_script2, hint2) = Fq::hinted_mul(1, py_inv, 0, -p.x);
@@ -533,7 +483,6 @@ mod test {
     use crate::bn254::fq::Fq;
     use crate::bn254::fq2::Fq2;
     use crate::bn254::g1::G1Affine;
-    use crate::bn254::g2::G2Affine;
 
     use super::*;
     use crate::{treepp::*, ExecuteInfo};

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -1,3 +1,4 @@
+use super::fq2::Fq2;
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
 use crate::bn254::utils::Hint;
@@ -5,8 +6,7 @@ use crate::treepp::{script, Script};
 use ark_ec::AffineRepr;
 use ark_ff::{AdditiveGroup, Field};
 use num_bigint::BigUint;
-
-use super::fq2::Fq2;
+use num_traits::Zero;
 
 pub struct G1Affine;
 
@@ -141,16 +141,16 @@ impl G1Affine {
 
     pub fn read_from_stack(witness: Vec<Vec<u8>>) -> ark_bn254::G1Affine {
         assert_eq!(witness.len() as u32, Fq::N_LIMBS * 2);
-        let x = Fq::read_u32_le(witness[0..Fq::N_LIMBS as usize].to_vec());
-        let y = Fq::read_u32_le(witness[Fq::N_LIMBS as usize..2 * Fq::N_LIMBS as usize].to_vec());
-        let mut zero = Vec::new();
-        for _ in 0..8 {
-            zero.push(0u32);
-        }
-        let is_inf = (x == zero) & (y == zero);
+        let x: ark_bn254::Fq =
+            BigUint::from_slice(&Fq::read_u32_le(witness[0..Fq::N_LIMBS as usize].to_vec())).into();
+        let y: ark_bn254::Fq = BigUint::from_slice(&Fq::read_u32_le(
+            witness[Fq::N_LIMBS as usize..2 * Fq::N_LIMBS as usize].to_vec(),
+        ))
+        .into();
+        let is_inf = x.is_zero() & y.is_zero();
         ark_bn254::G1Affine {
-            x: BigUint::from_slice(&x).into(),
-            y: BigUint::from_slice(&y).into(),
+            x,
+            y,
             infinity: is_inf,
         }
     }

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -123,7 +123,7 @@ impl G2Affine {
             witness[2 * Fq::N_LIMBS as usize..4 * Fq::N_LIMBS as usize].to_vec(),
         );
 
-        let is_inf = x.is_zero() & y.is_zero();
+        let is_inf = x.is_zero() && y.is_zero();
 
         ark_bn254::G2Affine {
             x,

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -772,7 +772,7 @@ mod test {
     use super::*;
     use crate::bn254::fq::Fq;
     use crate::bn254::fq2::Fq2;
-    use crate::bn254::g1::{hinted_from_eval_point, G1Affine};
+    use crate::bn254::g1::hinted_from_eval_point;
     use crate::bn254::g2::G2Affine;
     use crate::{treepp::*, ExecuteInfo};
     use ark_ff::AdditiveGroup;

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -791,19 +791,18 @@ mod test {
     #[test]
     fn test_read_from_stack() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
-        let a = ark_bn254::G1Affine::rand(&mut prng);
-        //let a = ark_bn254::G1Affine::zero();
+        let a = ark_bn254::G2Affine::rand(&mut prng);
         let script = script! {
-            {G1Affine::push(a)}
+            {G2Affine::push(a)}
         };
 
         let res = execute_script(script);
         let witness = extract_witness_from_stack(res);
-        let recovered_a = G1Affine::read_from_stack(witness);
+        let recovered_a = G2Affine::read_from_stack(witness);
 
         assert_eq!(a, recovered_a);
 
-        let b = ark_bn254::G2Affine::rand(&mut prng);
+        let b = ark_bn254::G2Affine::identity();
         let script = script! {
             {G2Affine::push(b)}
         };

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -9,6 +9,7 @@ use crate::treepp::{script, Script};
 use ark_ec::bn::BnConfig;
 use ark_ff::{AdditiveGroup, Field};
 use num_bigint::BigUint;
+use num_traits::Zero;
 use std::str::FromStr;
 
 pub struct G2Affine;
@@ -122,7 +123,7 @@ impl G2Affine {
             witness[2 * Fq::N_LIMBS as usize..4 * Fq::N_LIMBS as usize].to_vec(),
         );
 
-        let is_inf = (x == ark_bn254::Fq2::ZERO) & (y == ark_bn254::Fq2::ZERO);
+        let is_inf = x.is_zero() & y.is_zero();
 
         ark_bn254::G2Affine {
             x,

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -122,7 +122,7 @@ impl G2Affine {
             witness[2 * Fq::N_LIMBS as usize..4 * Fq::N_LIMBS as usize].to_vec(),
         );
 
-        let is_inf = (x == ark_bn254::Fq2::ZERO)&(y == ark_bn254::Fq2::ZERO);
+        let is_inf = (x == ark_bn254::Fq2::ZERO) & (y == ark_bn254::Fq2::ZERO);
 
         ark_bn254::G2Affine {
             x,

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -90,11 +90,12 @@ impl G2Affine {
         let (y_sq, y_sq_hint) = Fq2::hinted_square(y);
 
         let mut hints = Vec::new();
+        hints.extend(y_sq_hint);
         hints.extend(x_sq_hint);
         hints.extend(x_cu_hint);
-        hints.extend(y_sq_hint);
 
         let scr = script! {
+            { y_sq }
             { Fq2::copy(2) }
             { x_sq }
             { Fq2::roll(4) }
@@ -102,8 +103,6 @@ impl G2Affine {
             { Fq::push_dec("19485874751759354771024239261021720505790618469301721065564631296452457478373") }
             { Fq::push_dec("266929791119991161246907387137283842545076965332900288569378510910307636690") }
             { Fq2::add(2, 0) }
-            { Fq2::roll(2) }
-            { y_sq }
             { Fq2::equal() }
         };
         (scr, hints)
@@ -122,10 +121,13 @@ impl G2Affine {
         let y = Fq2::read_from_stack(
             witness[2 * Fq::N_LIMBS as usize..4 * Fq::N_LIMBS as usize].to_vec(),
         );
+
+        let is_inf = (x == ark_bn254::Fq2::ZERO)&(y == ark_bn254::Fq2::ZERO);
+
         ark_bn254::G2Affine {
             x,
             y,
-            infinity: false,
+            infinity: is_inf,
         }
     }
 }
@@ -790,6 +792,7 @@ mod test {
     fn test_read_from_stack() {
         let mut prng = ChaCha20Rng::seed_from_u64(0);
         let a = ark_bn254::G1Affine::rand(&mut prng);
+        //let a = ark_bn254::G1Affine::zero();
         let script = script! {
             {G1Affine::push(a)}
         };

--- a/bitvm/src/bn254/msm.rs
+++ b/bitvm/src/bn254/msm.rs
@@ -87,7 +87,7 @@ pub(crate) fn dfs_with_constant_mul(
                 { G1Affine::push(p_mul[(mask + (1 << index)) as usize]) }
             OP_ELSE
                 if mask == 0 {
-                    { G1Affine::push_zero() }
+                    { G1Affine::identity() }
                 } else {
                     { G1Affine::push(p_mul[mask as usize]) }
                 }


### PR DESCRIPTION
I fixed Mohit 3,4,6,8.
For Mohit 3 : I added a check for infinity case. Additionally G2Affine::read_from_stack had the same problem and I fixed that too. 
For Mohit 4: I deleted the function G1Affine::zero() and replaced it with G1Affine::identity()
For Mohit 6: We implemented the optimization and makethe same optimization for G2Affine::hinted_is_on_curve  
For Mohit 8 : Since the functions hinted_x_from_eval_point and hinted_y_from_eval_point are always being used together we delete them and I wrote the functions inside the hinted_from_eval_point and decreased the number of assertions to 1. 

**Mohit 3**
G1Affine::read_from_stack sets infinity to false even if the point being read is the zero point.

**Mohit 4**
G1Affine::push_zero does the same thing as G1Affine::identity and is not used anywhere except dfs_with_constant_mul in msm so can be removed

**Mohit 6**
The Fq::roll(1) in G1Affine::hinted_is_on_curve can also be avoided if y_sq is executed as the first instruction in the script

**Mohit 8**
Optimization: In bn254/[g1.rs](https://g1.rs/), in both hinted_from_eval_points and hinted_from_eval_point,  yinv*y == 1 is checked twice because it's checked in both hinted_x_from_eval_point and hinted_y_from_eval_point. The check can probably be removed from one of these 2 to save opcodes in hinted_from_eval_points
