### PR TITLE
refactor(graphs): make BaseGraph::id return &str and align usages

### DIFF
--- a/bridge/src/graphs/base.rs
+++ b/bridge/src/graphs/base.rs
@@ -56,7 +56,7 @@ pub type GraphId = String;
 
 pub trait BaseGraph {
     fn network(&self) -> Network;
-    fn id(&self) -> &String;
+    fn id(&self) -> &str;
     fn push_verifier_nonces(
         &mut self,
         verifier_context: &VerifierContext,

--- a/bridge/src/graphs/peg_in.rs
+++ b/bridge/src/graphs/peg_in.rs
@@ -115,7 +115,7 @@ impl BaseGraph for PegInGraph {
         self.network
     }
 
-    fn id(&self) -> &String {
+    fn id(&self) -> &str {
         &self.id
     }
 

--- a/bridge/src/graphs/peg_out.rs
+++ b/bridge/src/graphs/peg_out.rs
@@ -240,7 +240,7 @@ impl BaseGraph for PegOutGraph {
         self.network
     }
 
-    fn id(&self) -> &String {
+    fn id(&self) -> &str {
         &self.id
     }
 


### PR DESCRIPTION


### Summary
Switch `BaseGraph::id` to return `&str` instead of `&String` for a more idiomatic and flexible API. No runtime logic changes.

### Changes
- Update trait method in `bridge/src/graphs/base.rs` to `fn id(&self) -> &str`.
- Align implementations in `bridge/src/graphs/peg_in.rs` and `bridge/src/graphs/peg_out.rs`.
- Adjust call sites and type usages to work with `&str` where applicable.

### Motivation
- Prefer string slices over owned `String` in signatures.
- Decouple API from a concrete container, improve ergonomics and composability.
- Avoid unnecessary allocations/copies at call sites.
