### PR TITLE
[Zellic Audit] 3.23 Possible failures of tmul if the number of summands is not a power of two

### DIFF
--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -112,7 +112,7 @@ macro_rules! fp_lc_mul {
             trait [<Fp254 $NAME>] {
                 const LIMB_SIZE: u32 = 29;
                 const LCS: [bool; $LCS.len()] = $LCS;
-                const LC_BITS: u32 = usize::BITS - $LCS.len().leading_zeros() - 1;
+                const LC_BITS: u32 = usize::BITS - ($LCS.len() - 1).leading_zeros();
                 type U;
                 type T;
                 fn tmul() -> Script;


### PR DESCRIPTION
LC_BITS is changed in tmul.