### PR TITLE
fix #365 Blake3 script inscorrect

### DIFF
--- a/bitvm/src/hash/blake3_utils.rs
+++ b/bitvm/src/hash/blake3_utils.rs
@@ -454,8 +454,8 @@ fn init_state(
     for u32 in &IV[0..4] {
         state.push(stack.number_u32(*u32));
     }
-    state.push(stack.number_u32(0));
     state.push(stack.number_u32(counter));
+    state.push(stack.number_u32(0));
     state.push(stack.number_u32(block_len));
     state.push(stack.number_u32(flags));
 


### PR DESCRIPTION
fix #365  Blake3 script inscorrect for more than 1,024 bytes of input or more than 32 bytes of output