### PR TITLE
[Zellic Audit] 3.12 Incomplete handling of G1 point addition

### DIFF
--- a/bitvm/src/bigint/cmp.rs
+++ b/bitvm/src/bigint/cmp.rs
@@ -27,6 +27,22 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         }
     }
 
+    pub fn equal_keep_elements(a: u32, b: u32) -> Script {
+        script! {
+            { Self::copy_zip(a, b) }
+            for _ in 0..Self::N_LIMBS {
+                OP_EQUAL
+                OP_TOALTSTACK
+            }
+            for _ in 0..Self::N_LIMBS {
+                OP_FROMALTSTACK
+            }
+            for _ in 0..Self::N_LIMBS - 1 {
+                OP_BOOLAND
+            }
+        }
+    }
+
     pub fn notequal(a: u32, b: u32) -> Script {
         script! {
             { Self::equal(a, b) }

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -108,6 +108,11 @@ pub trait Fp254Impl {
     }
 
     #[inline]
+    fn equal_keep_elements(a: u32, b: u32) -> Script {
+        U254::equal_keep_elements(a, b)
+    }
+
+    #[inline]
     fn equalverify(a: u32, b: u32) -> Script {
         U254::equalverify(a, b)
     }

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -264,16 +264,16 @@ impl G1Affine {
                         OP_FROMALTSTACK OP_DROP
                         { G1Affine::drop() }
                         { G1Affine::drop() }
-                        { G1Affine::push_zero() }
+                        { G1Affine::identity() }
                     OP_ELSE                                // case: t != -q
                         for _ in 0..Fq::N_LIMBS {
                             OP_DEPTH OP_1SUB OP_ROLL
                         }
-                        // TODO: uncomment out this line after 3.4 { Fq::copy(0) } { Fq::check_validity() }
+                        { Fq::copy(0) } { Fq::check_validity() }
                         for _ in 0..Fq::N_LIMBS {
                             OP_DEPTH OP_1SUB OP_ROLL
                         }                                  // qx qy tx ty c3 c4
-                        // TODO: uncomment out this line after 3.4 { Fq::copy(0) } { Fq::check_validity() }
+                        { Fq::copy(0) } { Fq::check_validity() }
                         { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3
                         { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3 c4
                         { Fq::copy(5) }                    // qx qy tx ty c3 c4 c3 c4 tx

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -247,7 +247,7 @@ impl G1Affine {
             OP_IF
                 { G1Affine::drop() }
             OP_ELSE
-                { G1Affine::roll(1) }
+                { G1Affine::roll(2) }
                 { G1Affine::is_zero_keep_element() }
                 OP_IF
                     { G1Affine::drop() }
@@ -269,11 +269,11 @@ impl G1Affine {
                         for _ in 0..Fq::N_LIMBS {
                             OP_DEPTH OP_1SUB OP_ROLL
                         }
-                        { Fq::copy(0) } { Fq::check_validity() }
+                        { Fq::check_validity_and_keep_element() }
                         for _ in 0..Fq::N_LIMBS {
                             OP_DEPTH OP_1SUB OP_ROLL
                         }                                  // qx qy tx ty c3 c4
-                        { Fq::copy(0) } { Fq::check_validity() }
+                        { Fq::check_validity_and_keep_element() }
                         { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3
                         { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3 c4
                         { Fq::copy(5) }                    // qx qy tx ty c3 c4 c3 c4 tx
@@ -802,7 +802,7 @@ mod test {
         let negt = -t;
         let z = ark_bn254::G1Affine::zero();
 
-        for (t, q, r) in [(t, q, r), (t, t, tt), (t, negt, z)] {
+        for (t, q, r) in [(t, q, r), (t, t, tt), (t, negt, z), (t, z, t)] {
             let (hinted_check_add, hints) = G1Affine::hinted_check_add(t, q);
 
             let script = script! {

--- a/bitvm/src/bn254/msm.rs
+++ b/bitvm/src/bn254/msm.rs
@@ -230,7 +230,7 @@ fn accumulate_addition_chain_for_a_scalar_mul(
             );
 
             // accumulate value using hinted_check_add
-            let (add_scr, add_hints) = G1Affine::hinted_check_add(prev, row_g1);
+            let (add_scr, add_hints) = G1Affine::hinted_check_add_prevent_degenerate(prev, row_g1);
 
             prev = (prev + row_g1).into_affine(); // output of this chunk: t + q
             vec_row_g1_scr.push(row_g1_scr);

--- a/bitvm/src/chunk/taps_msm.rs
+++ b/bitvm/src/chunk/taps_msm.rs
@@ -135,7 +135,7 @@ pub(crate) fn chunk_hash_p(
     let (tx, qx, ty, qy) = (hint_in_t.x, hint_in_q.x, hint_in_t.y, hint_in_q.y);
     let t = ark_bn254::G1Affine::new_unchecked(tx, ty);
     let q = ark_bn254::G1Affine::new_unchecked(qx, qy);
-    let (add_scr, add_hints) = G1Affine::hinted_check_add(t, q);
+    let (add_scr, add_hints) = G1Affine::hinted_check_add_prevent_degenerate(t, q);
     let r = (t + q).into_affine();
     let ops_script = script! {
         // [t] [hash_r, hash_t]


### PR DESCRIPTION
I created a different version of G1Affine::hinted_check_add.
- G1Affine::hinted_check_add_prevent_degenerate() is the old G1Affine::hinted_check_add, additionally some asserts that ensure the given points do not satisfy t==q or t==-q. The caller must use this function if they are sure of this.
- G1Affine::hinted_check_add() is a more general version. It handles the excluded cases above. However, this results in substantially larger script size since it includes both the addition and doubling parts together. (618763 >> 275192)

To achieve this, I added Fq::equal_keep_elements() function that simply checks equality without consuming the elements.

We continue to use the version that excludes these cases, because they do not occur currently.

Edit: Newly added function is optimized from 618763 to 481633 bytes. It now merges the same operations for doubling and adding. And a TODO is added to hints in this function so that later we must add hint validity checks.

closes #302 