### PR TITLE
Fix typos across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Below is a list of the components and their purpose.
 
 ## BitVM1
 
-If you are looking for the deprectated BitVM1 implementation, please check out
+If you are looking for the deprecated BitVM1 implementation, please check out
 [BitVM1](https://github.com/BitVM/BitVM/tree/1dce989d1963b90c35391b77b451c6823302d503).
 
 

--- a/bitvm/src/bn254/fq.rs
+++ b/bitvm/src/bn254/fq.rs
@@ -416,7 +416,7 @@ impl Fq {
         (script, hints)
     }
 
-    // TODO: Optimize using the sqaure feature
+    // TODO: Optimize using the square feature
     pub fn hinted_square(a: ark_bn254::Fq) -> (Script, Vec<Hint>) {
         let mut hints = Vec::new();
         let x = &BigInt::from_str(&a.to_string()).unwrap();

--- a/bridge/tests/bridge/e2e/peg_out/disprove_success.rs
+++ b/bridge/tests/bridge/e2e/peg_out/disprove_success.rs
@@ -38,6 +38,6 @@ async fn test_e2e_disprove_success() {
 
     println!(
         "{}",
-        "Succesfully disproved incorrect ZK proof".bold().green()
+        "Successfully disproved incorrect ZK proof".bold().green()
     );
 }

--- a/docs/chunk_instructions.md
+++ b/docs/chunk_instructions.md
@@ -181,7 +181,7 @@ fn disprove_core(input, Option<output>, operator_claimed_input_hash, operator_cl
         if output.is_none() {  // tapscripts output is not passed as hint
             output = fn(input) // output is deterministically computed from input
         } else {
-            fn_valid(input, output) // output is determinstically validated from input
+            fn_valid(input, output) // output is deterministically validated from input
         }
         Add_To_Stack(output, input_is_valid)
     } else {


### PR DESCRIPTION


## Summary

This PR fixes several spelling errors in comments, documentation, and test messages to improve code quality and readability.

## Changes

- Fixed "deprectated" → "deprecated" 
- Fixed typo in TODO comment ("sqaure" → "square")
- Fixed "Succesfully" → "Successfully"
- Fixed "determinstically" → "deterministically"

