### PR TITLE
Ensure FTPS uses TLS by enabling secure mode in Ftps driver

### DIFF
--- a/bridge/src/client/data_store/ftp/ftps.rs
+++ b/bridge/src/client/data_store/ftp/ftps.rs
@@ -37,7 +37,7 @@ impl Ftps {
         }
 
         let credentials = FtpCredentials {
-            is_secure: false,
+            is_secure: true, // ensure FTPS uses secure connection
             host: host.unwrap(),
             port: port.unwrap(),
             username: username.unwrap(),


### PR DESCRIPTION


### Description
- Problem: The FTPS driver initialized credentials with `is_secure=false`, resulting in plaintext FTP instead of FTPS.
- Change: Set `is_secure=true` in `bridge/src/client/data_store/ftp/ftps.rs` so FTPS connections use TLS.
- Impact: Credentials and data in transit are now encrypted; non‑TLS servers may fail to connect (expected for FTPS).
