### PR TITLE
[Zellic Audit] 3.4 Computational hint types not validated

### DIFF
--- a/bitvm/src/bigint/std.rs
+++ b/bitvm/src/bigint/std.rs
@@ -307,6 +307,21 @@ impl<const N_BITS: u32, const LIMB_SIZE: u32> BigIntImpl<N_BITS, LIMB_SIZE> {
         }
     }
 
+    pub fn check_validity() -> Script {
+        script! {                            // a0 a1 ... an
+            { 1 << LIMB_SIZE }               // a0 a1 ... an x
+            for _ in 0..Self::N_LIMBS-2 {    // a x
+                OP_TUCK                      // x a x
+                0 OP_SWAP                    // x a 0 x
+                OP_WITHIN OP_VERIFY          // x
+            }                                // a0 a1 x
+            0 OP_SWAP                        // a0 a1 0 x
+            OP_WITHIN OP_VERIFY              // a0
+            0 { Self::HEAD_OFFSET }          // a0 0 y
+            OP_WITHIN OP_VERIFY
+        }
+    }
+
     /// Resize positive numbers
     ///
     /// # Note

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -126,6 +126,16 @@ pub trait Fp254Impl {
         }
     }
 
+    fn is_one_verify() -> Script {
+        script! {
+            OP_1
+            OP_EQUALVERIFY
+            for _ in 0..Self::N_LIMBS-1 {
+                OP_NOT OP_VERIFY
+            }
+        }
+    }
+
     fn is_one_keep_element(a: u32) -> Script {
         script! {
             { Self::copy(a) }
@@ -904,10 +914,11 @@ pub trait Fp254Impl {
         let q = (x * y) / modulus;
         let script = script! {
             for _ in 0..Self::N_LIMBS {
-                OP_DEPTH OP_1SUB OP_ROLL // hints
+                OP_DEPTH OP_1SUB OP_ROLL // hint, y
             }
+            { U254::copy(0) } { U254::check_validity() }
             for _ in 0..Self::N_LIMBS {
-                OP_DEPTH OP_1SUB OP_ROLL // hints
+                OP_DEPTH OP_1SUB OP_ROLL // hint, q
             }
             // { Fq::push(ark_bn254::Fq::from_str(&y.to_string()).unwrap()) }
             // { Fq::push(ark_bn254::Fq::from_str(&q.to_string()).unwrap()) }
@@ -917,8 +928,7 @@ pub trait Fp254Impl {
             // y, q, x, y
             { Fq::tmul() }
             // y, 1
-            { Fq::push_one() }
-            { Fq::equalverify(1, 0) }
+            { Fq::is_one_verify() }
         };
         hints.push(Hint::Fq(ark_bn254::Fq::from_str(&y.to_string()).unwrap()));
         hints.push(Hint::BigIntegerTmulLC1(q));

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -164,6 +164,10 @@ pub trait Fp254Impl {
         }
     }
 
+    fn check_validity() -> Script {
+        U254::check_validity()
+    }
+
     #[inline]
     fn convert_to_le_bits_toaltstack() -> Script {
         U254::convert_to_le_bits_toaltstack()
@@ -916,7 +920,7 @@ pub trait Fp254Impl {
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, y
             }
-            { U254::copy(0) } { U254::check_validity() }
+            { Fq::copy(0) } { Fq::check_validity() }
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, q
             }

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -5,7 +5,6 @@ use crate::bn254::fq::Fq;
 use crate::bn254::utils::Hint;
 use crate::treepp::*;
 use ark_ff::PrimeField;
-use bitcoin::opcodes::all::{OP_2DROP, OP_DROP, OP_FROMALTSTACK};
 use bitcoin_script::script;
 use num_bigint::{BigInt, BigUint};
 use num_traits::Num;
@@ -921,7 +920,7 @@ pub trait Fp254Impl {
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, y
             }
-            { Fq::copy(0) } { Fq::check_validity_and_consume() }
+            { Fq::check_validity_and_keep_element() }
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, q
             }
@@ -972,23 +971,10 @@ pub trait Fp254Impl {
     }
 
     fn check_validity_and_keep_element() -> Script {
-        script !{
+        script! {
             { Self::check_validity() }
             for _ in 0..Self::N_LIMBS {
                 OP_FROMALTSTACK
-            }
-        }
-    }
-
-    /// check that Self::N_LIMBS elements on stack form a valid FpImpl element
-    fn check_validity_and_consume() -> Script {
-        script! {
-            { Self::check_validity_and_keep_element() }
-            for _ in 0..(Self::N_LIMBS / 2) {
-                OP_2DROP
-            }
-            if Self::N_LIMBS % 2 == 1 {
-                OP_DROP
             }
         }
     }

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -164,8 +164,15 @@ pub trait Fp254Impl {
         }
     }
 
+    /// check that Self::N_LIMBS elements on stack form a valid FpImpl element
     fn check_validity() -> Script {
-        U254::check_validity()
+        script! {
+            { U254::copy(0) }
+            { U254::check_validity() }
+            { Self::push_modulus() }
+            { U254::lessthan(1, 0) }
+            OP_VERIFY
+        }
     }
 
     #[inline]

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -165,7 +165,7 @@ pub trait Fp254Impl {
     }
 
     /// check that Self::N_LIMBS elements on stack form a valid FpImpl element
-    fn check_validity() -> Script {
+    fn check_validity_and_consume() -> Script {
         script! {
             { U254::copy(0) }
             { U254::check_validity() }
@@ -927,7 +927,7 @@ pub trait Fp254Impl {
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, y
             }
-            { Fq::copy(0) } { Fq::check_validity() }
+            { Fq::copy(0) } { Fq::check_validity_and_consume() }
             for _ in 0..Self::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL // hint, q
             }

--- a/bitvm/src/bn254/fp254impl.rs
+++ b/bitvm/src/bn254/fp254impl.rs
@@ -28,6 +28,10 @@ pub trait Fp254Impl {
 
     type ConstantType: PrimeField;
 
+    fn modulus_as_bigint() -> BigInt {
+        BigInt::from_str_radix(Self::MODULUS, 16).unwrap()
+    }
+
     #[inline]
     fn copy(a: u32) -> Script {
         U254::copy(a)
@@ -945,5 +949,35 @@ pub trait Fp254Impl {
         hints.push(Hint::BigIntegerTmulLC1(q));
 
         (script, hints)
+    }
+
+    // verifies that the element at the top of the stack is less than the modulo and valid (limbs are in range)
+    // doesn't consume the element, instead sends it to the altstack
+    fn check_validity() -> Script {
+        let limbs_of_c = U254::biguint_to_limbs(Self::modulus_as_bigint().to_biguint().unwrap());
+        script! {
+            // (Assuming limbs are numbered big endian)
+            // Number A is greater than number B <=> there exists a limb i, s.t. (A_i > B_i OR (A_i >= B_i and i is the first limb)) and there's no limb j > i satisfying A_i < B_i
+            // Script below maintains if such state exists for each i behind the foremost limb, combining the results and negating them if there is such j
+            for i in 0..(Self::N_LIMBS as usize) {
+                OP_DUP OP_DUP OP_TOALTSTACK
+                { 0 } { 1 << U254::LIMB_SIZE } OP_WITHIN OP_VERIFY
+                if i == 0 {
+                    { limbs_of_c[i] }
+                    OP_GREATERTHANOREQUAL
+                } else {
+                    { limbs_of_c[i] } OP_2DUP
+                    OP_GREATERTHAN OP_TOALTSTACK
+                    OP_GREATERTHANOREQUAL
+                    OP_BOOLAND
+                    OP_FROMALTSTACK OP_BOOLOR
+                }
+                if i == (Self::N_LIMBS as usize) - 1 {
+                    OP_NOT OP_VERIFY //This OP_NOT can be negated, but it probably isn't necessary
+                } else {
+                    OP_SWAP
+                }
+            }
+        }
     }
 }

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::reversed_empty_ranges)]
 use num_bigint::{BigInt, BigUint};
-use num_traits::{FromPrimitive, Num, ToPrimitive};
+use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::bigint::BigIntImpl;
 use crate::bn254::fp254impl::Fp254Impl;
@@ -31,10 +31,6 @@ impl Fp254Impl for Fq {
 }
 
 impl Fq {
-    pub fn modulus_as_bigint() -> BigInt {
-        BigInt::from_str_radix(Self::MODULUS, 16).unwrap()
-    }
-
     pub fn tmul() -> Script {
         script! {
             { <Fq as Fp254Mul>::tmul() }
@@ -426,6 +422,7 @@ fp_lc_mul!(Mul4LC, 3, 3, [true, true, true, true]);
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::bigint::U254;
     use crate::bn254::fq::Fq;
     use crate::{bn254::fp254impl::Fp254Impl, ExecuteInfo};
     use ark_ff::AdditiveGroup;
@@ -1039,5 +1036,94 @@ mod test {
             <Fq as Fp254Mul2LC>::tmul().len(),
             max_stack
         );
+    }
+
+    #[test]
+    fn test_check_validity() {
+        let mut prng = ChaCha20Rng::seed_from_u64(37);
+        let x = Fq::modulus_as_bigint().to_biguint().unwrap();
+        let verification_script = Fq::check_validity();
+        let clearing_script = script! {
+            for _ in 0..U254::N_LIMBS { OP_FROMALTSTACK }
+            { U254::equalverify(0, 1) }
+            OP_TRUE
+        };
+
+        // -1
+        {
+            run(script! {
+                { U254::push_biguint(x.clone() - 1u32) }
+                { verification_script.clone() }
+                { U254::push_biguint(x.clone() - 1u32) }  { clearing_script.clone() }
+            })
+        }
+
+        // equal
+        {
+            assert!(
+                execute_script(script! {
+                    { U254::push_biguint(x.clone()) }
+                    { verification_script.clone() }
+                    { U254::push_biguint(x.clone()) }  { clearing_script.clone() }
+                })
+                .success
+                    == false
+            )
+        }
+
+        // +1
+        {
+            assert!(
+                execute_script(script! {
+                    { U254::push_biguint(x.clone() + 1u32) }
+                    { verification_script.clone() }
+                    { U254::push_biguint(x.clone() + 1u32) }  { clearing_script.clone() }
+                })
+                .success
+                    == false
+            )
+        }
+
+        // random less than
+        for _ in 0..100 {
+            let n = prng.gen_biguint_range(&BigUint::from(0u32), &x);
+            run(script! {
+                { U254::push_biguint(n.clone()) }
+                { verification_script.clone() }
+                { U254::push_biguint(n) }  { clearing_script.clone() }
+            })
+        }
+
+        // random geq
+        for _ in 0..100 {
+            let n = prng.gen_biguint_range(&x, &BigUint::from(2u32).pow(254));
+            assert!(
+                execute_script(script! {
+                    { U254::push_biguint(n.clone()) }
+                    { verification_script.clone() }
+                    { U254::push_biguint(n) }  { clearing_script.clone() }
+                })
+                .success
+                    == false
+            );
+        }
+
+        //corrupted data with negative
+        {
+            let limbs = U254::biguint_to_limbs(x.clone());
+            assert!(
+                execute_script(script! {
+                    for i in (1..U254::N_LIMBS as usize).rev() {
+                        { limbs[i] }
+                    }
+                    { -1 }
+
+                    { verification_script.clone() }
+                    { U254::push_biguint(x.clone()) }  { clearing_script.clone() }
+                })
+                .success
+                    == false
+            )
+        }
     }
 }

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -323,6 +323,8 @@ macro_rules! fp_lc_mul {
                             { U::lessthan(1, 0) } OP_VERIFY                                // {q} {x0} {x1} {y0} {y1}
                             { U::toaltstack() }                                            // {q} {x0} {x1} {y0} -> {y1}
                         }                                                                  // {q} -> {x0} {x1} {y0} {y1}
+                        // ensure q is a valid bigint
+                        { T::copy(0) } { T::check_validity() }
                         // Pre-compute lookup tables
                         { T::push_zero() }                   // {q} {0} -> {x0} {x1} {y0} {y1}
                         { T::sub(0, 1) }                     // {-q} -> {x0} {x1} {y0} {y1}

--- a/bitvm/src/bn254/fq12.rs
+++ b/bitvm/src/bn254/fq12.rs
@@ -285,7 +285,7 @@ impl Fq12 {
 
     pub fn check_validity() -> Script {
         script! {
-            for _ in 0..2 { 
+            for _ in 0..2 {
                 { Fq6::check_validity() }
             }
         }

--- a/bitvm/src/bn254/fq12.rs
+++ b/bitvm/src/bn254/fq12.rs
@@ -282,6 +282,14 @@ impl Fq12 {
 
         (script, hints)
     }
+
+    pub fn check_validity() -> Script {
+        script! {
+            for _ in 0..2 { 
+                { Fq6::check_validity() }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bitvm/src/bn254/fq2.rs
+++ b/bitvm/src/bn254/fq2.rs
@@ -156,6 +156,13 @@ impl Fq2 {
         }
     }
 
+    pub fn check_validity() -> Script {
+        script! {
+            { Fq::check_validity() }
+            { Fq::check_validity() }
+        }
+    }
+
     pub fn hinted_mul(
         mut a_depth: u32,
         mut a: ark_bn254::Fq2,

--- a/bitvm/src/bn254/fq2.rs
+++ b/bitvm/src/bn254/fq2.rs
@@ -156,10 +156,10 @@ impl Fq2 {
         }
     }
 
-    pub fn check_validity() -> Script {
+    pub fn check_validity_and_consume() -> Script {
         script! {
-            { Fq::check_validity() }
-            { Fq::check_validity() }
+            { Fq::check_validity_and_consume() }
+            { Fq::check_validity_and_consume() }
         }
     }
 

--- a/bitvm/src/bn254/fq2.rs
+++ b/bitvm/src/bn254/fq2.rs
@@ -357,6 +357,14 @@ impl Fq2 {
                 [i % ark_bn254::Fq2Config::FROBENIUS_COEFF_FP2_C1.len()],
         )
     }
+
+    pub fn check_validity() -> Script {
+        script! {
+            for _ in 0..2 { 
+                { Fq::check_validity() }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bitvm/src/bn254/fq2.rs
+++ b/bitvm/src/bn254/fq2.rs
@@ -156,10 +156,13 @@ impl Fq2 {
         }
     }
 
-    pub fn check_validity_and_consume() -> Script {
+    pub fn check_validity_and_keep_element() -> Script {
         script! {
-            { Fq::check_validity_and_consume() }
-            { Fq::check_validity_and_consume() }
+            { Fq::check_validity() }
+            { Fq::check_validity_and_keep_element() }
+            for _ in 0..Fq::N_LIMBS {
+                OP_FROMALTSTACK
+            }
         }
     }
 
@@ -360,7 +363,7 @@ impl Fq2 {
 
     pub fn check_validity() -> Script {
         script! {
-            for _ in 0..2 { 
+            for _ in 0..2 {
                 { Fq::check_validity() }
             }
         }

--- a/bitvm/src/bn254/fq6.rs
+++ b/bitvm/src/bn254/fq6.rs
@@ -580,7 +580,7 @@ impl Fq6 {
 
     pub fn check_validity() -> Script {
         script! {
-            for _ in 0..3 { 
+            for _ in 0..3 {
                 { Fq2::check_validity() }
             }
         }

--- a/bitvm/src/bn254/fq6.rs
+++ b/bitvm/src/bn254/fq6.rs
@@ -577,6 +577,14 @@ impl Fq6 {
 
         (script, hints)
     }
+
+    pub fn check_validity() -> Script {
+        script! {
+            for _ in 0..3 { 
+                { Fq2::check_validity() }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -184,11 +184,11 @@ impl G1Affine {
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq::copy(0) } { Fq::check_validity() }
+                    { Fq::copy(0) } { Fq::check_validity_and_consume() }
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }                                  // qx qy tx ty c3 c4
-                    { Fq::copy(0) } { Fq::check_validity() }
+                    { Fq::copy(0) } { Fq::check_validity_and_consume() }
                     { Fq::copy(1) }
                     { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3 c4
                     { Fq::copy(5) }
@@ -319,11 +319,11 @@ impl G1Affine {
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // -bias, ...,  x, y, alpha
-                { Fq::copy(0) } { Fq::check_validity() }
+                { Fq::copy(0) } { Fq::check_validity_and_consume() }
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // x, y, alpha, -bias
-                { Fq::copy(0) } { Fq::check_validity() }
+                { Fq::copy(0) } { Fq::check_validity_and_consume() }
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha, -bias
                 { Fq::copy(5) }                          // x, y, alpha, -bias, alpha, -bias, x
@@ -507,7 +507,7 @@ pub fn hinted_from_eval_points(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
         for _ in 0..Fq::N_LIMBS {
             OP_DEPTH OP_1SUB OP_ROLL
         }
-        { Fq::copy(0) } { Fq::check_validity() }
+        { Fq::copy(0) } { Fq::check_validity_and_consume() }
         {Fq2::fromaltstack()}
         // [hints, yinv, x, y]
         {Fq::copy(2)}

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -184,11 +184,11 @@ impl G1Affine {
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq::copy(0) } { Fq::check_validity_and_consume() }
+                    { Fq::check_validity_and_keep_element() }
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }                                  // qx qy tx ty c3 c4
-                    { Fq::copy(0) } { Fq::check_validity_and_consume() }
+                    { Fq::check_validity_and_keep_element() }
                     { Fq::copy(1) }
                     { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3 c4
                     { Fq::copy(5) }
@@ -319,11 +319,11 @@ impl G1Affine {
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // -bias, ...,  x, y, alpha
-                { Fq::copy(0) } { Fq::check_validity_and_consume() }
+                { Fq::check_validity_and_keep_element() }
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // x, y, alpha, -bias
-                { Fq::copy(0) } { Fq::check_validity_and_consume() }
+                { Fq::check_validity_and_keep_element() }
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha, -bias
                 { Fq::copy(5) }                          // x, y, alpha, -bias, alpha, -bias, x
@@ -507,7 +507,7 @@ pub fn hinted_from_eval_points(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
         for _ in 0..Fq::N_LIMBS {
             OP_DEPTH OP_1SUB OP_ROLL
         }
-        { Fq::copy(0) } { Fq::check_validity_and_consume() }
+        { Fq::check_validity_and_keep_element() }
         {Fq2::fromaltstack()}
         // [hints, yinv, x, y]
         {Fq::copy(2)}

--- a/bitvm/src/bn254/g1.rs
+++ b/bitvm/src/bn254/g1.rs
@@ -184,9 +184,11 @@ impl G1Affine {
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
+                    { Fq::copy(0) } { Fq::check_validity() }
                     for _ in 0..Fq::N_LIMBS {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }                                  // qx qy tx ty c3 c4
+                    { Fq::copy(0) } { Fq::check_validity() }
                     { Fq::copy(1) }
                     { Fq::copy(1) }                    // qx qy tx ty c3 c4 c3 c4
                     { Fq::copy(5) }
@@ -317,9 +319,11 @@ impl G1Affine {
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // -bias, ...,  x, y, alpha
+                { Fq::copy(0) } { Fq::check_validity() }
                 for _ in 0..Fq::N_LIMBS {
                     OP_DEPTH OP_1SUB OP_ROLL
                 }                                        // x, y, alpha, -bias
+                { Fq::copy(0) } { Fq::check_validity() }
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha
                 { Fq::copy(1) }                          // x, y, alpha, -bias, alpha, -bias
                 { Fq::copy(5) }                          // x, y, alpha, -bias, alpha, -bias, x
@@ -503,6 +507,7 @@ pub fn hinted_from_eval_points(p: ark_bn254::G1Affine) -> (Script, Vec<Hint>) {
         for _ in 0..Fq::N_LIMBS {
             OP_DEPTH OP_1SUB OP_ROLL
         }
+        { Fq::copy(0) } { Fq::check_validity() }
         {Fq2::fromaltstack()}
         // [hints, yinv, x, y]
         {Fq::copy(2)}

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -307,7 +307,7 @@ pub fn hinted_ell_by_constant_affine_and_sparse_mul(
             for _ in 0..Fq::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL
             }
-            { Fq::copy(0) } { Fq::check_validity_and_consume() }
+            { Fq::check_validity_and_keep_element() }
         }
     };
     let script = script! {

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -307,7 +307,7 @@ pub fn hinted_ell_by_constant_affine_and_sparse_mul(
             for _ in 0..Fq::N_LIMBS {
                 OP_DEPTH OP_1SUB OP_ROLL
             }
-            { Fq::copy(0) } { Fq::check_validity() }
+            { Fq::copy(0) } { Fq::check_validity_and_consume() }
         }
     };
     let script = script! {

--- a/bitvm/src/bn254/g2.rs
+++ b/bitvm/src/bn254/g2.rs
@@ -303,11 +303,12 @@ pub fn hinted_ell_by_constant_affine_and_sparse_mul(
     let (hinted_script5, hint5) = Fq12::hinted_mul_by_34(f, c1, c2);
 
     let hinted_script_constant = script! {
-       for _ in 0..4 {
-           for _ in 0..Fq::N_LIMBS {
-               OP_DEPTH OP_1SUB OP_ROLL
-           }
-       }
+        for _ in 0..4 {
+            for _ in 0..Fq::N_LIMBS {
+                OP_DEPTH OP_1SUB OP_ROLL
+            }
+            { Fq::copy(0) } { Fq::check_validity() }
+        }
     };
     let script = script! {
         {hinted_script_constant}

--- a/bitvm/src/chunk/api_runtime_utils.rs
+++ b/bitvm/src/chunk/api_runtime_utils.rs
@@ -418,8 +418,12 @@ fn utils_execute_chunked_g16(
                 println!("final {:?}", segments[i].scr_type);
                 panic!();
             }
-            if exec_result.remaining_script != "OP_PUSHNUM_1" && exec_result.remaining_script != "" {
-                println!("Script terminated early {:?} {:?}", exec_result.remaining_script, segments[i].scr_type);
+            if exec_result.remaining_script != "OP_PUSHNUM_1" && exec_result.remaining_script != ""
+            {
+                println!(
+                    "Script terminated early {:?} {:?}",
+                    exec_result.remaining_script, segments[i].scr_type
+                );
                 panic!();
             }
         } else {

--- a/bitvm/src/chunk/g16_runner_utils.rs
+++ b/bitvm/src/chunk/g16_runner_utils.rs
@@ -292,8 +292,8 @@ pub(crate) fn wrap_hint_msm(
     scalars: Vec<Segment>,
     pub_vky: Vec<ark_bn254::G1Affine>,
 ) -> Vec<Segment> {
-    let num_chunks_per_scalar =
-        (Fr::N_BITS + WINDOW_G1_MSM * BATCH_SIZE_PER_CHUNK - 1) / (WINDOW_G1_MSM * BATCH_SIZE_PER_CHUNK);
+    let num_chunks_per_scalar = (Fr::N_BITS + WINDOW_G1_MSM * BATCH_SIZE_PER_CHUNK - 1)
+        / (WINDOW_G1_MSM * BATCH_SIZE_PER_CHUNK);
 
     let hint_scalars: Vec<ark_ff::BigInt<4>> = scalars
         .iter()

--- a/bitvm/src/chunk/taps_point_ops.rs
+++ b/bitvm/src/chunk/taps_point_ops.rs
@@ -351,9 +351,11 @@ fn utils_point_add_eval(
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
+                    { Fq2::copy(0) } { Fq2::check_validity() }
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
+                    { Fq2::copy(0) } { Fq2::check_validity() }
                     // [qx, qy, tx, ty, c3, c4]
                     {Fq2::roll(6)} {Fq2::roll(6)}
                     // [qx, qy, c3, c4, tx, ty]

--- a/bitvm/src/chunk/taps_point_ops.rs
+++ b/bitvm/src/chunk/taps_point_ops.rs
@@ -176,11 +176,11 @@ fn utils_point_double_eval(
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }                                        // -bias, ...,  x, y, alpha
-            { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
+            { Fq2::check_validity_and_keep_element() }
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }
-            { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
+            { Fq2::check_validity_and_keep_element() }
             // [tx ty a b]
             {Fq2::roll(6)} {Fq2::roll(6)}          // alpha, -bias, x, y
             // [a b tx ty]
@@ -351,11 +351,11 @@ fn utils_point_add_eval(
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
+                    { Fq2::check_validity_and_keep_element() }
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
+                    { Fq2::check_validity_and_keep_element() }
                     // [qx, qy, tx, ty, c3, c4]
                     {Fq2::roll(6)} {Fq2::roll(6)}
                     // [qx, qy, c3, c4, tx, ty]

--- a/bitvm/src/chunk/taps_point_ops.rs
+++ b/bitvm/src/chunk/taps_point_ops.rs
@@ -176,11 +176,11 @@ fn utils_point_double_eval(
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }                                        // -bias, ...,  x, y, alpha
-            { Fq2::copy(0) } { Fq2::check_validity() }
+            { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }
-            { Fq2::copy(0) } { Fq2::check_validity() }
+            { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
             // [tx ty a b]
             {Fq2::roll(6)} {Fq2::roll(6)}          // alpha, -bias, x, y
             // [a b tx ty]
@@ -351,11 +351,11 @@ fn utils_point_add_eval(
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq2::copy(0) } { Fq2::check_validity() }
+                    { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
                     for _ in 0..Fq::N_LIMBS * 2 {
                         OP_DEPTH OP_1SUB OP_ROLL
                     }
-                    { Fq2::copy(0) } { Fq2::check_validity() }
+                    { Fq2::copy(0) } { Fq2::check_validity_and_consume() }
                     // [qx, qy, tx, ty, c3, c4]
                     {Fq2::roll(6)} {Fq2::roll(6)}
                     // [qx, qy, c3, c4, tx, ty]

--- a/bitvm/src/chunk/taps_point_ops.rs
+++ b/bitvm/src/chunk/taps_point_ops.rs
@@ -176,9 +176,11 @@ fn utils_point_double_eval(
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }                                        // -bias, ...,  x, y, alpha
+            { Fq2::copy(0) } { Fq2::check_validity() }
             for _ in 0..Fq::N_LIMBS * 2 {
                 OP_DEPTH OP_1SUB OP_ROLL
             }
+            { Fq2::copy(0) } { Fq2::check_validity() }
             // [tx ty a b]
             {Fq2::roll(6)} {Fq2::roll(6)}          // alpha, -bias, x, y
             // [a b tx ty]

--- a/bitvm/src/signatures/winternitz.rs
+++ b/bitvm/src/signatures/winternitz.rs
@@ -496,7 +496,7 @@ impl Verifier for BruteforceVerifier {
                 OP_DUP
                 { -1 }
                 OP_NUMNOTEQUAL OP_VERIFY
-                OP_FROMALTSTACK 
+                OP_FROMALTSTACK
                 { -1 } OP_EQUALVERIFY // Verify the sentinel value -1 to avoid altstack overflow in the rare case where pk == hash160^n(pk).
                 OP_TOALTSTACK
             }


### PR DESCRIPTION
I added a validation for hint being a correctly formed T type value to tmul. This introduces an increase of 70 bytes in tmul for hinted mul. Also, Fq::check_validity() is added, it checks that a given N_LIMBS elements on stack form a valid Fq. It is then used in necessary places.

Closes #305 and closes #304