### PR TITLE
[Zellic Audit] 3.22 Window size of 1 leads to incorrect results for tmul

### DIFF
--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -169,8 +169,8 @@ macro_rules! fp_lc_mul {
                     // Initialize the lookup table
                     fn init_table(window: u32) -> Script {
                         assert!(
-                            (1..=6).contains(&window),
-                            "expected 1<=window<=6; got window={}",
+                            (2..=6).contains(&window),
+                            "expected 2<=window<=6; got window={}",
                             window
                         );
                         script! {


### PR DESCRIPTION
I simply modified the assert in init_table in tmul to exclude window=1 case. Closes #307 