### PR TITLE
[Zellic Audit] 3.15 The init_table script in tmul does not check for overflow on doubling

### DIFF
--- a/bitvm/src/bigint/add.rs
+++ b/bitvm/src/bigint/add.rs
@@ -144,6 +144,25 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         }
     }
 
+    /// Double the referenced BigInt but keep the original element in its position
+    /// This function prevents overflow of the underlying integer types during
+    /// doubling operation.
+    pub fn double_prevent_overflow_keep_element(n: u32) -> Script {
+        script! {
+            { 1 << LIMB_SIZE }
+            { n + 1 } OP_PICK limb_double_without_carry OP_TOALTSTACK
+            for i in 0..Self::N_LIMBS - 2 {
+                { n + i + 3 } OP_PICK limb_double_with_carry OP_TOALTSTACK
+            }
+            OP_NIP
+            { n + Self::N_LIMBS } OP_PICK OP_SWAP
+            { limb_double_with_carry_prevent_overflow(Self::HEAD_OFFSET) }
+            for _ in 0..Self::N_LIMBS - 1 {
+                OP_FROMALTSTACK
+            }
+        }
+    }
+
     /// Left shift the BigInt on top of the stack by `bits`
     ///
     /// # Note

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -177,7 +177,9 @@ macro_rules! fp_lc_mul {
                             for i in 2..=window {
                                 for j in 1 << (i - 1)..1 << i {
                                     if j % 2 == 0 {
-                                        { T::double_allow_overflow_keep_element( (j/2 - 1) * T::N_LIMBS ) }
+                                        // { T::copy(j/2 - 1) }
+                                        // { T::double_prevent_overflow() }
+                                        { T::double_prevent_overflow_keep_element((j/2 - 1) * T::N_LIMBS) }
                                     } else {
                                         { T::add_ref_with_top(j - 2) }
                                     }


### PR DESCRIPTION
I created BigInt::double_prevent_overflow_keep_element function and used it in tmul. (Note that this version is better than the version in #331  in terms of script size, since in 331, it is just copy and double_prevent_overflow combined). Also, this change introduces an increase of 140 bytes in the tmul size, for standard hinted multiplication. (67820 -> 67960)

Closes #310 