### PR TITLE
[Zellic Audit] fix fq6_hinted_mul_keep_elements

### DIFF
--- a/bitvm/src/bn254/fq6.rs
+++ b/bitvm/src/bn254/fq6.rs
@@ -218,37 +218,10 @@ impl Fq6 {
     // Input: [A, B]
     // Output: [C] where C = A x B
     pub fn hinted_mul(
-        a_depth: u32,
-        a: ark_bn254::Fq6,
-        b_depth: u32,
-        b: ark_bn254::Fq6,
-    ) -> (Script, Vec<Hint>) {
-        Self::hinted_mul_core(a_depth, a, b_depth, b, script! {})
-    }
-
-    // Input: [A, B]
-    // Output: [A, B, C] where C = A x B
-    pub fn hinted_mul_keep_elements(
-        a_depth: u32,
-        a: ark_bn254::Fq6,
-        b_depth: u32,
-        b: ark_bn254::Fq6,
-    ) -> (Script, Vec<Hint>) {
-        let preserve_scr = script! {
-            {Fq6::toaltstack()}
-            {Fq12::copy(0)}
-            {Fq6::fromaltstack()}
-        };
-
-        Self::hinted_mul_core(a_depth, a, b_depth, b, preserve_scr)
-    }
-
-    fn hinted_mul_core(
         mut a_depth: u32,
         mut a: ark_bn254::Fq6,
         mut b_depth: u32,
         mut b: ark_bn254::Fq6,
-        keep_elements_scr: Script,
     ) -> (Script, Vec<Hint>) {
         // The degree-6 extension on BN254 Fq2 is under the polynomial y^3 - x - 9
         // Toom-Cook-3 from https://eprint.iacr.org/2006/471.pdf
@@ -305,8 +278,6 @@ impl Fq6 {
 
             // compute (a-b+c)(d-e+f) = P(-1)
             { hinted_script3 }
-
-            { keep_elements_scr }
 
             // compute 2b
             { Fq2::roll(a_depth + 8) }
@@ -420,6 +391,186 @@ impl Fq6 {
         hints.extend(hint5);
 
         (script, hints)
+    }
+
+    // Input: [A, B]
+    // Output: [A, B, C] where C = A x B
+    pub fn hinted_mul_keep_elements(
+        mut a_depth: u32,
+        mut a: ark_bn254::Fq6,
+        mut b_depth: u32,
+        mut b: ark_bn254::Fq6,
+    ) -> (Script, Vec<Hint>) {
+        // The degree-6 extension on BN254 Fq2 is under the polynomial y^3 - x - 9
+        // Toom-Cook-3 from https://eprint.iacr.org/2006/471.pdf
+        if a_depth < b_depth {
+            (a_depth, b_depth) = (b_depth, a_depth);
+            (a, b) = (b, a);
+        }
+        assert_ne!(a_depth, b_depth);
+        let mut hints = Vec::new();
+
+        let (hinted_script1, hint1) = Fq2::hinted_mul(2, a.c0, 0, b.c0);
+        let (hinted_script2, hint2) = Fq2::hinted_mul(6, a.c0 + a.c1 + a.c2, 2, b.c0 + b.c1 + b.c2);
+        let (hinted_script3, hint3) = Fq2::hinted_mul(4, a.c0 - a.c1 + a.c2, 2, b.c0 - b.c1 + b.c2);
+        let (hinted_script4, hint4) = Fq2::hinted_mul(
+            2,
+            a.c0 + a.c1 + a.c1 + a.c2 + a.c2 + a.c2 + a.c2,
+            0,
+            b.c0 + b.c1 + b.c1 + b.c2 + b.c2 + b.c2 + b.c2,
+        );
+        let (hinted_script5, hint5) = Fq2::hinted_mul(2, a.c2, 0, b.c2);
+
+        let script = script! {
+            // compute ad = P(0)
+            { Fq2::copy(a_depth + 4) }
+            { Fq2::copy(b_depth + 6) }
+            { hinted_script1 }
+
+            // compute a+c
+            { Fq2::copy(a_depth + 6) }
+            { Fq2::copy(a_depth + 4) }
+            { Fq2::add(2, 0) }
+
+            // compute a+b+c, a-b+c
+            { Fq2::copy(0) }
+            { Fq2::copy(a_depth + 8) }
+            { Fq2::copy(0) }
+            { Fq2::add(4, 0) }
+            { Fq2::sub(4, 2) }
+
+            // compute d+f
+            { Fq2::copy(b_depth + 10) }
+            { Fq2::copy(b_depth + 8) }
+            { Fq2::add(2, 0) }
+
+            // compute d+e+f, d-e+f
+            { Fq2::copy(0) }
+            { Fq2::copy(b_depth + 12) }
+            { Fq2::copy(0) }
+            { Fq2::add(4, 0) }
+            { Fq2::sub(4, 2) }
+
+            // compute (a+b+c)(d+e+f) = P(1)
+            { hinted_script2 }
+
+            // compute (a-b+c)(d-e+f) = P(-1)
+            { hinted_script3 }
+
+            // compute 2b
+            { Fq2::copy(a_depth + 8) }
+            { Fq2::double(0) }
+
+            // compute 4c
+            { Fq2::copy(a_depth + 8) }
+            { Fq2::double(0) }
+            { Fq2::double(0) }
+            // compute a+2b+4c
+            { Fq2::add(2, 0) }
+            { Fq2::copy(a_depth + 12) }
+            { Fq2::add(2, 0) }
+
+            // compute 2e
+            { Fq2::copy(b_depth + 10) }
+            { Fq2::double(0) }
+
+            // compute 4f
+            { Fq2::copy(b_depth + 10) }
+            { Fq2::double(0) }
+            { Fq2::double(0) }
+
+            // compute d+2e+4f
+            { Fq2::add(2, 0) }
+            { Fq2::copy(b_depth + 14) }
+            { Fq2::add(2, 0) }
+
+            // compute (a+2b+4c)(d+2e+4f) = P(2)
+            { hinted_script4 }
+
+            // compute cf = P(inf)
+            { Fq2::copy(a_depth + 8) }
+            { Fq2::copy(b_depth + 10) }
+            { hinted_script5 }
+
+            // // at this point, we have v_0, v_1, v_2, v_3, v_4
+
+            // compute 3v_0
+            { Fq2::triple(8) }
+
+            // compute 3v_1
+            { Fq2::triple(8) }
+
+            // compute 6v_4
+            { Fq2::triple(4) }
+            { Fq2::double(0) }
+
+            // compute x = 3v_0 - 3v_1 - v_2 + v_3 - 12v_4
+            { Fq2::copy(4) }
+            { Fq2::copy(4) }
+            { Fq2::sub(2, 0) }
+            { Fq2::copy(10) }
+            { Fq2::sub(2, 0) }
+            { Fq2::copy(8) }
+            { Fq2::add(2, 0) }
+            { Fq2::copy(2) }
+            { Fq2::double(0) }
+            { Fq2::sub(2, 0) }
+
+            // compute c_0 = 6v_0 + \beta x
+            { Fq6::mul_fq2_by_nonresidue() }
+            { Fq2::copy(6) }
+            { Fq2::double(0) }
+            { Fq2::add(2, 0) }
+
+            // compute y = -3v_0 + 6v_1 - 2v_2 - v_3 + 12v_4
+            { Fq2::copy(4) }
+            { Fq2::double(0) }
+            { Fq2::copy(8) }
+            { Fq2::sub(2, 0) }
+            { Fq2::copy(12) }
+            { Fq2::double(0) }
+            { Fq2::sub(2, 0) }
+            { Fq2::roll(10) }
+            { Fq2::sub(2, 0) }
+            { Fq2::copy(4) }
+            { Fq2::double(0) }
+            { Fq2::add(2, 0) }
+
+            // compute c_1 = y + \beta 6v_4
+            { Fq2::copy(4) }
+            { Fq6::mul_fq2_by_nonresidue() }
+            { Fq2::add(2, 0) }
+
+            // compute c_2 = 3v_1 - 6v_0 + 3v_2 - 6v_4
+            { Fq2::roll(6) }
+            { Fq2::roll(8) }
+            { Fq2::double(0) }
+            { Fq2::sub(2, 0) }
+            { Fq2::roll(8) }
+            { Fq2::triple(0) }
+            { Fq2::add(2, 0) }
+            { Fq2::sub(0, 6) }
+
+            // divide by 6
+            { Fq2::roll(4) }
+            { Fq2::div2() }
+            { Fq2::div3() }
+            { Fq2::roll(4) }
+            { Fq2::div2() }
+            { Fq2::div3() }
+            { Fq2::roll(4) }
+            { Fq2::div2() }
+            { Fq2::div3() }
+        };
+        hints.extend(hint1);
+        hints.extend(hint2);
+        hints.extend(hint3);
+        hints.extend(hint4);
+        hints.extend(hint5);
+
+        (script, hints)
+
+        
     }
 
     // input:
@@ -669,13 +820,15 @@ mod test {
     fn test_bn254_fq6_hinted_mul() {
         let mut prng: ChaCha20Rng = ChaCha20Rng::seed_from_u64(0);
 
-        for _ in 0..100 {
+        for i in 0..100 {
             let a = ark_bn254::Fq6::rand(&mut prng);
             let b = ark_bn254::Fq6::rand(&mut prng);
             let c = a.mul(&b);
 
             let (hinted_mul, hints) = Fq6::hinted_mul(6, a, 0, b);
-            println!("Fq6::hinted_mul: {} bytes", hinted_mul.len());
+            if i == 0 {
+                println!("Fq6::hinted_mul: {} bytes", hinted_mul.len());
+            }
 
             let script = script! {
                 for hint in hints {
@@ -686,6 +839,73 @@ mod test {
                 { hinted_mul.clone() }
                 { Fq6::push(c) }
                 { Fq6::equalverify() }
+                OP_TRUE
+            };
+            run(script);
+        }
+    }
+
+    #[test]
+    fn test_bn254_fq6_hinted_mul_keep_elements() {
+        let mut prng: ChaCha20Rng = ChaCha20Rng::seed_from_u64(0);
+
+        for i in 0..100 {
+            let a = ark_bn254::Fq6::rand(&mut prng);
+            let b = ark_bn254::Fq6::rand(&mut prng);
+            let c = ark_bn254::Fq6::rand(&mut prng);
+            let d = a.mul(&b);
+            let e = b.mul(&c);
+
+            let (hinted_mul, hints) = Fq6::hinted_mul_keep_elements(12, a, 6, b);
+            if i == 0 {
+                println!("Fq6::hinted_mul(12,6): {} bytes", hinted_mul.len());
+            }
+
+            let script = script! {
+                for hint in hints {
+                    { hint.push() }
+                }
+                { Fq6::push(a) }
+                { Fq6::push(b) }
+                { Fq6::push(c) }
+                { hinted_mul.clone() }
+                { Fq6::push(d) }
+                { Fq6::equalverify() }
+
+                { Fq6::push(c) }
+                { Fq6::equalverify() }
+                { Fq6::push(b) }
+                { Fq6::equalverify() }
+                { Fq6::push(a) }
+                { Fq6::equalverify() }
+
+                OP_TRUE
+            };
+            run(script);
+
+            let (hinted_mul, hints) = Fq6::hinted_mul_keep_elements(6, b, 0, c);
+            if i == 0 {
+                println!("Fq6::hinted_mul(12,6): {} bytes", hinted_mul.len());
+            }
+
+            let script = script! {
+                for hint in hints {
+                    { hint.push() }
+                }
+                { Fq6::push(a) }
+                { Fq6::push(b) }
+                { Fq6::push(c) }
+                { hinted_mul.clone() }
+                { Fq6::push(e) }
+                { Fq6::equalverify() }
+
+                { Fq6::push(c) }
+                { Fq6::equalverify() }
+                { Fq6::push(b) }
+                { Fq6::equalverify() }
+                { Fq6::push(a) }
+                { Fq6::equalverify() }
+
                 OP_TRUE
             };
             run(script);

--- a/bitvm/src/bn254/fq6.rs
+++ b/bitvm/src/bn254/fq6.rs
@@ -1,6 +1,5 @@
 use crate::bn254::fp254impl::Fp254Impl;
 use crate::bn254::fq::Fq;
-use crate::bn254::fq12::Fq12;
 use crate::bn254::fq2::Fq2;
 use crate::bn254::utils::Hint;
 use crate::treepp::{script, Script};

--- a/bitvm/src/bn254/fq6.rs
+++ b/bitvm/src/bn254/fq6.rs
@@ -568,8 +568,6 @@ impl Fq6 {
         hints.extend(hint5);
 
         (script, hints)
-
-        
     }
 
     // input:


### PR DESCRIPTION
I fixed **Mark 1**. Fq6::hinted_mul_keep_elements now works for all parameters (not only for (6,0)) to do that I removed hinted_mul_core and rewrote hinted_mul_keep_elements.