### PR TITLE
refactor: make user_profile parameter required in BitVMClient::newrefactor: make user_profile parameter required in BitVMClient::new

### DIFF
--- a/bridge/src/client/client.rs
+++ b/bridge/src/client/client.rs
@@ -17,7 +17,6 @@ use std::{
 use crate::{
     client::{
         chain::ethereum_adaptor::EthereumAdaptor, esplora::get_esplora_url,
-        files::DEFAULT_PATH_PREFIX,
     },
     commitments::CommitmentMessageId,
     common::ZkProofVerifyingKey,
@@ -145,7 +144,7 @@ impl BitVMClient {
         operator_secret: Option<&str>,
         verifier_secret: Option<&str>,
         withdrawer_secret: Option<&str>,
-        file_path_prefix: Option<&str>,
+        user_profile: &str,
         zkproof_verifying_key: Option<ZkProofVerifyingKey>,
     ) -> Self {
         let depositor_context = depositor_secret
@@ -168,9 +167,9 @@ impl BitVMClient {
         // explicitly in the format string below.
         let remote_file_path = format! {"{BRIDGE_DATA_DIRECTORY_NAME}/{source_network}/{destination_network}/{n_of_n_public_key}"};
         // The local file path, on the other hand, must use the platform specific path separator.
-        // Additionally, it includes the provided file path prefix to create a user namespace.
+        // Additionally, it includes the provided user profile to create a user namespace.
         let local_file_path = Path::new(BRIDGE_DATA_DIRECTORY_NAME)
-            .join(file_path_prefix.unwrap_or(DEFAULT_PATH_PREFIX)) // TODO: Refactor to require a prefix and remove the const, as the client already has a default and will always pass it. Also rename to 'user_profile' to match the client implementation.
+            .join(user_profile)
             .join(source_network.to_string())
             .join(destination_network.to_string())
             .join(n_of_n_public_key.to_string());


### PR DESCRIPTION


- Rename file_path_prefix to user_profile for better clarity
- Make user_profile parameter required instead of Optional
- Remove DEFAULT_PATH_PREFIX constant and its usage
- Update all call sites to provide user_profile parameter
- Improve API consistency and prevent potential errors