### PR TITLE
fix #360 Incorrect behavior of limb_to_le_bits_toaltstack in the case of num_bits <= 1

### DIFF
--- a/bitvm/src/bigint/bits.rs
+++ b/bitvm/src/bigint/bits.rs
@@ -188,8 +188,14 @@ pub fn limb_to_le_bits_toaltstack(num_bits: u32) -> Script {
                 OP_TOALTSTACK
             }
         }
+    } else if num_bits == 1 {
+        script! {
+            OP_TOALTSTACK
+        }
     } else {
-        script! {}
+        script! {
+            OP_DROP
+        }
     }
 }
 


### PR DESCRIPTION
fix #360 Incorrect behavior of limb_to_le_bits_toaltstack in the case of num_bits <= 1